### PR TITLE
Support lot syntax in a posting list

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -54,6 +54,7 @@ mod tests {
                 Assets:Bank  -20 CHF=1CHF
                 Expenses:Household  = 0
                 Assets:Complex  (-10 * 2.1 $) @ (1 $ + 1 $) = 2.5 $
+                Assets:Broker  -2 SPINX (bought before Xmas) {100 USD} [2010/12/23] @ 10000 USD
         "};
         // TODO: 1. guess commodity width if not available.
         // TOOD: 2. remove trailing space on non-commodity value.
@@ -72,6 +73,7 @@ mod tests {
                 Assets:Bank                                  -20 CHF = 1 CHF
                 Expenses:Household                               = 0
                 Assets:Complex                        (-10 * 2.1 $) @ (1 $ + 1 $) = 2.5 $
+                Assets:Broker                                 -2 SPINX {100 USD} [2010/12/23] (bought before Xmas) @ 10000 USD
 
         "};
         let mut output = Vec::new();

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -151,6 +151,17 @@ impl fmt::Display for Metadata {
 pub struct PostingAmount {
     pub amount: expr::ValueExpr,
     pub cost: Option<Exchange>,
+    pub lot: Lot,
+}
+
+impl From<expr::ValueExpr> for PostingAmount {
+    fn from(v: expr::ValueExpr) -> Self {
+        PostingAmount {
+            amount: v,
+            cost: None,
+            lot: Lot::default(),
+        }
+    }
 }
 
 impl From<data::ExchangedAmount> for PostingAmount {
@@ -158,8 +169,17 @@ impl From<data::ExchangedAmount> for PostingAmount {
         PostingAmount {
             amount: v.amount.into(),
             cost: v.exchange.map(Into::into),
+            lot: Lot::default(),
         }
     }
+}
+
+/// Lot information is a set of metadata to record the original lot which the commodity is acquired with.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Lot {
+    pub price: Option<Exchange>,
+    pub date: Option<NaiveDate>,
+    pub note: Option<String>,
 }
 
 /// Exchange represents the amount expressed in the different commodity.

--- a/src/repl/parser.rs
+++ b/src/repl/parser.rs
@@ -140,7 +140,14 @@ fn parse_posting_amount<'a>(
             cond_else(is_double_at, parse_total_cost, parse_rate_cost),
         ),
     )(input)?;
-    Ok((input, repl::PostingAmount { amount, cost }))
+    Ok((
+        input,
+        repl::PostingAmount {
+            amount,
+            cost,
+            lot: repl::Lot::default(),
+        },
+    ))
 }
 
 fn parse_total_cost<'a>(input: &'a str) -> IResult<&str, repl::Exchange, VerboseError<&'a str>> {
@@ -280,6 +287,7 @@ mod tests {
                                     commodity: "USD".to_string(),
                                 }),
                                 cost: None,
+                                lot: repl::Lot::default(),
                             }),
                             ..repl::Posting::new("Expense A".to_string())
                         },
@@ -324,6 +332,7 @@ mod tests {
                                     commodity: "USD".to_string(),
                                 }),
                                 cost: None,
+                                lot: repl::Lot::default(),
                             }),
                             metadata: vec![
                                 repl::Metadata::Comment("Note expense A".to_string()),
@@ -341,6 +350,7 @@ mod tests {
                                     commodity: "JPY".to_string(),
                                 }),
                                 cost: None,
+                                lot: repl::Lot::default(),
                             }),
                             balance: Some(repl::expr::ValueExpr::Amount(repl::Amount {
                                 value: dec!(-1000),
@@ -387,7 +397,8 @@ mod tests {
                             value: dec!(1.2),
                             commodity: "CHF".to_string(),
                         }
-                    )))
+                    ))),
+                    lot: repl::Lot::default(),
                 }
             )
         );
@@ -405,7 +416,8 @@ mod tests {
                             value: dec!(120),
                             commodity: "CHF".to_string(),
                         }
