### PR TITLE
Add configuration to skip lines, only applicable for CSV.

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -39,6 +39,7 @@ impl ImportCmd {
                 self.source.display()
             ))
         })?;
+        log::debug!("config: {:?}", config_entry);
         let file = File::open(&self.source)?;
         // Use dedicated flags or config systems instead.
         let format = match self.source.extension().and_then(OsStr::to_str) {

--- a/src/import/config.rs
+++ b/src/import/config.rs
@@ -201,9 +201,18 @@ pub struct FormatSpec {
     /// Delimiter for the CSV. Leave it empty to use default ",".
     #[serde(default)]
     pub delimiter: String,
+    #[serde(default)]
+    pub skip: SkipSpec,
     /// Order of the row.
     #[serde(default)]
     pub row_order: RowOrder,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+pub struct SkipSpec {
+    /// The number of lines skipped at head.
+    /// Only supported for CSV.
+    pub head: i32,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]


### PR DESCRIPTION
This will allow skipping miscellaneous lines of CSV, for now at the beginning.
It's not supported for ISO_Camt / Viseca format.