### PR TITLE
Add functionality to support exchange rate on ISO Camt import.

### DIFF
--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -42,6 +42,9 @@ pub struct ConfigEntry {
     pub encoding: Encoding,
     pub account: String,
     pub account_type: AccountType,
+    /// Operator of the import target.
+    /// Required only when some charges happen.
+    pub operator: Option<String>,
     pub commodity: String,
     #[serde(default)]
     pub format: FormatSpec,
@@ -209,6 +212,7 @@ mod tests {
             encoding: Encoding(encoding_rs::UTF_8),
             path: path.to_owned(),
             account_type: AccountType::Asset,
+            operator: None,
             commodity: "JPY".to_owned(),
             format: FormatSpec {
                 date: "%Y%m%d".to_owned(),

--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -226,9 +226,10 @@ impl config::RewriteMatcher {
 
 impl config::FieldMatcher {
     fn to_payee_matcher(&self) -> Result<regex::Regex, ImportError> {
-        let payee = self.fields.get(&config::RewriteField::Payee).ok_or({
-            ImportError::Unimplemented("only payee field is supported")
-        })?;
+        let payee = self
+            .fields
+            .get(&config::RewriteField::Payee)
+            .ok_or(ImportError::Unimplemented("only payee field is supported"))?;
         regex::Regex::new(payee).map_err(ImportError::InvalidRegex)
     }
 }

--- a/src/import/iso_camt053.rs
+++ b/src/import/iso_camt053.rs
@@ -70,7 +70,7 @@ impl super::Importer for ISOCamt053Importer {
                         .code(code)
                         .dest_account_option(fragment.account);
                     if transaction.amount != transaction.amount_details.transaction.amount {
-                        txn.exchanged_amount(data::ExchangedAmount {
+                        txn.transferred_amount(data::ExchangedAmount {
                             amount: to_data_amount(
                                 transaction.credit_or_debit.value,
                                 &transaction.amount_details.transaction.amount,

--- a/src/import/iso_camt053/extract.rs
+++ b/src/import/iso_camt053/extract.rs
@@ -392,6 +392,10 @@ mod tests {
                 credit_or_debit: xmlnode::CreditDebitIndicator {
                     value: xmlnode::CreditOrDebit::Credit,
                 },
+                amount: xmlnode::Amount {
+                    value: dec!(12.3),
+                    currency: "CHF".to_string(),
+                },
                 amount_details: xmlnode::AmountDetails {
                     instructed: xmlnode::AmountWithExchange {
                         amount: xmlnode::Amount {

--- a/src/import/iso_camt053/xmlnode.rs
+++ b/src/import/iso_camt053/xmlnode.rs
@@ -182,6 +182,8 @@ pub struct Batch {
 pub struct TransactionDetails {
     #[serde(rename = "Refs")]
     pub refs: References,
+    #[serde(rename = "Amt")]
+    pub amount: Amount,
     #[serde(rename = "CdtDbtInd")]
     pub credit_or_debit: CreditDebitIndicator,
     #[serde(rename = "AmtDtls")]

--- a/src/import/single_entry.rs
+++ b/src/import/single_entry.rs
@@ -20,6 +20,9 @@ pub struct Txn {
     /// Destination account.
     dest_account: Option<String>,
 
+    /// amount in exchanged rate.
+    exchanged_amount: Option<data::ExchangedAmount>,
+
     /// Amount of the transaction, applied for the associated account.
     /// For bank account, positive means deposit, negative means withdraw.
     /// For credit card account, negative means expense, positive means payment to the card.
@@ -36,6 +39,7 @@ impl Txn {
             code: None,
             payee: payee.to_string(),
             dest_account: None,
+            exchanged_amount: None,
             amount,
             balance: None,
         }
@@ -69,6 +73,24 @@ impl Txn {
         self
     }
 
+    pub fn exchanged_amount(&mut self, amount: data::ExchangedAmount) -> &mut Txn {
+        self.exchanged_amount = Some(amount);
+        self
+    }
+
+    fn dest_amount(&self) -> data::ExchangedAmount {
+        self.exchanged_amount
+            .as_ref()
+            .map(|x| data::ExchangedAmount {
+                amount: -x.amount.clone(),
+                exchange: x.exchange.clone(),
+            })
+            .unwrap_or(data::ExchangedAmount {
+                amount: -self.amount.clone(),
+                exchange: None,
+            })
+    }
+
     pub fn balance(&mut self, balance: data::Amount) -> &mut Txn {
         self.balance = Some(balance);
         self
@@ -87,20 +109,26 @@ impl Txn {
                     .clone()
                     .unwrap_or_else(|| "Incomes:Unknown".to_string()),
                 clear_state: post_clear,
-                amount: -self.amount.clone(),
+                amount: self.dest_amount(),
                 balance: None,
             });
             posts.push(data::Post {
                 account: src_account.to_string(),
                 clear_state: data::ClearState::Uncleared,
-                amount: self.amount.clone(),
+                amount: data::ExchangedAmount {
+                    amount: self.amount.clone(),
+                    exchange: None,
+                },
                 balance: self.balance.clone(),
             });
         } else if self.amount.is_sign_negative() {
             posts.push(data::Post {
                 account: src_account.to_string(),
                 clear_state: data::ClearState::Uncleared,
-                amount: self.amount.clone(),
+                amount: data::ExchangedAmount {
+                    amount: self.amount.clone(),
+                    exchange: None,
+                },
                 balance: self.balance.clone(),
             });
             posts.push(data::Post {
@@ -109,7 +137,7 @@ impl Txn {
                     .clone()
                     .unwrap_or_else(|| "Expenses:Unknown".to_string()),
                 clear_state: post_clear,
-                amount: -self.amount.clone(),
+                amount: self.dest_amount(),
                 balance: None,
             });
         } else {

--- a/src/import/single_entry.rs
+++ b/src/import/single_entry.rs
@@ -21,7 +21,7 @@ pub struct Txn {
     dest_account: Option<String>,
 
     /// amount in exchanged rate.
-    exchanged_amount: Option<data::ExchangedAmount>,
+    transferred_amount: Option<data::ExchangedAmount>,
 
     /// Amount of the transaction, applied for the associated account.
     /// For bank account, positive means deposit, negative means withdraw.
@@ -39,7 +39,7 @@ impl Txn {
             code: None,
             payee: payee.to_string(),
             dest_account: None,
-            exchanged_amount: None,
+            transferred_amount: None,
             amount,
             balance: None,
         }
@@ -73,13 +73,13 @@ impl Txn {
         self
     }
 
-    pub fn exchanged_amount(&mut self, amount: data::ExchangedAmount) -> &mut Txn {
-        self.exchanged_amount = Some(amount);
+    pub fn transferred_amount(&mut self, amount: data::ExchangedAmount) -> &mut Txn {
+        self.transferred_amount = Some(amount);
         self
     }
 
     fn dest_amount(&self) -> data::ExchangedAmount {
-        self.exchanged_amount
+        self.transferred_amount
             .as_ref()
             .map(|x| data::ExchangedAmount {
                 amount: -x.amount.clone(),


### PR DESCRIPTION
Currently it does convert ISO Camt import with exchange rate properly.
However it won't support charges, it should be implemented later.
It's not yet supported in CSV.