-                    )))
+                    ))),
+                    lot: repl::Lot::default()
                 }
             )
         );
@@ -419,13 +431,13 @@ mod tests {
             (
                 "",
                 repl::Posting {
-                    amount: Some(repl::PostingAmount {
-                        amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                    amount: Some(
+                        repl::expr::ValueExpr::Amount(repl::Amount {
                             value: dec!(1),
                             commodity: "USD".to_string(),
-                        }),
-                        cost: None,
-                    },),
+                        })
+                        .into()
+                    ),
                     metadata: vec![
                         repl::Metadata::KeyValueTag {
                             key: "Payee".to_string(),

--- a/src/repl/parser.rs
+++ b/src/repl/parser.rs
@@ -1,26 +1,24 @@
 //! Defines parser for the Ledger format.
 
-pub mod character;
-pub mod combinator;
-pub mod expr;
-pub mod primitive;
+pub(crate) mod character;
+pub(crate) mod combinator;
+pub(crate) mod expr;
+pub(crate) mod metadata;
+pub(crate) mod posting;
+pub(crate) mod primitive;
 
 #[cfg(test)]
 pub mod testing;
 
 use crate::repl;
-use combinator::{cond_else, has_peek};
-
-use std::cmp::min;
+use combinator::has_peek;
 
 use nom::{
-    branch::alt,
-    bytes::complete::{tag, take, take_till1},
-    character::complete::{char, line_ending, not_line_ending, one_of, space0, space1},
-    combinator::{cond, eof, map, opt, peek},
-    error::{context, convert_error, ContextError, ParseError, VerboseError},
-    multi::{many0, many1, many_till, separated_list0},
-    sequence::{delimited, pair, preceded, terminated},
+    character::complete::{char, line_ending, one_of, space0, space1},
+    combinator::{cond, eof, map, opt},
+    error::{convert_error, VerboseError},
+    multi::{many0, many_till},
+    sequence::{preceded, terminated},
     Finish, IResult,
 };
 
@@ -59,8 +57,8 @@ fn parse_transaction(input: &str) -> IResult<&str, repl::Transaction, VerboseErr
     };
     let (input, code) = opt(terminated(character::paren_str, space0))(input)?;
     let (input, payee) = opt(map(character::not_line_ending_or_semi, str::trim_end))(input)?;
-    let (input, metadata) = parse_block_metadata(input)?;
-    let (input, (posts, _)) = many_till(parse_posting, character::line_ending_or_eof)(input)?;
+    let (input, metadata) = metadata::block_metadata(input)?;
+    let (input, (posts, _)) = many_till(posting::posting, character::line_ending_or_eof)(input)?;
     Ok((
         input,
         repl::Transaction {
@@ -70,160 +68,6 @@ fn parse_transaction(input: &str) -> IResult<&str, repl::Transaction, VerboseErr
             posts,
             metadata,
             ..repl::Transaction::new(date, payee.unwrap_or("").to_string())
-        },
-    ))
-}
-
-fn parse_posting(input: &str) -> IResult<&str, repl::Posting, VerboseError<&str>> {
-    context("posting of the transaction", |input| {
-        let (input, account) = context(
-            "account of the posting",
-            preceded(space1, parse_posting_account),
-        )(input)?;
-        let (input, shortcut_amount) = has_peek(character::line_ending_or_semi)(input)?;
-        if shortcut_amount {
-            let (input, metadata) = parse_block_metadata(input)?;
-            return Ok((
-                input,
-                repl::Posting {
-                    metadata,
-                    ..repl::Posting::new(account.to_string())
-                },
-            ));
-        }
-        let (input, amount) = context(
-            "amount of the posting",
-            opt(terminated(parse_posting_amount, space0)),
-        )(input)?;
-        let (input, balance) = context(
-            "balance of the posting",
-            opt(delimited(pair(char('='), space0), expr::value_expr, space0)),
-        )(input)?;
-        let (input, metadata) = parse_block_metadata(input)?;
-        Ok((
-            input,
-            repl::Posting {
-                amount,
-                balance,
-                metadata,
-                ..repl::Posting::new(account.to_string())
-            },
-        ))
-    })(input)
-}
-
-/// Parses the posting account name, and consumes the trailing spaces and tabs.
-fn parse_posting_account<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&str, &str, E> {
-    let (input, line) = peek(character::not_line_ending_or_semi)(input)?;
-    let space = line.find("  ");
-    let tab = line.find('\t');
-    let length = match (space, tab) {
-        (Some(x), Some(y)) => min(x, y),
-        (Some(x), None) => x,
-        (None, Some(x)) => x,
-        _ => line.len(),
-    };
-    // Note space may be zero for the case amount / balance is omitted.
-    terminated(take(length), space0)(input)
-}
-
-fn parse_posting_amount<'a>(
-    input: &'a str,
-) -> IResult<&str, repl::PostingAmount, VerboseError<&'a str>> {
-    let (input, amount) = terminated(expr::value_expr, space0)(input)?;
-    let (input, is_at) = has_peek(char('@'))(input)?;
-    let (input, is_double_at) = has_peek(tag("@@"))(input)?;
-    let (input, cost) = cond(
-        is_at,
-        context(
-            "posting cost exchange",
-            cond_else(is_double_at, parse_total_cost, parse_rate_cost),
-        ),
-    )(input)?;
-    Ok((
-        input,
-        repl::PostingAmount {
-            amount,
-            cost,
-            lot: repl::Lot::default(),
-        },
-    ))
-}
-
-fn parse_total_cost<'a>(input: &'a str) -> IResult<&str, repl::Exchange, VerboseError<&'a str>> {
-    let (input, v) = preceded(pair(tag("@@"), space0), expr::value_expr)(input)?;
-    Ok((input, repl::Exchange::Total(v)))
-}
-
-fn parse_rate_cost<'a>(input: &'a str) -> IResult<&str, repl::Exchange, VerboseError<&'a str>> {
-    let (input, v) = preceded(pair(tag("@"), space0), expr::value_expr)(input)?;
-    Ok((input, repl::Exchange::Rate(v)))
-}
-
-/// Parses block of metadata including the last line_end.
-/// Note this consumes one line_ending regardless of Metadata existence.
-fn parse_block_metadata<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    input: &'a str,
-) -> IResult<&str, Vec<repl::Metadata>, E> {
-    let (input, is_metadata) = has_peek(char(';'))(input)?;
-    let (input, _) = cond(!is_metadata, line_ending)(input)?;
-    separated_list0(space1, preceded(space0, parse_line_metadata))(input)
-}
-
-fn parse_line_metadata<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
-    input: &'a str,
-) -> IResult<&str, repl::Metadata, E> {
-    context(
-        "parsing a line for Metadata",
-        delimited(
-            pair(char(';'), space0),
-            alt((
-                parse_metadata_tags,
-                parse_metadata_kv,
-                map(not_line_ending, |s: &str| {
-                    if s.contains(':') {
-                        log::warn!("metadata containing `:` not parsed as tags");
-                    }
-                    repl::Metadata::Comment(s.trim_end().to_string())
-                }),
-            )),
-            character::line_ending_or_eof,
-        ),
-    )(input)
-}
-
-fn parse_metadata_tags<'a, E: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&str, repl::Metadata, E> {
-    let (input, tags) = delimited(
-        char(':'),
-        many1(terminated(
-            take_till1(|c: char| c.is_whitespace() || c == ':'),
-            char(':'),
-        )),
-        space0,
-    )(input)?;
-    Ok((
-        input,
-        repl::Metadata::WordTags(tags.into_iter().map(String::from).collect()),
-    ))
-}
-
-fn parse_metadata_kv<'a, E: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&str, repl::Metadata, E> {
-    let (input, (key, value)) = pair(
-        terminated(
-            take_till1(|c: char| c.is_whitespace() || c == ':'),
-            pair(space0, char(':')),
-        ),
-        preceded(space0, not_line_ending),
-    )(input)?;
-    Ok((
-        input,
-        repl::Metadata::KeyValueTag {
-            key: key.to_string(),
-            value: value.trim_end().to_string(),
         },
     ))
 }
