### PR TITLE
Fix #106 not to fail contiguous transactions

### DIFF
--- a/core/src/repl/parser.rs
+++ b/core/src/repl/parser.rs
@@ -67,6 +67,7 @@ mod tests {
     use super::*;
 
     use chrono::NaiveDate;
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -80,5 +81,35 @@ mod tests {
                 "".to_string()
             ))]
         );
+    }
+
+    #[test]
+    fn parse_ledger_two_contiguous_transactions() {
+        let input = indoc! {"
+            2024/4/10 Migros
+                Expenses:Grocery
+            2024/4/20 Coop
+                Expenses:Grocery
+        "};
+
+        assert_eq!(
+            parse_ledger(input).unwrap(),
+            vec![
+                repl::LedgerEntry::Txn(repl::Transaction {
+                    posts: vec![repl::Posting::new("Expenses:Grocery".to_string())],
+                    ..repl::Transaction::new(
+                        NaiveDate::from_ymd_opt(2024, 4, 10).unwrap(),
+                        "Migros".to_string(),
+                    )
+                }),
+                repl::LedgerEntry::Txn(repl::Transaction {
+                    posts: vec![repl::Posting::new("Expenses:Grocery".to_string())],
+                    ..repl::Transaction::new(
+                        NaiveDate::from_ymd_opt(2024, 4, 20).unwrap(),
+                        "Coop".to_string(),
+                    )
+                })
+            ]
+        )
     }
 }

--- a/core/src/repl/parser/combinator.rs
+++ b/core/src/repl/parser/combinator.rs
@@ -3,7 +3,7 @@
 use nom::{
     combinator::{map, opt, peek},
     error::ParseError,
-    IResult, InputLength, Parser,
+    IResult, Parser,
 };
 
 /// Calls first parser if the condition is met, otherwise the second parser.
@@ -34,50 +34,12 @@ where
     map(peek(opt(f)), |x| x.is_some())
 }
 
-/// Applies the parser `f` while it can peek with the parser `g`.
-/// Returns a `Vec` containing the result of `f`.
-/// 
-/// Strictly speaking, this has the same output with `many0` as long as the input is well-formed.
-/// However, it'll make the debug easier as `f` failure is immediately caught as long as `g` is met.
-pub fn many0_while<I, O, P, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
-where
-    I: Clone + InputLength,
-    F: Parser<I, O, E>,
-    G: Parser<I, P, E>,
-    E: ParseError<I>,
-{
-    move |mut i: I| {
-        let mut ret = Vec::new();
-        loop {
-            let len = i.input_len();
-            match g.parse(i.clone()) {
-                Ok((_, _)) => (),
-                Err(nom::Err::Error(_)) => return Ok((i, ret)),
-                Err(e) => return Err(e),
-            };
-            let (i1, o) = f.parse(i)?;
-            ret.push(o);
-            if i1.input_len() == len {
-                return Err(nom::Err::Error(E::from_error_kind(
-                    i1,
-                    nom::error::ErrorKind::ManyTill,
-                )));
-            }
-            i = i1;
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::repl::parser::testing::expect_parse_ok;
 
-    use nom::{
-        bytes::complete::is_a,
-        character::complete::{anychar, char, space0, space1},
-        sequence::preceded,
-    };
+    use nom::bytes::complete::is_a;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -106,30 +68,5 @@ mod tests {
             expect_parse_ok(has_peek(is_a("0123")), "abcde"),
             ("abcde", false)
         );
-    }
-
-    #[test]
-    fn many_while_zero() {
-        assert_eq!(
-            expect_parse_ok(many0_while(preceded(space1, is_a("abc")), char(' ')), "abc"),
-            ("abc", vec![])
-        )
-    }
-
-    #[test]
-    fn many_while_some_items() {
-        assert_eq!(
-            expect_parse_ok(
-                many0_while(preceded(space1, is_a("abc")), char(' ')),
-                " abc   abc abc123"
-            ),
-            ("123", vec!["abc", "abc", "abc"])
-        )
-    }
-
-    #[test]
-    fn many_while_empty_item_error() {
-        let _: nom::Err<nom::error::Error<&'static str>> =
-            many0_while(space0, anychar)("abc").unwrap_err();
     }
 }

--- a/core/src/repl/parser/transaction.rs
+++ b/core/src/repl/parser/transaction.rs
@@ -1,13 +1,16 @@
 //! Defines parser functions for transaction.
 
 use crate::repl;
-use repl::parser::{character, combinator::has_peek, metadata, posting, primitive};
+use repl::parser::{
+    character,
+    combinator::{has_peek, many0_while},
+    metadata, posting, primitive,
+};
 
 use nom::{
     character::complete::{char, one_of, space0, space1},
     combinator::{cond, map, opt},
     error::VerboseError,
-    multi::many_till,
     sequence::{preceded, terminated},
     IResult,
 };
@@ -29,7 +32,7 @@ pub fn transaction(input: &str) -> IResult<&str, repl::Transaction, VerboseError
     let (input, code) = opt(terminated(character::paren_str, space0))(input)?;
     let (input, payee) = opt(map(character::not_line_ending_or_semi, str::trim_end))(input)?;
     let (input, metadata) = metadata::block_metadata(input)?;
-    let (input, (posts, _)) = many_till(posting::posting, character::line_ending_or_eof)(input)?;
+    let (input, posts) = many0_while(posting::posting, char(' '))(input)?;
     Ok((
         input,
         repl::Transaction {


### PR DESCRIPTION
This change fixed a bug #106 , failing to parse the following transaction

```
2024/4/10 Migros
    Expenses:Grocery
2024/4/20 Coop
    Expenses:Grocery
```