### PR TITLE
Improve format accepting syntax

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -53,14 +53,16 @@ mod tests {
         let input = indoc! {b"
         2021/05/14 !(#txn-1) My Grocery
             Expenses:Grocery\t10 CHF
-            Assets:Bank  -20 CHF
-            Expenses:Household
+            Assets:Bank  -20 CHF=1CHF
+            Expenses:Household  = 0
         "};
+        // TODO: 1. guess commodity width if not available.
+        // TOOD: 2. remove trailing space on non-commodity value.
         let want = indoc! {"
         2021/05/14 ! (#txn-1) My Grocery
             Expenses:Grocery                              10 CHF
-            Assets:Bank                                  -20 CHF
-            Expenses:Household
+            Assets:Bank                                  -20 CHF = 1 CHF
+            Expenses:Household                                = 0
 
         "};
         let mut output = Vec::new();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -225,12 +225,14 @@ impl<'a> fmt::Display for TransactionWithContext<'a> {
                 };
                 write!(
                     f,
-                    "{:>width$} {} {}",
+                    "{:>width$} {}",
                     " =",
                     rescale(balance, self.context),
-                    balance.commodity,
                     width = balance_padding
                 )?;
+                if !balance.commodity.is_empty() {
+                    write!(f, " {}", balance.commodity)?;
+                }
             }
             writeln!(f)?;
             for m in &post.metadata {


### PR DESCRIPTION
Since `format` command was added with minimal parsing ability, it had several quarks about acceptable syntax.
Now it implements several syntax properly.
* preceding newline
* Balance validation syntax (` = 0`, ` = 1234 JPY`)