### PR TITLE
Adds STDO (standing order) subfamily code for transactions.

### DIFF
--- a/src/import/iso_camt053/xmlnode.rs
+++ b/src/import/iso_camt053/xmlnode.rs
@@ -155,6 +155,8 @@ pub enum DomainSubFamilyCode {
     PaymentDirectDebit,
     #[serde(rename = "SALA")]
     Salary,
+    #[serde(rename = "STDO")]
+    StandingOrder,
     #[serde(rename = "OTHR")]
     Other,
 }


### PR DESCRIPTION
We do have plenty of ISO Camt codes which aren't supported yet, and `STDO` is one of them.
Recently BCGE started to use `STDO` instead of `AUTT` for standing orders.