### PR TITLE
Account width larger than expected / double-byte characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "thiserror",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_with = { version = "1.9", features = [ "chrono" ] }
 serde_yaml = "0.8"
 strum = { version = "0.23", features = ["derive"] }
 thiserror = "1.0"
+unicode-width = "0.1.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/import/viseca/parser.rs
+++ b/src/import/viseca/parser.rs
@@ -74,7 +74,7 @@ impl<T: BufRead> Parser<T> {
     fn parse_first_line(&self, c: regex::Captures) -> Result<Entry, ImportError> {
         let date_str = self.expect_name(&c, "date", "date should exist")?;
         let date = parse_euro_date(date_str)
-            .map_err(|x| self.err(format!("invalid date: {}", x.to_string())))?;
+            .map_err(|x| self.err(format!("invalid date: {}", x)))?;
         let edate_str = self.expect_name(&c, "edate", "effective date should exist")?;
         let edate = parse_euro_date(edate_str)?;
         let payee = self


### PR DESCRIPTION
* Cumulative minor fix related to cargo clippy warnings.
* Insert account / amount spacing (double spaces) even when the account is so long.
* Calculate the account column using unicode-width crate to support CJK characters.