### PR TITLE
Add verbose logging for parser of metadata.

### DIFF
--- a/core/src/repl/parser/metadata.rs
+++ b/core/src/repl/parser/metadata.rs
@@ -37,7 +37,7 @@ where
                 metadata_kv,
                 map(not_line_ending, |s: &str| {
                     if s.contains(':') {
-                        log::warn!("metadata containing `:` not parsed as tags");
+                        log::warn!("metadata containing `:` not parsed as tags: {}", s);
                     }
                     repl::Metadata::Comment(s.trim_end().to_string())
                 }),


### PR DESCRIPTION
When the parser receives tag-like non-tag metadata, it'll show warning logs with the actual line.