### PR TITLE
Add include directive support.

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -52,6 +52,8 @@ mod tests {
 
             end  apply   tag
 
+            include        path/to/other.ledger
+
             2021/03/12 Opening Balance  ; initial balance
              Assets:Bank     = 1000 CHF
              Equity
@@ -81,6 +83,8 @@ mod tests {
             apply tag foo
 
             end apply tag
+
+            include path/to/other.ledger
 
             2021/03/12 Opening Balance
                 ; initial balance

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -25,6 +25,8 @@ pub enum LedgerEntry {
     ApplyTag(ApplyTag),
     /// "end apply tag" directive.
     EndApplyTag,
+    /// "include" directive.
+    Include(IncludeFile),
 }
 
 /// Top-level comment. OK to have multi-line comment.
@@ -37,6 +39,11 @@ pub struct ApplyTag {
     pub key: String,
     pub value: Option<String>,
 }
+
+/// "include" directive, taking a path as an argument.
+/// Path can be a relative path or an absolute path.
+#[derive(Debug, PartialEq, Eq)]
+pub struct IncludeFile(String);
 
 /// Represents a transaction where the money transfered across the accounts.
 #[derive(Debug, PartialEq, Eq)]

--- a/src/repl/display.rs
+++ b/src/repl/display.rs
@@ -47,6 +47,7 @@ impl<'a> fmt::Display for WithContext<'a, LedgerEntry> {
             LedgerEntry::Comment(v) => write!(f, "{}", v),
             LedgerEntry::ApplyTag(v) => v.fmt(f),
             LedgerEntry::EndApplyTag => writeln!(f, "end apply tag"),
+            LedgerEntry::Include(v) => v.fmt(f),
         }
     }
 }
@@ -67,6 +68,12 @@ impl fmt::Display for ApplyTag {
             None => writeln!(f),
             Some(v) => writeln!(f, ": {}", v),
         }
+    }
+}
+
+impl fmt::Display for IncludeFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "include {}", self.0)
     }
 }
 

--- a/src/repl/parser.rs
+++ b/src/repl/parser.rs
@@ -48,6 +48,7 @@ fn parse_ledger_entry(input: &str) -> IResult<&str, repl::LedgerEntry, VerboseEr
         }
         'a' => map(directive::apply_tag, repl::LedgerEntry::ApplyTag)(input),
         'e' => map(directive::end_apply_tag, |_| repl::LedgerEntry::EndApplyTag)(input),
+        'i' => map(directive::include, repl::LedgerEntry::Include)(input),
         c if c.is_ascii_digit() => map(transaction::transaction, repl::LedgerEntry::Txn)(input),
         _ => context("unexpected character", fail)(input),
     }


### PR DESCRIPTION
Now it supports parsing & formatting include directive. Probably we should support dense (no-space) pattern as my ledger often utilize the vertical space to put semantical gap between items.

#57 