### PR TITLE
Add commodity / account directives for format supported syntax.

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -48,6 +48,15 @@ mod tests {
             ; second
             ; round
 
+            account  Foo\t
+             alias Bar\t
+               note これは何でしょうか
+              alias Baz
+
+            commodity  USD\t
+             \talias 米ドル\t
+             \talias $\t
+
             apply    tag   foo
 
             end  apply   tag
@@ -79,7 +88,16 @@ mod tests {
 
             ; second
             ; round
+
+            account Foo
+                alias Bar
+                note これは何でしょうか
+                alias Baz
             
+            commodity USD
+                alias 米ドル
+                alias $
+
             apply tag foo
 
             end apply tag

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -27,6 +27,10 @@ pub enum LedgerEntry {
     EndApplyTag,
     /// "include" directive.
     Include(IncludeFile),
+    /// "account" directive.
+    Account(AccountDeclaration),
+    /// "commodity" directive.
+    Commodity(CommodityDeclaration),
 }
 
 /// Top-level comment. OK to have multi-line comment.
@@ -44,6 +48,49 @@ pub struct ApplyTag {
 /// Path can be a relative path or an absolute path.
 #[derive(Debug, PartialEq, Eq)]
 pub struct IncludeFile(String);
+
+/// "account" directive to declare account information.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AccountDeclaration {
+    /// Canonical name of the account.
+    name: String,
+    /// sub-directives for the account.
+    details: Vec<AccountDetail>,
+}
+
+/// Sub directives for "account" directive.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AccountDetail {
+    /// Comment is a pure comment without any semantics, similar to `TopLevelComment`.
+    Comment(String),
+    /// Note is a "note" sub-directive.
+    /// Usually it would be one-line.
+    Note(String),
+    /// Declare the given string is an alias for the declared account.
+    Alias(String),
+}
+
+/// "commodity" directive to declare commodity information.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommodityDeclaration {
+    /// Canonical name of the commodity.
+    name: String,
+    /// sub-directives for the commodity.
+    details: Vec<CommodityDetail>,
+}
+
+/// Sub directives for "commodity" directive.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CommodityDetail {
+    /// Comment is a pure comment without any semantics, similar to `TopLevelComment`.
+    Comment(String),
+    /// Note is a "note" sub-directive to note the commodity.
+    /// Usually it would be one-line.
+    Note(String),
+    /// Declare the given string is an alias for the declared account.
+    /// Multiple declaration should work.
+    Alias(String),
+}
 
 /// Represents a transaction where the money transfered across the accounts.
 #[derive(Debug, PartialEq, Eq)]

--- a/src/repl/parser/directive.rs
+++ b/src/repl/parser/directive.rs
@@ -3,14 +3,99 @@ use crate::repl;
 use super::{character::line_ending_or_eof, metadata};
 
 use nom::{
+    branch::alt,
     bytes::complete::{is_a, tag},
-    character::complete::{line_ending, not_line_ending, space0, space1},
+    character::complete::{not_line_ending, space0, space1},
     combinator::{map, recognize},
     error::{context, ContextError, ParseError},
-    multi::fold_many1,
+    multi::{fold_many1, many0},
     sequence::{delimited, pair, preceded, terminated, tuple},
-    IResult,
+    IResult, Parser,
 };
+
+/// Parses "account" directive.
+pub fn account_declaration<'a, E>(input: &'a str) -> IResult<&'a str, repl::AccountDeclaration, E>
+where
+    E: ParseError<&'a str> + ContextError<&'a str>,
+{
+    map(
+        pair(
+            delimited(
+                pair(tag("account"), space1),
+                not_line_ending,
+                line_ending_or_eof,
+            ),
+            // Note nesting many0 would cause parse failure at nom 7,
+            // as many0 would fail if the sub-parser consumes empty input.
+            // So make sure no branches in alt would emit zero input as success.
+            many0(alt((
+                map(
+                    multiline_text(pair(space1, is_a(COMMENT_PREFIX))),
+                    repl::AccountDetail::Comment,
+                ),
+                map(
+                    multiline_text(tuple((space1, tag("note"), space1))),
+                    repl::AccountDetail::Note,
+                ),
+                map(
+                    delimited(
+                        tuple((space1, tag("alias"), space1)),
+                        not_line_ending,
+                        line_ending_or_eof,
+                    ),
+                    |a| repl::AccountDetail::Alias(a.trim_end().to_string()),
+                ),
+            ))),
+        ),
+        |(name, details)| repl::AccountDeclaration {
+            name: name.trim_end().to_string(),
+            details,
+        },
+    )(input)
+}
+
+/// Parses "commodity" directive.
+pub fn commodity_declaration<'a, E>(
+    input: &'a str,
+) -> IResult<&'a str, repl::CommodityDeclaration, E>
+where
+    E: ParseError<&'a str> + ContextError<&'a str>,
+{
+    map(
+        pair(
+            delimited(
+                pair(tag("commodity"), space1),
+                not_line_ending,
+                line_ending_or_eof,
+            ),
+            // Note nesting many0 would cause parse failure at nom 7,
+            // as many0 would fail if the sub-parser consumes empty input.
+            // So make sure no branches in alt would emit zero input as success.
+            many0(alt((
+                map(
+                    multiline_text(pair(space1, is_a(COMMENT_PREFIX))),
+                    repl::CommodityDetail::Comment,
+                ),
+                map(
+                    multiline_text(tuple((space1, tag("note"), space1))),
+                    repl::CommodityDetail::Note,
+                ),
+                map(
+                    delimited(
+                        tuple((space1, tag("alias"), space1)),
+                        not_line_ending,
+                        line_ending_or_eof,
+                    ),
+                    |a| repl::CommodityDetail::Alias(a.trim_end().to_string()),
+                ),
+            ))),
+        ),
+        |(name, details)| repl::CommodityDeclaration {
+            name: name.trim_end().to_string(),
+            details,
+        },
+    )(input)
+}
 
 /// Parses "apply tag" directive.
 pub fn apply_tag<'a, E>(input: &'a str) -> IResult<&'a str, repl::ApplyTag, E>