@@ -379,149 +223,5 @@ mod tests {
                 }
             )
         );
-    }
-
-    #[test]
-    fn posting_cost_parses_valid_input() {
-        assert_eq!(
-            expect_parse_ok(parse_posting_amount, "100 EUR @ 1.2 CHF"),
-            (
-                "",
-                repl::PostingAmount {
-                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
-                        value: dec!(100),
-                        commodity: "EUR".to_string()
-                    }),
-                    cost: Some(repl::Exchange::Rate(repl::expr::ValueExpr::Amount(
-                        repl::Amount {
-                            value: dec!(1.2),
-                            commodity: "CHF".to_string(),
-                        }
-                    ))),
-                    lot: repl::Lot::default(),
-                }
-            )
-        );
-        assert_eq!(
-            expect_parse_ok(parse_posting_amount, "100 EUR @@ 120 CHF"),
-            (
-                "",
-                repl::PostingAmount {
-                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
-                        value: dec!(100),
-                        commodity: "EUR".to_string()
-                    }),
-                    cost: Some(repl::Exchange::Total(repl::expr::ValueExpr::Amount(
-                        repl::Amount {
-                            value: dec!(120),
-                            commodity: "CHF".to_string(),
-                        }
-                    ))),
-                    lot: repl::Lot::default()
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn parse_posting_many_comments() {
-        let input: &str = " Expenses:Commissions    1 USD ; Payee: My Card\n ; My card took commission\n ; :financial:経済:\n";
-        assert_eq!(
-            expect_parse_ok(parse_posting, input),
-            (
-                "",
-                repl::Posting {
-                    amount: Some(
-                        repl::expr::ValueExpr::Amount(repl::Amount {
-                            value: dec!(1),
-                            commodity: "USD".to_string(),
-                        })
-                        .into()
-                    ),
-                    metadata: vec![
-                        repl::Metadata::KeyValueTag {
-                            key: "Payee".to_string(),
-                            value: "My Card".to_string(),
-                        },
-                        repl::Metadata::Comment("My card took commission".to_string()),
-                        repl::Metadata::WordTags(
-                            vec!["financial".to_string(), "経済".to_string(),],
-                        ),
-                    ],
-                    ..repl::Posting::new("Expenses:Commissions".to_string())
-                }
-            )
-        )
-    }
-
-    #[test]
-    fn parse_posting_account_returns_minimal() {
-        let input = indoc! {"
-            Account Value     ;
-            Next Account Value
-        "};
-        assert_eq!(
-            expect_parse_ok(parse_posting_account, input),
-            (";\nNext Account Value\n", "Account Value")
-        );
-        let input = indoc! {"
-            Account Value\t\t
-            Next Account Value
-        "};
-        assert_eq!(
-            expect_parse_ok(parse_posting_account, input),
-            ("\nNext Account Value\n", "Account Value")
-        );
-        let input = indoc! {"
-            Account Value
-            Next Account Value
-        "};
-        assert_eq!(
-            expect_parse_ok(parse_posting_account, input),
-            ("\nNext Account Value\n", "Account Value")
-        );
-    }
-
-    #[test]
-    fn parse_line_metadata_valid_tags() {
-        let input: &str = ";   :tag1:tag2:tag3:\n";
-        assert_eq!(
-            expect_parse_ok(parse_line_metadata, input),
-            (
-                "",
-                repl::Metadata::WordTags(vec![
-                    "tag1".to_string(),
-                    "tag2".to_string(),
-                    "tag3".to_string()
-                ])
-            )
-        )
-    }
-
-    #[test]
-    fn parse_line_metadata_valid_kv() {
-        let input: &str = ";   場所: ドラッグストア\n";
-        assert_eq!(
-            expect_parse_ok(parse_line_metadata, input),
-            (
-                "",
-                repl::Metadata::KeyValueTag {
-                    key: "場所".to_string(),
-                    value: "ドラッグストア".to_string(),
-                }
-            )
-        )
-    }
-
-    #[test]
-    fn parse_line_metadata_valid_comment() {
-        let input: &str = ";A fox jumps over: この例文見飽きた    \n";
-        assert_eq!(
-            expect_parse_ok(parse_line_metadata, input),
-            (
-                "",
-                repl::Metadata::Comment("A fox jumps over: この例文見飽きた".to_string())
-            )
-        )
     }
 }

--- a/src/repl/parser/expr.rs
+++ b/src/repl/parser/expr.rs
@@ -100,7 +100,7 @@ where
 }
 
 /// Parses amount expression.
-fn amount<'a, E>(input: &'a str) -> IResult<&'a str, expr::ValueExpr, E>
+pub fn amount<'a, E>(input: &'a str) -> IResult<&'a str, expr::ValueExpr, E>
 where
     E: ParseError<&'a str>
         + FromExternalError<&'a str, rust_decimal::Error>

