### PR TITLE
Add precision feature for the commodity.

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,3 +1,4 @@
+use crate::data;
 use crate::import::{self, Format, ImportError};
 
 use std::ffi::OsStr;
@@ -34,8 +35,16 @@ impl<'c> ImportCmd<'c> {
             .encoding(Some(config_entry.encoding.as_encoding()))
             .build(file);
         let xacts = import::import(&mut decoded, format, config_entry)?;
+        let ctx = data::DisplayContext {
+            precisions: config_entry
+                .format
+                .commodity
+                .iter()
+                .map(|(k, v)| (k.clone(), v.precision))
+                .collect(),
+        };
         for xact in &xacts {
-            writeln!(w, "{}", xact)?;
+            writeln!(w, "{}", xact.display(&ctx))?;
         }
         Ok(())
     }

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -92,10 +92,19 @@ pub enum AccountType {
 #[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FormatSpec {
     /// Specify the date format, in chrono::format::strftime compatible format.
+    #[serde(default)]
     pub date: String,
+    /// Commodity (currency) styling
+    #[serde(default)]
+    pub commodity: HashMap<String, CommodityFormatSpec>,
     /// Mapping from abstracted field key to abstracted position.
     #[serde(default)]
     pub fields: HashMap<FieldKey, FieldPos>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct CommodityFormatSpec {
+    pub precision: u8,
 }
 
 /// Key represents the field abstracted way.
@@ -203,6 +212,7 @@ mod tests {
             commodity: "JPY".to_owned(),
             format: FormatSpec {
                 date: "%Y%m%d".to_owned(),
+                commodity: HashMap::new(),
                 fields: hashmap! {},
             },
             rewrite: vec![],


### PR DESCRIPTION
Ensure minimal precision (such as `1.00` USD)