### PR TITLE
Fixed commodity conversion feature in CSV format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-### Changed
+### Fixed
+
+* Fixed import with commodity conversion spec (https://github.com/xkikeg/okane/pull/108).
 
 ## [0.7.0] - 2023-11-16
 

--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -82,7 +82,7 @@ impl super::Importer for CsvImporter {
                 .commodity
                 .and_then(|i| r.get(i))
                 .map(|x| x.to_string())
-                .unwrap_or_else(|| config.commodity.clone());
+                .unwrap_or_else(|| config.commodity.primary.clone());
             let rate = fm
                 .rate
                 .map(|i| str_to_comma_decimal(r.get(i).unwrap()))
@@ -125,7 +125,7 @@ impl super::Importer for CsvImporter {
                     extract::Conversion::Primary => {
                         txn.rate(datamodel::Exchange::Rate(datamodel::Amount {
                             value: rate,
-                            commodity: config.commodity.clone(),
+                            commodity: config.commodity.primary.clone(),
                         }));
                         let eqa = equivalent_amount.ok_or_else(|| ImportError::Other(format!(
                             "equivalent_amount should be specified when primary conversion is used @ line {}", pos.line()
@@ -133,7 +133,7 @@ impl super::Importer for CsvImporter {
                         datamodel::ExchangedAmount {
                             amount: datamodel::Amount {
                                 value: eqa,
-                                commodity: config.commodity.clone(),
+                                commodity: config.commodity.primary.clone(),
                             },
                             exchange: None,
                         }

--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -141,14 +141,9 @@ impl super::Importer for CsvImporter {
                     extract::Conversion::Specified {
                         commodity: rate_commodity,
                     } => {
-                        warn!(
-                            "Can't infer converted amount specified @ line {}",
-                            pos.line()
-                        );
-
                         datamodel::ExchangedAmount {
                             amount: datamodel::Amount {
-                                value: amount,
+                                value: amount / rate,
                                 commodity: rate_commodity,
                             },
                             exchange: Some(datamodel::Exchange::Rate(datamodel::Amount {

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -122,10 +122,10 @@ pub enum Conversion {
 impl From<config::CommodityConversion> for Conversion {
     fn from(config: config::CommodityConversion) -> Conversion {
         match config {
-            config::CommodityConversion::Unspecified(
-                config::UnspecifiedCommodityConversion::Primary,
+            config::CommodityConversion::Preset(
+                config::PresetCommodityConversion::Primary,
             ) => Conversion::Primary,
-            config::CommodityConversion::Specified { commodity } => {
+            config::CommodityConversion::Trivial { commodity } => {
                 Conversion::Specified { commodity }
             }
         }
@@ -440,7 +440,7 @@ mod tests {
                 pending: true,
                 payee: None,
                 account: Some("Expenses:Petrol".to_string()),
-                conversion: Some(config::CommodityConversion::Specified {
+                conversion: Some(config::CommodityConversion::Trivial {
                     commodity: "JPY".to_string(),
                 }),
                 ..into_rule(config::RewriteMatcher::Field(config::FieldMatcher {

--- a/cli/src/import/viseca.rs
+++ b/cli/src/import/viseca.rs
@@ -20,7 +20,8 @@ impl super::Importer for VisecaImporter {
         config: &config::ConfigEntry,
     ) -> Result<Vec<single_entry::Txn>, ImportError> {
         let extractor: extract::Extractor<VisecaMatcher> = (&config.rewrite).try_into()?;
-        let mut parser = parser::Parser::new(std::io::BufReader::new(r), config.commodity.clone());
+        let mut parser =
+            parser::Parser::new(std::io::BufReader::new(r), config.commodity.primary.clone());
         let mut result = Vec::new();
         while let Some(entry) = parser.parse_entry()? {
             let fragment = extractor.extract(&entry);
@@ -37,7 +38,7 @@ impl super::Importer for VisecaImporter {
                 payee,
                 datamodel::Amount {
                     value: -entry.amount,
-                    commodity: config.commodity.clone(),
+                    commodity: config.commodity.primary.clone(),
                 },
             );
             txn.effective_date(entry.effective_date)

--- a/cli/tests/testdata/csv_multi_currency.ledger
+++ b/cli/tests/testdata/csv_multi_currency.ledger
@@ -12,7 +12,7 @@
 
 2020/07/29 * 外貨普通預金（ユーロ）へ振替
     Assets:Okane Bank                       -2353.40 USD = 29338.38 USD
-    Assets:Wire                              2353.40 EUR @ 1.1767 USD
+    Assets:Wire                              2000.00 EUR @ 1.1767 USD
 
 2020/07/29 * 外貨普通預金（米ドル）より振替
     Assets:Wire                             -2000.00 EUR

--- a/cli/tests/testdata/test_config.yml
+++ b/cli/tests/testdata/test_config.yml
@@ -16,6 +16,9 @@ format:
     commodity: 通貨
     rate: 適用レート
     equivalent_absolute: 取引円換算額
+  commodity:
+    EUR:
+      precision: 2
 rewrite:
   - matcher:
       payee: ^Visaデビット　(?P<code>\d+)　(?P<payee>.*)$


### PR DESCRIPTION
Before this CL, these CSV+rewrite config are imported in a wrong way.

```csv
"2020/07/29";"普通";"";"USD";"外貨普通預金（ユーロ）へ振替";"";"2353.40";"29338.38";"1.1767";"246918";""
```

```yaml
  - account: Assets:Wire
    matcher:
      payee: 外貨普通預金（ユーロ）へ振替
    conversion:
      commodity: EUR
```

```
2020/07/29 * 外貨普通預金（ユーロ）へ振替
    Assets:Okane Bank                       -2353.40 USD = 29338.38 USD
    Assets:Wire                              2353.40 EUR @ 1.1767 USD
    ; WRONG!! this needs to be 2000 EUR
```

This PR fixes it to convert transferred amount with the exchange rate.

```
2020/07/29 * 外貨普通預金（ユーロ）へ振替
    Assets:Okane Bank                       -2353.40 USD = 29338.38 USD
    Assets:Wire                              2353.40 EUR @ 1.1767 USD
```