--- a/src/repl/parser/metadata.rs
+++ b/src/repl/parser/metadata.rs
@@ -1,0 +1,133 @@
+//! Parsers related to metadata aka comments.
+
+use crate::repl;
+use repl::parser::{character, combinator::has_peek};
+
+use nom::{
+    branch::alt,
+    bytes::complete::take_till1,
+    character::complete::{char, line_ending, not_line_ending, space0, space1},
+    combinator::{cond, map},
+    error::{context, ContextError, ParseError},
+    multi::{many1, separated_list0},
+    sequence::{delimited, pair, preceded, terminated},
+    IResult,
+};
+
+/// Parses block of metadata including the last line_end.
+/// Note this consumes one line_ending regardless of Metadata existence.
+pub fn block_metadata<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    input: &'a str,
+) -> IResult<&str, Vec<repl::Metadata>, E> {
+    let (input, is_metadata) = has_peek(char(';'))(input)?;
+    let (input, _) = cond(!is_metadata, line_ending)(input)?;
+    separated_list0(space1, preceded(space0, line_metadata))(input)
+}
+
+fn line_metadata<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+    input: &'a str,
+) -> IResult<&str, repl::Metadata, E> {
+    context(
+        "parsing a line for Metadata",
+        delimited(
+            pair(char(';'), space0),
+            alt((
+                parse_metadata_tags,
+                parse_metadata_kv,
+                map(not_line_ending, |s: &str| {
+                    if s.contains(':') {
+                        log::warn!("metadata containing `:` not parsed as tags");
+                    }
+                    repl::Metadata::Comment(s.trim_end().to_string())
+                }),
+            )),
+            character::line_ending_or_eof,
+        ),
+    )(input)
+}
+
+fn parse_metadata_tags<'a, E: ParseError<&'a str>>(
+    input: &'a str,
+) -> IResult<&str, repl::Metadata, E> {
+    let (input, tags) = delimited(
+        char(':'),
+        many1(terminated(
+            take_till1(|c: char| c.is_whitespace() || c == ':'),
+            char(':'),
+        )),
+        space0,
+    )(input)?;
+    Ok((
+        input,
+        repl::Metadata::WordTags(tags.into_iter().map(String::from).collect()),
+    ))
+}
+
+fn parse_metadata_kv<'a, E: ParseError<&'a str>>(
+    input: &'a str,
+) -> IResult<&str, repl::Metadata, E> {
+    let (input, (key, value)) = pair(
+        terminated(
+            take_till1(|c: char| c.is_whitespace() || c == ':'),
+            pair(space0, char(':')),
+        ),
+        preceded(space0, not_line_ending),
+    )(input)?;
+    Ok((
+        input,
+        repl::Metadata::KeyValueTag {
+            key: key.to_string(),
+            value: value.trim_end().to_string(),
+        },
+    ))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::parser::testing::expect_parse_ok;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parse_line_metadata_valid_tags() {
+        let input: &str = ";   :tag1:tag2:tag3:\n";
+        assert_eq!(
+            expect_parse_ok(line_metadata, input),
+            (
+                "",
+                repl::Metadata::WordTags(vec![
+                    "tag1".to_string(),
+                    "tag2".to_string(),
+                    "tag3".to_string()
+                ])
+            )
+        )
+    }
+
+    #[test]
+    fn parse_line_metadata_valid_kv() {
+        let input: &str = ";   場所: ドラッグストア\n";
+        assert_eq!(
+            expect_parse_ok(line_metadata, input),
+            (
+                "",
+                repl::Metadata::KeyValueTag {
+                    key: "場所".to_string(),
+                    value: "ドラッグストア".to_string(),
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn parse_line_metadata_valid_comment() {
+        let input: &str = ";A fox jumps over: この例文見飽きた    \n";
+        assert_eq!(
+            expect_parse_ok(line_metadata, input),
+            (
+                "",
+                repl::Metadata::Comment("A fox jumps over: この例文見飽きた".to_string())
+            )
+        )
+    }
+}

--- a/src/repl/parser/posting.rs
+++ b/src/repl/parser/posting.rs
@@ -1,0 +1,212 @@
+//! Parser about ledger postings.
+
+use crate::repl;
+use repl::parser::{
+    character,
+    combinator::{cond_else, has_peek},
+    expr, metadata,
+};
+
+use std::cmp::min;
+
+use nom::{
+    bytes::complete::{tag, take},
+    character::complete::{char, space0, space1},
+    combinator::{cond, opt, peek},
+    error::{context, ParseError, VerboseError},
+    sequence::{delimited, pair, preceded, terminated},
+    IResult,
+};
+
+pub fn posting(input: &str) -> IResult<&str, repl::Posting, VerboseError<&str>> {
+    context("posting of the transaction", |input| {
+        let (input, account) =
+            context("account of the posting", preceded(space1, posting_account))(input)?;
+        let (input, shortcut_amount) = has_peek(character::line_ending_or_semi)(input)?;
+        if shortcut_amount {
+            let (input, metadata) = metadata::block_metadata(input)?;
+            return Ok((
+                input,
+                repl::Posting {
+                    metadata,
+                    ..repl::Posting::new(account.to_string())
+                },
+            ));
+        }
+        let (input, amount) = context(
+            "amount of the posting",
+            opt(terminated(posting_amount, space0)),
+        )(input)?;
+        let (input, balance) = context(
+            "balance of the posting",
+            opt(delimited(pair(char('='), space0), expr::value_expr, space0)),
+        )(input)?;
+        let (input, metadata) = metadata::block_metadata(input)?;
+        Ok((
+            input,
+            repl::Posting {
+                amount,
+                balance,
+                metadata,
+                ..repl::Posting::new(account.to_string())
+            },
+        ))
+    })(input)
+}
+
+/// Parses the posting account name, and consumes the trailing spaces and tabs.
+fn posting_account<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&str, &str, E> {
+    let (input, line) = peek(character::not_line_ending_or_semi)(input)?;
+    let space = line.find("  ");
+    let tab = line.find('\t');
+    let length = match (space, tab) {
+        (Some(x), Some(y)) => min(x, y),
+        (Some(x), None) => x,
+        (None, Some(x)) => x,
+        _ => line.len(),
+    };
+    // Note space may be zero for the case amount / balance is omitted.
+    terminated(take(length), space0)(input)
+}
+
+fn posting_amount<'a>(input: &'a str) -> IResult<&str, repl::PostingAmount, VerboseError<&'a str>> {
+    let (input, amount) = terminated(expr::value_expr, space0)(input)?;
+    let (input, is_at) = has_peek(char('@'))(input)?;
+    let (input, is_double_at) = has_peek(tag("@@"))(input)?;
+    let (input, cost) = cond(
+        is_at,
+        context(
+            "posting cost exchange",
+            cond_else(is_double_at, total_cost, rate_cost),
+        ),
+    )(input)?;
+    Ok((
+        input,
+        repl::PostingAmount {
+            amount,
+            cost,
+            lot: repl::Lot::default(),
+        },
+    ))
+}
+
+fn total_cost<'a>(input: &'a str) -> IResult<&str, repl::Exchange, VerboseError<&'a str>> {
+    let (input, v) = preceded(pair(tag("@@"), space0), expr::value_expr)(input)?;
+    Ok((input, repl::Exchange::Total(v)))
+}
+
+fn rate_cost<'a>(input: &'a str) -> IResult<&str, repl::Exchange, VerboseError<&'a str>> {
+    let (input, v) = preceded(pair(tag("@"), space0), expr::value_expr)(input)?;
+    Ok((input, repl::Exchange::Rate(v)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repl::parser::testing::expect_parse_ok;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn posting_cost_parses_valid_input() {
+        assert_eq!(
+            expect_parse_ok(posting_amount, "100 EUR @ 1.2 CHF"),
+            (
+                "",
+                repl::PostingAmount {
+                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                        value: dec!(100),
+                        commodity: "EUR".to_string()
+                    }),
+                    cost: Some(repl::Exchange::Rate(repl::expr::ValueExpr::Amount(
+                        repl::Amount {
+                            value: dec!(1.2),
+                            commodity: "CHF".to_string(),
+                        }
+                    ))),
+                    lot: repl::Lot::default(),
+                }
+            )
+        );
+        assert_eq!(
+            expect_parse_ok(posting_amount, "100 EUR @@ 120 CHF"),
+            (
+                "",
+                repl::PostingAmount {
+                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                        value: dec!(100),
+                        commodity: "EUR".to_string()
+                    }),
+                    cost: Some(repl::Exchange::Total(repl::expr::ValueExpr::Amount(
+                        repl::Amount {
+                            value: dec!(120),
+                            commodity: "CHF".to_string(),
+                        }
+                    ))),
+                    lot: repl::Lot::default()
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn posting_many_comments() {
+        let input: &str = " Expenses:Commissions    1 USD ; Payee: My Card\n ; My card took commission\n ; :financial:経済:\n";
+        assert_eq!(
+            expect_parse_ok(posting, input),
+            (
+                "",
+                repl::Posting {
+                    amount: Some(
+                        repl::expr::ValueExpr::Amount(repl::Amount {
+                            value: dec!(1),
+                            commodity: "USD".to_string(),
+                        })
+                        .into()
+                    ),
+                    metadata: vec![
+                        repl::Metadata::KeyValueTag {
+                            key: "Payee".to_string(),
+                            value: "My Card".to_string(),
+                        },
+                        repl::Metadata::Comment("My card took commission".to_string()),
+                        repl::Metadata::WordTags(
+                            vec!["financial".to_string(), "経済".to_string(),],
+                        ),
+                    ],
+                    ..repl::Posting::new("Expenses:Commissions".to_string())
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn posting_account_returns_minimal() {
+        let input = indoc! {"
+            Account Value     ;
+            Next Account Value
+        "};
+        assert_eq!(
+            expect_parse_ok(posting_account, input),
+            (";\nNext Account Value\n", "Account Value")
+        );
+        let input = indoc! {"
+            Account Value\t\t
+            Next Account Value
+        "};
+        assert_eq!(
+            expect_parse_ok(posting_account, input),
+            ("\nNext Account Value\n", "Account Value")
+        );
+        let input = indoc! {"
+            Account Value
+            Next Account Value
+        "};
+        assert_eq!(
+            expect_parse_ok(posting_account, input),
+            ("\nNext Account Value\n", "Account Value")
+        );
+    }
+}


### PR DESCRIPTION
Support lot information such as

```
  Foo        20 USD {100 JPY} [2021/01/03] (before yenyasu)
```

This is part of #57 effort.