### PR TITLE
Support apply tag directive with value

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -58,8 +58,13 @@ mod tests {
              \talias $\t
 
             apply    tag   foo
+            apply tag key: value
+            apply tag key:: 10 USD
 
             end  apply   tag
+
+            end apply tag
+            end apply tag
 
             include        path/to/other.ledger
 
@@ -99,6 +104,14 @@ mod tests {
                 alias $
 
             apply tag foo
+
+            apply tag key: value
+
+            apply tag key:: 10 USD
+
+            end apply tag
+
+            end apply tag
 
             end apply tag
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -41,7 +41,7 @@ pub struct TopLevelComment(String);
 #[derive(Debug, PartialEq, Eq)]
 pub struct ApplyTag {
     pub key: String,
-    pub value: Option<String>,
+    pub value: Option<MetadataValue>,
 }
 
 /// "include" directive, taking a path as an argument.
@@ -174,7 +174,7 @@ impl From<data::Posting> for Posting {
             .into_iter()
             .map(|v| Metadata::KeyValueTag {
                 key: "Payee".to_string(),
-                value: v,
+                value: MetadataValue::Text(v),
             })
             .collect();
         Posting {
@@ -195,7 +195,16 @@ pub enum Metadata {
     /// Tags of word, in a format :tag1:tag2:tag3:, each tag can't contain white spaces.
     WordTags(Vec<String>),
     /// Key-value paired tag. Key can't contain white spaces.
-    KeyValueTag { key: String, value: String },
+    KeyValueTag { key: String, value: MetadataValue },
+}
+
+/// MetadataValue represents the value in key-value pair used in `Metadata`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MetadataValue {
+    /// Regular string.
+    Text(String),
+    /// Expression parsed properly prefixed by `::` instead of `:`. Note it should be Expr not String.
+    Expr(String),
 }
 
 /// This is an amout for each posting.

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -198,22 +198,6 @@ pub enum Metadata {
     KeyValueTag { key: String, value: String },
 }
 
-impl fmt::Display for Metadata {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Metadata::WordTags(tags) => {
-                write!(f, ":")?;
-                for tag in tags {
-                    write!(f, "{}:", tag)?;
-                }
-            }
-            Metadata::KeyValueTag { key, value } => write!(f, "{}: {}", key, value)?,
-            Metadata::Comment(s) => write!(f, "{}", s)?,
-        };
-        Ok(())
-    }
-}
-
 /// This is an amout for each posting.
 /// Which contains
 /// - how much the asset is increased.

--- a/src/repl/display.rs
+++ b/src/repl/display.rs
@@ -86,7 +86,7 @@ impl fmt::Display for ApplyTag {
         write!(f, "apply tag {}", self.key)?;
         match &self.value {
             None => writeln!(f),
-            Some(v) => writeln!(f, ": {}", v),
+            Some(v) => writeln!(f, "{}", v),
         }
     }
 }
@@ -172,10 +172,19 @@ impl fmt::Display for Metadata {
                     write!(f, "{}:", tag)?;
                 }
             }
-            Metadata::KeyValueTag { key, value } => write!(f, "{}: {}", key, value)?,
+            Metadata::KeyValueTag { key, value } => write!(f, "{}{}", key, value)?,
             Metadata::Comment(s) => write!(f, "{}", s)?,
         };
         Ok(())
+    }
+}
+
+impl fmt::Display for MetadataValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MetadataValue::Expr(expr) => write!(f, ":: {}", expr),
+            MetadataValue::Text(text) => write!(f, ": {}", text),
+        }
     }
 }
 
@@ -423,7 +432,17 @@ mod tests {
                 "{}",
                 ctx.as_display(&LedgerEntry::ApplyTag(ApplyTag {
                     key: "foo".to_string(),
-                    value: Some("bar".to_string())
+                    value: Some(MetadataValue::Text("bar".to_string()))
+                }))
+            ),
+        );
+        assert_eq!(
+            "apply tag foo:: 100\n",
+            format!(
+                "{}",
+                ctx.as_display(&LedgerEntry::ApplyTag(ApplyTag {
+                    key: "foo".to_string(),
+                    value: Some(MetadataValue::Expr("100".to_string()))
                 }))
             ),
         );

--- a/src/repl/display.rs
+++ b/src/repl/display.rs
@@ -163,6 +163,22 @@ impl<'a> fmt::Display for WithContext<'a, Transaction> {
     }
 }
 
+impl fmt::Display for Metadata {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Metadata::WordTags(tags) => {
+                write!(f, ":")?;
+                for tag in tags {
+                    write!(f, "{}:", tag)?;
+                }
+            }
+            Metadata::KeyValueTag { key, value } => write!(f, "{}: {}", key, value)?,
+            Metadata::Comment(s) => write!(f, "{}", s)?,
+        };
+        Ok(())
+    }
+}
+
 impl<'a> fmt::Display for WithContext<'a, Posting> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let post = self.value;

--- a/src/repl/parser/posting.rs
+++ b/src/repl/parser/posting.rs
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn posting_many_comments() {
-        let input: &str = " Expenses:Commissions    1 USD ; Payee: My Card\n ; My card took commission\n ; :financial:経済:\n";
+        let input: &str = " Expenses:Commissions    1 USD ; Payee: My Card\n ;Date ::  [2022-3-4] \n ; My card took commission\n ; :financial:経済:\n";
         assert_eq!(
             expect_parse_ok(posting, input),
             (
@@ -217,7 +217,11 @@ mod tests {
                     metadata: vec![
                         repl::Metadata::KeyValueTag {
                             key: "Payee".to_string(),
-                            value: "My Card".to_string(),
+                            value: repl::MetadataValue::Text("My Card".to_string()),
+                        },
+                        repl::Metadata::KeyValueTag {
+                            key: "Date".to_string(),
+                            value: repl::MetadataValue::Expr("[2022-3-4]".to_string()),
                         },
                         repl::Metadata::Comment("My card took commission".to_string()),
                         repl::Metadata::WordTags(

--- a/src/repl/parser/transaction.rs
+++ b/src/repl/parser/transaction.rs
@@ -146,7 +146,7 @@ mod tests {
                                 repl::Metadata::Comment("Note expense A".to_string()),
                                 repl::Metadata::KeyValueTag {
                                     key: "Payee".to_string(),
-                                    value: "Bar".to_string()
+                                    value: repl::MetadataValue::Text("Bar".to_string())
                                 },
                             ],
                             ..repl::Posting::new("Expense A".to_string())


### PR DESCRIPTION
It should support both

```
apply tag foo: bar
apply tag foo:: bar
```

This PR also solves the issue `:` and `::` weren't differentiated.