### PR TITLE
Add secondary_commodity feature and renamed equivalent_amount.

### DIFF
--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -277,10 +277,13 @@ pub enum FieldKey {
     Commodity,
     /// Currency rate used in the statement.
     Rate,
-    /// Equivalent amount exchanged into the account currency.
-    /// This is the case when your account statement always shows the converted amount
-    /// in the primary currency.
-    EquivalentAmount,
+    /// Secondary amount represents the amount in the secondary currency.
+    /// Useful when the transaction exchanges one one commodity into the other.
+    /// The commodity can be specified via CommodityConversion.
+    SecondaryAmount,
+    /// Secondary commodity for the `SecondaryAmount`.
+    /// Used only when `PresetCommodityConversion::Secondary` is specified.
+    SecondaryCommodity,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -331,16 +334,17 @@ pub enum CommodityConversion {
     /// As of 2024-02 only primary commodity is supported.
     Preset(PresetCommodityConversion),
     /// Conversion commodity is specified by the rule.
-    Trivial {
-        commodity: String,
-    },
+    Trivial { commodity: String },
 }
 
 /// Give preset commodity conversion.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum PresetCommodityConversion {
+    /// Secondary amount is in the account primary commodity.
     Primary,
+    /// Secondary amount is in the secondary commodity specified in each row.
+    Secondary,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -116,15 +116,19 @@ pub struct Matched<'a> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Conversion {
     Primary,
+    Secondary,
     Specified { commodity: String },
 }
 
 impl From<config::CommodityConversion> for Conversion {
     fn from(config: config::CommodityConversion) -> Conversion {
         match config {
-            config::CommodityConversion::Preset(
-                config::PresetCommodityConversion::Primary,
-            ) => Conversion::Primary,
+            config::CommodityConversion::Preset(config::PresetCommodityConversion::Primary) => {
+                Conversion::Primary
+            }
+            config::CommodityConversion::Preset(config::PresetCommodityConversion::Secondary) => {
+                Conversion::Secondary
+            }
             config::CommodityConversion::Trivial { commodity } => {
                 Conversion::Specified { commodity }
             }

--- a/cli/tests/testdata/test_config.yml
+++ b/cli/tests/testdata/test_config.yml
@@ -15,7 +15,7 @@ format:
     balance: 残高
     commodity: 通貨
     rate: 適用レート
-    equivalent_amount: 取引円換算額
+    secondary_amount: 取引円換算額
   commodity:
     EUR:
       precision: 2


### PR DESCRIPTION
Now that commodity conversion feature is getting into concrete shape, and I found it can be named as secondary commodity / amount as it is the second commodity in the single transaction.