### PR TITLE
Make regex matching case insensitive following the critical use cases.

### DIFF
--- a/src/import/csv.rs
+++ b/src/import/csv.rs
@@ -13,7 +13,7 @@ use std::io::BufReader;
 
 use chrono::NaiveDate;
 use log::{info, warn};
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 use rust_decimal::Decimal;
 
 pub struct CsvImporter {}
@@ -328,7 +328,7 @@ enum Field {
 #[derive(Debug)]
 struct CsvMatcher {
     field: Field,
-    pattern: regex::Regex,
+    pattern: Regex,
 }
 
 impl<'a> extract::Entity<'a> for CsvMatcher {
@@ -346,7 +346,7 @@ impl TryFrom<(config::RewriteField, &str)> for CsvMatcher {
                 "CSV only supports payee or category matcher.",
             )),
         }?;
-        let pattern = Regex::new(pattern)?;
+        let pattern = RegexBuilder::new(pattern).case_insensitive(true).build()?;
         Ok(CsvMatcher { field, pattern })
     }
 }

--- a/src/import/iso_camt053.rs
+++ b/src/import/iso_camt053.rs
@@ -9,6 +9,7 @@ use crate::data;
 use std::convert::{TryFrom, TryInto};
 
 use regex::Regex;
+use regex::RegexBuilder;
 use rust_decimal::Decimal;
 
 pub struct IsoCamt053Importer {}
@@ -235,7 +236,9 @@ impl TryFrom<(config::RewriteField, &str)> for FieldMatch {
                 FieldMatch::DomainSubFamily(code)
             }
             _ => {
-                let pattern = Regex::new(v)?;
+                // Most likely we don't need case sensitivity.
+                // If needed, we'll go back and change the config as needed.
+                let pattern = RegexBuilder::new(v).case_insensitive(true).build()?;
                 let field = to_field(f)?;
                 FieldMatch::RegexMatch(field, pattern)
             }

--- a/src/import/viseca.rs
+++ b/src/import/viseca.rs
@@ -10,6 +10,7 @@ use crate::data;
 use std::convert::{TryFrom, TryInto};
 
 use regex::Regex;
+use regex::RegexBuilder;
 
 pub struct VisecaImporter {}
 
@@ -109,7 +110,7 @@ impl TryFrom<(config::RewriteField, &str)> for VisecaMatcher {
                 return Err(ImportError::InvalidConfig("unsupported rewrite field"));
             }
         };
-        let pattern = Regex::new(v)?;
+        let pattern = RegexBuilder::new(v).case_insensitive(true).build()?;
         Ok(VisecaMatcher { field, pattern })
     }
 }

--- a/tests/testdata/test_config.yml
+++ b/tests/testdata/test_config.yml
@@ -54,7 +54,8 @@ rewrite:
     account: Income:Misc
     pending: true
   - matcher:
-      payee: Migros
+      # test case insensitive
+      payee: MIGROS
     account: Expenses:Grocery
 ---
 path: testdata/label_credit_debit.csv


### PR DESCRIPTION
It's unlikely FOO and foo has the different payee, while case can be changed arbitrarily by connected system. In future we can add case-sensitivity config if needed.

The currrent structure is useful so that we can configure EntityMatcher for each format, but this flexibility exposes code duplication for this change. It'd also arise when we introduce other based matcher. Potentially we can stop using GAT-based polymorphism and get back to more simpler approach (e.g. provide EnumMatcher, RegexMatcher and translate it with simple args) so that we can use unified matcher logic. This would help us to fuse regex or matchers into one gigantic regex, which in term much optimized.