### PR TITLE
Support comma separated amount value

### DIFF
--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -4,7 +4,7 @@ use super::single_entry;
 use super::ImportError;
 use okane_core::datamodel;
 use okane_core::repl;
-use repl::parser::primitive::str_to_comma_decimal;
+use repl::pretty_decimal::{self, PrettyDecimal};
 
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
@@ -17,6 +17,11 @@ use regex::Regex;
 use rust_decimal::Decimal;
 
 pub struct CsvImporter {}
+
+fn str_to_comma_decimal(input: &str) -> Result<Decimal, pretty_decimal::Error> {
+    let r: Result<PrettyDecimal, pretty_decimal::Error> = input.parse();
+    r.map(|x| x.into())
+}
 
 impl super::Importer for CsvImporter {
     fn import<R: std::io::Read>(

--- a/cli/src/import/error.rs
+++ b/cli/src/import/error.rs
@@ -1,5 +1,7 @@
-use ::csv::Error as CsvError;
-use ::regex::Error as RegexError;
+use okane_core::repl::pretty_decimal;
+
+use csv::Error as CsvError;
+use regex::Error as RegexError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ImportError {
@@ -21,6 +23,8 @@ pub enum ImportError {
     InvalidDatetime(#[from] chrono::ParseError),
     #[error("invalid decimal")]
     InvalidDecimal(#[from] rust_decimal::Error),
+    #[error("invalid pretty decimal")]
+    InvalidPrettyDecimal(#[from] pretty_decimal::Error),
     #[error("invalid regex")]
     InvalidRegex(#[from] RegexError),
     #[error("other error: {0}")]

--- a/core/src/repl.rs
+++ b/core/src/repl.rs
@@ -6,6 +6,7 @@
 pub mod display;
 pub mod expr;
 pub mod parser;
+pub mod pretty_decimal;
 
 use crate::datamodel;
 pub use crate::datamodel::ClearState;

--- a/core/src/repl/display.rs
+++ b/core/src/repl/display.rs
@@ -1,8 +1,8 @@
 //! repl::display contains data & functions for displaying repl data.
 
 use super::*;
+use crate::repl::pretty_decimal::PrettyDecimal;
 
-use rust_decimal::Decimal;
 use std::collections::HashMap;
 use unicode_width::UnicodeWidthStr;
 
@@ -368,10 +368,10 @@ fn get_column(colsize: usize, left: usize, padding: usize) -> usize {
     }
 }
 
-fn rescale(x: &expr::Amount, context: &DisplayContext) -> Decimal {
-    let mut v = x.value;
+fn rescale(x: &expr::Amount, context: &DisplayContext) -> PrettyDecimal {
+    let mut v = x.value.clone();
     v.rescale(std::cmp::max(
-        x.value.scale(),
+        v.scale(),
         context.precisions.get(&x.commodity).cloned().unwrap_or(0) as u32,
     ));
     v
@@ -391,16 +391,19 @@ mod tests {
 
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
+    use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
     fn amount<T: Into<Decimal>>(value: T, commodity: &'static str) -> expr::ValueExpr {
+        let value: Decimal = value.into();
         expr::ValueExpr::Amount(expr::Amount {
             commodity: commodity.to_string(),
-            value: value.into(),
+            value: PrettyDecimal::unformatted(value),
         })
     }
 
     fn amount_expr<T: Into<Decimal>>(value: T, commodity: &'static str) -> expr::Expr {
+        let value: Decimal = value.into();
         expr::Expr::Value(Box::new(amount(value, commodity)))
     }
 

--- a/core/src/repl/expr.rs
+++ b/core/src/repl/expr.rs
@@ -1,12 +1,27 @@
 //! Defines value expression representation used in Ledger format.
 //! Note this is purely lexicographical and not always valid expression.
 
+use super::pretty_decimal::PrettyDecimal;
 use crate::datamodel;
 
 use core::fmt;
 
-/// Re-export data Amount as-is.
-pub use datamodel::Amount;
+/// Amount with presentation information.
+/// Similar to `datamodel::Amount` with extra formatting information.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Amount {
+    pub value: PrettyDecimal,
+    pub commodity: String,
+}
+
+impl From<datamodel::Amount> for Amount {
+    fn from(value: datamodel::Amount) -> Self {
+        Self {
+            value: PrettyDecimal::unformatted(value.value),
+            commodity: value.commodity,
+        }
+    }
+}
 
 /// Defines value expression.
 /// Value expression is a valid expression when used in amount.
@@ -20,6 +35,12 @@ pub enum ValueExpr {
 impl From<Amount> for ValueExpr {
     fn from(v: Amount) -> Self {
         ValueExpr::Amount(v)
+    }
+}
+
+impl From<datamodel::Amount> for ValueExpr {
+    fn from(value: datamodel::Amount) -> Self {
+        ValueExpr::Amount(value.into())
     }
 }
 

--- a/core/src/repl/parser.rs
+++ b/core/src/repl/parser.rs
@@ -6,7 +6,7 @@ mod directive;
 mod expr;
 mod metadata;
 mod posting;
-pub mod primitive;
+mod primitive;
 mod transaction;
 
 #[cfg(test)]

--- a/core/src/repl/parser/posting.rs
+++ b/core/src/repl/parser/posting.rs
@@ -150,7 +150,7 @@ fn rate_cost(input: &str) -> IResult<&str, repl::Exchange, VerboseError<&str>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::repl::parser::testing::expect_parse_ok;
+    use crate::repl::{parser::testing::expect_parse_ok, pretty_decimal::PrettyDecimal};
 
     use chrono::NaiveDate;
     use indoc::indoc;
@@ -165,12 +165,12 @@ mod tests {
                 "",
                 repl::PostingAmount {
                     amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                        value: dec!(100),
+                        value: PrettyDecimal::unformatted(dec!(100)),
                         commodity: "EUR".to_string()
                     }),
                     cost: Some(repl::Exchange::Rate(repl::expr::ValueExpr::Amount(
                         repl::expr::Amount {
-                            value: dec!(1.2),
+                            value: PrettyDecimal::unformatted(dec!(1.2)),
                             commodity: "CHF".to_string(),
                         }
                     ))),
@@ -179,17 +179,17 @@ mod tests {
             )
         );
         assert_eq!(
-            expect_parse_ok(posting_amount, "100 EUR @@ 120 CHF"),
+            expect_parse_ok(posting_amount, "1000 EUR @@ 1,020 CHF"),
             (
                 "",
                 repl::PostingAmount {
                     amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                        value: dec!(100),
+                        value: PrettyDecimal::plain(dec!(1000)),
                         commodity: "EUR".to_string()
                     }),
                     cost: Some(repl::Exchange::Total(repl::expr::ValueExpr::Amount(
                         repl::expr::Amount {
-                            value: dec!(120),
+                            value: PrettyDecimal::comma3dot(dec!(1020)),
                             commodity: "CHF".to_string(),
                         }
                     ))),
@@ -209,7 +209,7 @@ mod tests {
                 repl::Posting {
                     amount: Some(
                         repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                            value: dec!(1),
+                            value: PrettyDecimal::unformatted(dec!(1)),
                             commodity: "USD".to_string(),
                         })
                         .into()
@@ -280,7 +280,7 @@ mod tests {
                                 repl::Lot {
                                     price: Some(repl::Exchange::Rate(
                                         repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                            value: dec!(200),
+                                            value: PrettyDecimal::unformatted(dec!(200)),
                                             commodity: "JPY".to_string()
                                         })
                                     )),

--- a/core/src/repl/parser/transaction.rs
+++ b/core/src/repl/parser/transaction.rs
@@ -46,7 +46,7 @@ pub fn transaction(input: &str) -> IResult<&str, repl::Transaction, VerboseError
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::repl::parser::testing::expect_parse_ok;
+    use crate::repl::{parser::testing::expect_parse_ok, pretty_decimal::PrettyDecimal};
 
     use chrono::NaiveDate;
     use indoc::indoc;
@@ -88,7 +88,7 @@ mod tests {
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
                                 amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                    value: dec!(123456.78),
+                                    value: PrettyDecimal::comma3dot(dec!(123456.78)),
                                     commodity: "USD".to_string(),
                                 }),
                                 cost: None,
@@ -114,7 +114,7 @@ mod tests {
               ; :取引:
              Expense A\t\t-123,456.78 USD;  Note expense A
              ; Payee: Bar
-             Liabilities B  12 JPY  =  -1,000 CHF
+             Liabilities B  12 JPY  =  -1000 CHF
              ; :tag1:他のタグ:
              Assets C    =0    ; Cのノート
              ; これなんだっけ
@@ -136,7 +136,7 @@ mod tests {
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
                                 amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                    value: dec!(-123456.78),
+                                    value: PrettyDecimal::comma3dot(dec!(-123456.78)),
                                     commodity: "USD".to_string(),
                                 }),
                                 cost: None,
@@ -154,14 +154,14 @@ mod tests {
                         repl::Posting {
                             amount: Some(repl::PostingAmount {
                                 amount: repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                    value: dec!(12),
+                                    value: PrettyDecimal::unformatted(dec!(12)),
                                     commodity: "JPY".to_string(),
                                 }),
                                 cost: None,
                                 lot: repl::Lot::default(),
                             }),
                             balance: Some(repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                value: dec!(-1000),
+                                value: PrettyDecimal::plain(dec!(-1000)),
                                 commodity: "CHF".to_string(),
                             })),
                             metadata: vec![repl::Metadata::WordTags(vec![
@@ -172,7 +172,7 @@ mod tests {
                         },
                         repl::Posting {
                             balance: Some(repl::expr::ValueExpr::Amount(repl::expr::Amount {
-                                value: dec!(0),
+                                value: PrettyDecimal::unformatted(dec!(0)),
                                 commodity: "".to_string(),
                             })),
                             metadata: vec![

--- a/core/src/repl/pretty_decimal.rs
+++ b/core/src/repl/pretty_decimal.rs
@@ -1,0 +1,274 @@
+use rust_decimal::Decimal;
+use std::{convert::TryInto, fmt::Display, str::FromStr};
+
+/// Decimal formatting type for pretty-printing.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Format {
+    /// Decimal without no formatting, such as
+    /// `1234` or `1234.5`.
+    Plain,
+    /// Use `,` on every thousands, `.` for the decimal point.
+    Comma3Dot,
+}
+
+/// Decimal with the original format information encoded.
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct PrettyDecimal {
+    /// Format of the decimal, None means there's no associated information.
+    format: Option<Format>,
+    pub value: Decimal,
+}
+
+#[derive(thiserror::Error, PartialEq, Debug)]
+pub enum Error {
+    #[error("unexpected char {0} at {0}")]
+    UnexpectedChar(char, usize),
+    #[error("comma required at {0}")]
+    CommaRequired(usize),
+    #[error("unexpressible decimal {0}")]
+    InvalidDecimal(#[from] rust_decimal::Error),
+}
+
+impl PrettyDecimal {
+    /// Constructs unformatted PrettyDecimal.
+    pub fn unformatted(value: Decimal) -> Self {
+        Self {
+            value,
+            format: None,
+        }
+    }
+
+    /// Constructs plain PrettyDecimal.
+    pub fn plain(value: Decimal) -> Self {
+        Self {
+            format: Some(Format::Plain),
+            value,
+        }
+    }
+
+    /// Constructs comma3 PrettyDecimal.
+    pub fn comma3dot(value: Decimal) -> Self {
+        Self {
+            format: Some(Format::Comma3Dot),
+            value,
+        }
+    }
+
+    /// Returns the current scale.
+    pub fn scale(&self) -> u32 {
+        self.value.scale()
+    }
+
+    /// Rescale the underlying value.
+    pub fn rescale(&mut self, scale: u32) {
+        self.value.rescale(scale)
+    }
+}
+
+impl From<PrettyDecimal> for Decimal {
+    fn from(value: PrettyDecimal) -> Self {
+        value.value
+    }
+}
+
+impl FromStr for PrettyDecimal {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut comma_pos = None;
+        let mut format = None;
+        let mut mantissa: i128 = 0;
+        let mut scale: Option<u32> = None;
+        let mut prefix_len = 0;
+        let mut sign = 1;
+        let aligned_comma = |offset, cp, pos| match (cp, pos) {
+            (None, _) if pos > offset && pos <= 3 + offset => true,
+            _ if cp == Some(pos) => true,
+            _ => false,
+        };
+        for (i, c) in s.chars().enumerate() {
+            match (comma_pos, i, c) {
+                (_, 0, '-') => {
+                    prefix_len = 1;
+                    sign = -1;
+                }
+                (_, _, ',') if aligned_comma(prefix_len, comma_pos, i) => {
+                    format = Some(Format::Comma3Dot);
+                    comma_pos = Some(i + 4);
+                }
+                (_, _, '.') if comma_pos.is_none() || comma_pos == Some(i) => {
+                    scale = Some(0);
+                    comma_pos = None;
+                }
+                (Some(cp), _, _) if cp == i => {
+                    return Err(Error::CommaRequired(i));
+                }
+                _ if c.is_ascii_digit() => {
+                    if scale.is_none() && format.is_none() && i >= 3 + prefix_len {
+                        format = Some(Format::Plain);
+                    }
+                    mantissa = mantissa * 10 + (c as u32 - '0' as u32) as i128;
+                    scale = scale.map(|x| x + 1);
+                }
+                _ => {
+                    return Err(Error::UnexpectedChar(c, i));
+                }
+            }
+        }
+        let value = Decimal::try_from_i128_with_scale(sign * mantissa, scale.unwrap_or(0))?;
+        Ok(Self { format, value })
+    }
+}
+
+impl Display for PrettyDecimal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.format {
+            Some(Format::Plain) | None => self.value.fmt(f),
+            Some(Format::Comma3Dot) => {
+                if self.value.is_sign_negative() {
+                    write!(f, "-")?;
+                }
+                let mantissa = self.value.abs().mantissa().to_string();
+                let scale: usize = self
+                    .value
+                    .scale()
+                    .try_into()
+                    .expect("32-bit or larger bit only");
+                let mut remainder = mantissa.as_str();
+                // Here we assume mantissa is all ASCII (given it's [0-9.]+)
+                let mut initial_integer = true;
+                // caluclate the first comma position out of the integral portion digits.
+                let mut comma_pos = (mantissa.len() - scale) % 3;
+                if comma_pos == 0 {
+                    comma_pos = 3;
+                }
+                while remainder.len() > scale {
+                    if !initial_integer {
+                        write!(f, ",")?;
+                    }
+                    let section;
+                    (section, remainder) = remainder.split_at(comma_pos);
+                    write!(f, "{}", section)?;
+                    comma_pos = 3;
+                    initial_integer = false;
+                }
+                if initial_integer {
+                    write!(f, "0")?;
+                }
+                if !remainder.is_empty() {
+                    write!(f, ".{}", remainder)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn from_str_unformatted() {
+        // If the number is below 1000, we can't tell if the number is plain or comma3dot.
+        // Thus we declare them as unformatted instead of plain.
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(1))), "1".parse());
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(-1))), "-1".parse());
+
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(12))), "12".parse());
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(-12))), "-12".parse());
+
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(123))), "123".parse());
+        assert_eq!(Ok(PrettyDecimal::unformatted(dec!(-123))), "-123".parse());
+
+        assert_eq!(
+            Ok(PrettyDecimal::unformatted(dec!(0.123450))),
+            "0.123450".parse()
+        );
+    }
+
+    #[test]
+    fn from_str_plain() {
+        assert_eq!(Ok(PrettyDecimal::plain(dec!(1234))), "1234".parse());
+        assert_eq!(Ok(PrettyDecimal::plain(dec!(-1234))), "-1234".parse());
+
+        assert_eq!(Ok(PrettyDecimal::plain(dec!(1234567))), "1234567".parse());
+        assert_eq!(Ok(PrettyDecimal::plain(dec!(-1234567))), "-1234567".parse());
+
+        assert_eq!(Ok(PrettyDecimal::plain(dec!(1234.567))), "1234.567".parse());
+        assert_eq!(
+            Ok(PrettyDecimal::plain(dec!(-1234.567))),
+            "-1234.567".parse()
+        );
+    }
+
+    #[test]
+    fn from_str_comma() {
+        assert_eq!(Ok(PrettyDecimal::comma3dot(dec!(1234))), "1,234".parse());
+        assert_eq!(Ok(PrettyDecimal::comma3dot(dec!(-1234))), "-1,234".parse());
+
+        assert_eq!(Ok(PrettyDecimal::comma3dot(dec!(12345))), "12,345".parse());
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(-12345))),
+            "-12,345".parse()
+        );
+
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(123456))),
+            "123,456".parse()
+        );
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(-123456))),
+            "-123,456".parse()
+        );
+
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(1234567))),
+            "1,234,567".parse()
+        );
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(-1234567))),
+            "-1,234,567".parse()
+        );
+
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(1234.567))),
+            "1,234.567".parse()
+        );
+        assert_eq!(
+            Ok(PrettyDecimal::comma3dot(dec!(-1234.567))),
+            "-1,234.567".parse()
+        );
+    }
+
+    #[test]
+    fn display_plain() {
+        assert_eq!("1.234000", PrettyDecimal::plain(dec!(1.234000)).to_string());
+    }
+
+    #[test]
+    fn display_comma3_dot() {
+        assert_eq!("123", PrettyDecimal::comma3dot(dec!(123)).to_string());
+
+        assert_eq!("-1,234", PrettyDecimal::comma3dot(dec!(-1234)).to_string());
+
+        assert_eq!("0", PrettyDecimal::comma3dot(dec!(0)).to_string());
+
+        assert_eq!("0.1200", PrettyDecimal::comma3dot(dec!(0.1200)).to_string());
+
+        assert_eq!(
+            "1.234000",
+            PrettyDecimal::comma3dot(dec!(1.234000)).to_string()
+        );
+
+        assert_eq!("123.4", PrettyDecimal::comma3dot(dec!(123.4)).to_string());
+
+        assert_eq!(
+            "1,234,567.890120",
+            PrettyDecimal::comma3dot(dec!(1234567.890120)).to_string()
+        );
+    }
+}

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -158,7 +158,11 @@ amount-expr ::= comma-decimal commodity?
 Here some primitive data structures are defined.
 
 ```ebnf
-comma-decimal ::= [0-9][0-9,]* | [0-9][0-9,]* "." [0-9]*
+comma-decimal ::= comma-integer ("." decimal-number*)?
+
+comma-integer ::= number+ | number{1-3} ("," number{3})*
+
+number ::= [0-9]
 
 commodity ::= [^- \t\r\n0123456789.,;:?!+*/^&|=<>[](){}@]
 

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -119,6 +119,7 @@ commodity-declaration ::= "commodity" sp+ commodity sp* new-line commodity-detai
 
 commodity-detail ::= commodity-note
                    | commodity-alias
+                   | commodity-format
                    | commodity-comment
 
 ; FYI information of the commodity.


### PR DESCRIPTION
Support comma separated amount.
Amount must have strict format separated with comma on every 3 digits.