### PR TITLE
Set non-default features to chrono to workaround vulnerability warning on old time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -531,7 +530,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1122,7 +1121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -1243,17 +1242,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -1335,12 +1323,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ repository = "https://github.com/xkikeg/okane"
 
 [workspace.dependencies]
 # dependencies
-chrono = "0.4.24"
+# TODO: Revert to = "0.5" once 0.5 is released.
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "wasmbind"] }
 log = "0.4"
 rust_decimal = "1.29"
 thiserror = "1.0"


### PR DESCRIPTION
https://github.com/xkikeg/okane/security/dependabot/5