### PR TITLE
Allow commodity format directive to have comma separated number.

### DIFF
--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -81,6 +81,7 @@ mod tests {
                 Expenses:Household  = 0
                 Assets:Complex  (-10 * 2.1 $) @ (1 $ + 1 $) = 2.5 $
                 Assets:Broker  -2 SPINX (bought before Xmas) {100 USD} [2010/12/23] @ 10000 USD
+                Liabilities:Comma      5,678.00 CHF @ 1,000,000 JPYRIN = -123,456.12 CHF
         "};
         // TODO: 1. guess commodity width if not available.
         // TOOD: 2. remove trailing space on non-commodity value.
@@ -132,6 +133,7 @@ mod tests {
                 Expenses:Household                               = 0
                 Assets:Complex                        (-10 * 2.1 $) @ (1 $ + 1 $) = 2.5 $
                 Assets:Broker                                 -2 SPINX {100 USD} [2010/12/23] (bought before Xmas) @ 10000 USD
+                Liabilities:Comma                       5,678.00 CHF @ 1,000,000 JPYRIN = -123,456.12 CHF
 
         "};
         let mut output = Vec::new();

--- a/core/src/repl.rs
+++ b/core/src/repl.rs
@@ -91,6 +91,8 @@ pub enum CommodityDetail {
     /// Declare the given string is an alias for the declared account.
     /// Multiple declaration should work.
     Alias(String),
+    /// Format describes how the comodity should be printed.
+    Format(expr::Amount),
 }
 
 /// Represents a transaction where the money transfered across the accounts.

--- a/core/src/repl/display.rs
+++ b/core/src/repl/display.rs
@@ -43,13 +43,13 @@ impl<'a, T> WithContext<'a, T> {
 impl<'a> fmt::Display for WithContext<'a, LedgerEntry> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.value {
-            LedgerEntry::Txn(txn) => write!(f, "{}", self.pass_context(txn)),
-            LedgerEntry::Comment(v) => write!(f, "{}", v),
+            LedgerEntry::Txn(txn) => self.pass_context(txn).fmt(f),
+            LedgerEntry::Comment(v) => v.fmt(f),
             LedgerEntry::ApplyTag(v) => v.fmt(f),
             LedgerEntry::EndApplyTag => writeln!(f, "end apply tag"),
             LedgerEntry::Include(v) => v.fmt(f),
             LedgerEntry::Account(v) => v.fmt(f),
-            LedgerEntry::Commodity(v) => v.fmt(f),
+            LedgerEntry::Commodity(v) => self.pass_context(v).fmt(f),
         }
     }
 }
@@ -116,21 +116,22 @@ impl fmt::Display for AccountDetail {
     }
 }
 
-impl fmt::Display for CommodityDeclaration {
+impl<'a> fmt::Display for WithContext<'a, CommodityDeclaration> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "commodity {}", self.name)?;
-        for detail in &self.details {
-            detail.fmt(f)?;
+        writeln!(f, "commodity {}", self.value.name)?;
+        for detail in &self.value.details {
+            self.pass_context(detail).fmt(f)?;
         }
         Ok(())
     }
 }
-impl fmt::Display for CommodityDetail {
+impl<'a> fmt::Display for WithContext<'a, CommodityDetail> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match self.value {
             CommodityDetail::Comment(v) => LineWrapStr::wrap("    ; ", v).fmt(f),
             CommodityDetail::Note(v) => LineWrapStr::wrap("    note ", v).fmt(f),
             CommodityDetail::Alias(v) => writeln!(f, "    alias {}", v),
+            CommodityDetail::Format(v) => writeln!(f, "    format {}", self.pass_context(v)),
         }
     }
 }

--- a/core/src/repl/parser/expr.rs
+++ b/core/src/repl/parser/expr.rs
@@ -25,7 +25,10 @@ where
         + FromExternalError<&'a str, pretty_decimal::Error>,
 {
     let (input, is_paren) = has_peek(char('('))(input)?;
-    context("value-expr", cond_else(is_paren, paren, amount))(input)
+    context(
+        "value-expr",
+        cond_else(is_paren, paren, map(amount, expr::ValueExpr::Amount)),
+    )(input)
 }
 
 fn paren<'a, E>(input: &'a str) -> IResult<&'a str, expr::ValueExpr, E>
@@ -101,7 +104,7 @@ where
 }
 
 /// Parses amount expression.
-pub fn amount<'a, E>(input: &'a str) -> IResult<&'a str, expr::ValueExpr, E>
+pub fn amount<'a, E>(input: &'a str) -> IResult<&'a str, expr::Amount, E>
 where
     E: ParseError<&'a str>
         + FromExternalError<&'a str, pretty_decimal::Error>
@@ -113,10 +116,10 @@ where
     let (input, c) = primitive::commodity(input)?;
     Ok((
         input,
-        expr::ValueExpr::Amount(expr::Amount {
+        expr::Amount {
             value,
             commodity: c.to_string(),
-        }),
+        },
     ))
 }
 

--- a/core/src/repl/parser/posting.rs
+++ b/core/src/repl/parser/posting.rs
@@ -96,16 +96,17 @@ fn lot(input: &str) -> IResult<&str, repl::Lot, VerboseError<&str>> {
                 if is_total {
                     let (i1, amount) = delimited(
                         pair(tag("{{"), space0),
-                        expr::amount,
+                        expr::value_expr,
                         pair(space0, tag("}}")),
                     )(input)?;
                     lot.price = Some(repl::Exchange::Total(amount));
                     input = i1;
                 } else {
-                    let (i1, amount) =
-                        delimited(pair(tag("{"), space0), expr::amount, pair(space0, tag("}")))(
-                            input,
-                        )?;
+                    let (i1, amount) = delimited(
+                        pair(tag("{"), space0),
+                        expr::value_expr,
+                        pair(space0, tag("}")),
+                    )(input)?;
                     lot.price = Some(repl::Exchange::Rate(amount));
                     input = i1;
                 }


### PR DESCRIPTION
Now we have proper support for comma separaeted number and it makes sense to have comma separated number as format sub-directive in commodity directive.