### PR TITLE
Separate Amount type for repl and datamodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* Exposed more fields in repl structs.
+* Unify repl::Amount into repl::expr::Amount.
+
 ## [0.6] - 2023-04-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "okane"
-version = "0.6.1-dev"
+version = "0.7.0-dev"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "okane-core"
-version = "0.6.1-dev"
+version = "0.7.0-dev"
 dependencies = [
  "chrono",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1-dev"
+version = "0.7.0-dev"
 authors = ["xkikeg"]
 edition = "2021"
 license = "MIT"

--- a/core/src/repl.rs
+++ b/core/src/repl.rs
@@ -53,9 +53,9 @@ pub struct IncludeFile(String);
 #[derive(Debug, PartialEq, Eq)]
 pub struct AccountDeclaration {
     /// Canonical name of the account.
-    name: String,
+    pub name: String,
     /// sub-directives for the account.
-    details: Vec<AccountDetail>,
+    pub details: Vec<AccountDetail>,
 }
 
 /// Sub directives for "account" directive.
@@ -74,9 +74,9 @@ pub enum AccountDetail {
 #[derive(Debug, PartialEq, Eq)]
 pub struct CommodityDeclaration {
     /// Canonical name of the commodity.
-    name: String,
+    pub name: String,
     /// sub-directives for the commodity.
-    details: Vec<CommodityDetail>,
+    pub details: Vec<CommodityDetail>,
 }
 
 /// Sub directives for "commodity" directive.
@@ -108,7 +108,7 @@ pub struct Transaction {
     /// Postings of the transaction, could be empty.
     pub posts: Vec<Posting>,
     /// Transaction level metadata.
-    metadata: Vec<Metadata>,
+    pub metadata: Vec<Metadata>,
 }
 
 impl Transaction {

--- a/core/src/repl.rs
+++ b/core/src/repl.rs
@@ -8,7 +8,7 @@ pub mod expr;
 pub mod parser;
 
 use crate::datamodel;
-pub use crate::datamodel::{Amount, ClearState};
+pub use crate::datamodel::ClearState;
 
 use std::fmt;
 

--- a/core/src/repl/display.rs
+++ b/core/src/repl/display.rs
@@ -344,7 +344,7 @@ impl<'a> DisplayWithAlignment for WithContext<'a, expr::Expr> {
     }
 }
 
-impl<'a> DisplayWithAlignment for WithContext<'a, Amount> {
+impl<'a> DisplayWithAlignment for WithContext<'a, expr::Amount> {
     fn fmt_with_alignment<W: fmt::Write>(&self, f: &mut W) -> Result<Alignment, fmt::Error> {
         let amount_str = rescale(self.value, self.context).to_string();
         // TODO: Implement prefix-amount.
@@ -368,7 +368,7 @@ fn get_column(colsize: usize, left: usize, padding: usize) -> usize {
     }
 }
 
-fn rescale(x: &Amount, context: &DisplayContext) -> Decimal {
+fn rescale(x: &expr::Amount, context: &DisplayContext) -> Decimal {
     let mut v = x.value;
     v.rescale(std::cmp::max(
         x.value.scale(),
@@ -394,7 +394,7 @@ mod tests {
     use rust_decimal_macros::dec;
 
     fn amount<T: Into<Decimal>>(value: T, commodity: &'static str) -> expr::ValueExpr {
-        expr::ValueExpr::Amount(Amount {
+        expr::ValueExpr::Amount(expr::Amount {
             commodity: commodity.to_string(),
             value: value.into(),
         })

--- a/core/src/repl/parser/expr.rs
+++ b/core/src/repl/parser/expr.rs
@@ -112,7 +112,7 @@ where
     let (input, c) = primitive::commodity(input)?;
     Ok((
         input,
-        repl::expr::ValueExpr::Amount(repl::Amount {
+        expr::ValueExpr::Amount(expr::Amount {
             value,
             commodity: c.to_string(),
         }),
@@ -171,7 +171,7 @@ mod tests {
             expect_parse_ok(value_expr, "1000 JPY"),
             (
                 "",
-                expr::ValueExpr::Amount(repl::Amount {
+                expr::ValueExpr::Amount(expr::Amount {
                     value: dec!(1000),
                     commodity: "JPY".to_string()
                 }),
@@ -182,7 +182,7 @@ mod tests {
             expect_parse_ok(value_expr, "1,234,567.89 USD"),
             (
                 "",
-                expr::ValueExpr::Amount(repl::Amount {
+                expr::ValueExpr::Amount(expr::Amount {
                     value: dec!(1234567.89),
                     commodity: "USD".to_string()
                 })
@@ -191,7 +191,7 @@ mod tests {
     }
 
     fn amount_expr<T: Into<Decimal>>(value: T, commodity: &'static str) -> expr::Expr {
-        expr::Expr::Value(Box::new(expr::ValueExpr::Amount(repl::Amount {
+        expr::Expr::Value(Box::new(expr::ValueExpr::Amount(expr::Amount {
             commodity: commodity.to_string(),
             value: value.into(),
         })))

--- a/core/src/repl/parser/posting.rs
+++ b/core/src/repl/parser/posting.rs
@@ -164,12 +164,12 @@ mod tests {
             (
                 "",
                 repl::PostingAmount {
-                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                    amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
                         value: dec!(100),
                         commodity: "EUR".to_string()
                     }),
                     cost: Some(repl::Exchange::Rate(repl::expr::ValueExpr::Amount(
-                        repl::Amount {
+                        repl::expr::Amount {
                             value: dec!(1.2),
                             commodity: "CHF".to_string(),
                         }
@@ -183,12 +183,12 @@ mod tests {
             (
                 "",
                 repl::PostingAmount {
-                    amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                    amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
                         value: dec!(100),
                         commodity: "EUR".to_string()
                     }),
                     cost: Some(repl::Exchange::Total(repl::expr::ValueExpr::Amount(
-                        repl::Amount {
+                        repl::expr::Amount {
                             value: dec!(120),
                             commodity: "CHF".to_string(),
                         }
@@ -208,7 +208,7 @@ mod tests {
                 "",
                 repl::Posting {
                     amount: Some(
-                        repl::expr::ValueExpr::Amount(repl::Amount {
+                        repl::expr::ValueExpr::Amount(repl::expr::Amount {
                             value: dec!(1),
                             commodity: "USD".to_string(),
                         })
@@ -279,7 +279,7 @@ mod tests {
                                 "",
                                 repl::Lot {
                                     price: Some(repl::Exchange::Rate(
-                                        repl::expr::ValueExpr::Amount(repl::Amount {
+                                        repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                             value: dec!(200),
                                             commodity: "JPY".to_string()
                                         })

--- a/core/src/repl/parser/transaction.rs
+++ b/core/src/repl/parser/transaction.rs
@@ -87,7 +87,7 @@ mod tests {
                     posts: vec![
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
-                                amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                                amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                     value: dec!(123456.78),
                                     commodity: "USD".to_string(),
                                 }),
@@ -135,7 +135,7 @@ mod tests {
                     posts: vec![
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
-                                amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                                amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                     value: dec!(-123456.78),
                                     commodity: "USD".to_string(),
                                 }),
@@ -153,14 +153,14 @@ mod tests {
                         },
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
-                                amount: repl::expr::ValueExpr::Amount(repl::Amount {
+                                amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                     value: dec!(12),
                                     commodity: "JPY".to_string(),
                                 }),
                                 cost: None,
                                 lot: repl::Lot::default(),
                             }),
-                            balance: Some(repl::expr::ValueExpr::Amount(repl::Amount {
+                            balance: Some(repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                 value: dec!(-1000),
                                 commodity: "CHF".to_string(),
                             })),
@@ -171,7 +171,7 @@ mod tests {
                             ..repl::Posting::new("Liabilities B".to_string())
                         },
                         repl::Posting {
-                            balance: Some(repl::expr::ValueExpr::Amount(repl::Amount {
+                            balance: Some(repl::expr::ValueExpr::Amount(repl::expr::Amount {
                                 value: dec!(0),
                                 commodity: "".to_string(),
                             })),


### PR DESCRIPTION
In datamodel, we don't need to maintain the formatting information for the Amount.
In repl, `Amount` should hold format information.
We need to separate those two types.