@@ -78,24 +163,35 @@ where
     )(input)
 }
 
+static COMMENT_PREFIX: &str = ";#%|*";
+
 /// Parses top level comment in the Ledger file format.
 /// Notable difference with block_metadata is, this accepts multiple prefix.
 pub fn top_comment<'a, E>(input: &'a str) -> IResult<&'a str, repl::TopLevelComment, E>
 where
-    E: ParseError<&'a str>,
+    E: ParseError<&'a str> + ContextError<&'a str>,
 {
-    map(
-        fold_many1(
-            delimited(is_a(";#%|*"), not_line_ending, line_ending),
-            String::new,
-            |mut ret, l| {
-                ret.push_str(l);
-                ret.push('\n');
-                ret
-            },
-        ),
-        repl::TopLevelComment,
+    context(
+        "top level comment",
+        map(multiline_text(is_a(COMMENT_PREFIX)), repl::TopLevelComment),
     )(input)
+}
+
+/// Parses multi-line text with preceding prefix.
+fn multiline_text<'a, E, F, O1>(prefix: F) -> impl FnMut(&'a str) -> IResult<&'a str, String, E>
+where
+    E: ParseError<&'a str>,
+    F: Parser<&'a str, O1, E>,
+{
+    fold_many1(
+        delimited(prefix, not_line_ending, line_ending_or_eof),
+        String::new,
+        |mut ret, l| {
+            ret.push_str(l);
+            ret.push('\n');
+            ret
+        },
+    )
 }
 
 #[cfg(test)]
@@ -103,7 +199,66 @@ mod tests {
     use super::*;
     use crate::repl::parser::testing::expect_parse_ok;
 
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn account_declaration_without_details() {
+        let input = "account Foo:Bar Baz";
+        assert_eq!(
+            expect_parse_ok(account_declaration, input),
+            (
+                "",
+                repl::AccountDeclaration {
+                    name: "Foo:Bar Baz".to_string(),
+                    details: vec![]
+                }
+            )
+        );
+
+        let input = "account Foo:Bar Baz\n2022";
+        assert_eq!(
+            expect_parse_ok(account_declaration, input),
+            (
+                "2022",
+                repl::AccountDeclaration {
+                    name: "Foo:Bar Baz".to_string(),
+                    details: vec![]
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn account_declaration_with_details() {
+        let input = indoc! {"
+            account Foo:Bar
+             ; comment1
+               ; comment1-cont
+               note note1
+               alias alias1
+               alias Alias 2:
+               note note2
+               note note2-cont
+
+            2020"};
+        assert_eq!(
+            expect_parse_ok(account_declaration, input),
+            (
+                "\n2020",
+                repl::AccountDeclaration {
+                    name: "Foo:Bar".to_string(),
+                    details: vec![
+                        repl::AccountDetail::Comment(" comment1\n comment1-cont\n".to_string()),
+                        repl::AccountDetail::Note("note1\n".to_string()),
+                        repl::AccountDetail::Alias("alias1".to_string()),
+                        repl::AccountDetail::Alias("Alias 2:".to_string()),
+                        repl::AccountDetail::Note("note2\nnote2-cont\n".to_string()),
+                    ],
+                }
+            )
+        )
+    }
 
     #[test]
     fn apply_tag_without_value() {
@@ -179,6 +334,30 @@ mod tests {
         assert_eq!(
             expect_parse_ok(include, "include\t\t /path/to/foo bar.ledger  \n"),
             ("", repl::IncludeFile("/path/to/foo bar.ledger".to_string()))
+        );
+    }
+
+    #[test]
+    fn top_comment_single_line() {
+        assert_eq!(
+            expect_parse_ok(top_comment, ";foo"),
+            ("", repl::TopLevelComment("foo\n".to_string()))
+        );
+        assert_eq!(
+            expect_parse_ok(top_comment, ";foo\nbaz"),
+            ("baz", repl::TopLevelComment("foo\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn top_comment_multi_lines() {
+        assert_eq!(
+            expect_parse_ok(top_comment, ";foo\n;bar"),
+            ("", repl::TopLevelComment("foo\nbar\n".to_string()))
+        );
+        assert_eq!(
+            expect_parse_ok(top_comment, ";foo\n#bar\nbaz"),
+            ("baz", repl::TopLevelComment("foo\nbar\n".to_string()))
         );
     }
 }

--- a/src/repl/parser/testing.rs
+++ b/src/repl/parser/testing.rs
@@ -17,7 +17,7 @@ where
         Err(e) => match e {
             nom::Err::Incomplete(_) => panic!("failed with incomplete: input: {}", input),
             nom::Err::Error(e) => panic!("error: {}", convert_error(input, e)),
-            nom::Err::Failure(e) => panic!("error: {}", convert_error(input, e)),
+            nom::Err::Failure(e) => panic!("failure: {}", convert_error(input, e)),
         },
     }
 }


### PR DESCRIPTION
We'll support the syntax below.

```
account foo
    alias bar
    note note
    ; comment

commodity JPY
    alias ￥
    alias 日本円
    note 日本円です
    ; comment
```

More sub-directives would follow.