### PR TITLE
Support air tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* Supported "Air-*:" annotations in viseca format.
+
 ### Changed
 
 * Exposed more fields in repl structs.

--- a/core/src/repl/parser/expr.rs
+++ b/core/src/repl/parser/expr.rs
@@ -1,7 +1,7 @@
 //! Defines parsers related to value expression.
 
 use crate::repl::{
-    self, expr,
+    expr,
     parser::{
         combinator::{cond_else, has_peek},
         primitive,
@@ -159,7 +159,7 @@ where
 mod tests {
     use super::*;
 
-    use repl::parser::testing::expect_parse_ok;
+    use crate::repl::parser::testing::expect_parse_ok;
 
     use pretty_assertions::assert_eq;
     use rust_decimal::Decimal;


### PR DESCRIPTION
Viseca statement contains meta information for airline purchases.

```
Air-Pass-Name: ...
Air-Ticket-Nbr: ...
Air-Trav-Agt-Name: ...
Air-Departure-Date: ...
Air-Origin-City: ...
Air-Des-City: ...
```

Viseca format parser should skip those lines.