### PR TITLE
Add accounts command to list all accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
 name = "okane-core"
 version = "0.10.0-dev"
 dependencies = [
+ "bumpalo",
  "chrono",
  "criterion",
  "ctor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ name = "okane"
 version = "0.10.0-dev"
 dependencies = [
  "assert_cmd",
+ "bumpalo",
  "chrono",
  "clap",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/xkikeg/okane"
 
 [workspace.dependencies]
 # dependencies
+bumpalo = {version = "3.16", features = ["collections"]}
 chrono = "0.4.38"
 log = "0.4"
 rust_decimal = "1.35"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 okane-core = { version = "0.10.0-dev", path = "../core" }
+bumpalo.workspace = true
 chrono.workspace = true
 clap = { version = "4.5", features = ["derive", "unicode"] }
 csv = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ readme.workspace = true
 repository.workspace = true
 
 [dependencies]
+bumpalo = {version = "3.16", features = ["collections"]}
 chrono.workspace = true
 log.workspace = true
 rust_decimal.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ readme.workspace = true
 repository.workspace = true
 
 [dependencies]
-bumpalo = {version = "3.16", features = ["collections"]}
+bumpalo.workspace = true
 chrono.workspace = true
 log.workspace = true
 rust_decimal.workspace = true

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -1,6 +1,7 @@
 //! eval module contains functions for Ledger file evaluation.
 
-mod context;
+pub mod context;
+pub mod types;
 
 use std::path::PathBuf;
 
@@ -9,6 +10,22 @@ use crate::repl::{
     parser::{parse_ledger, ParseLedgerError},
     LedgerEntry,
 };
+
+/// Returns all accounts for the given LedgerEntry.
+/// Note this function will be removed by the next release.
+pub fn accounts<'ctx>(
+    ctx: &'ctx mut context::EvalContext,
+    entries: &[repl::LedgerEntry],
+) -> Vec<types::Account<'ctx>> {
+    for entry in entries {
+        if let LedgerEntry::Txn(txn) = entry {
+            for posting in &txn.posts {
+                ctx.accounts.intern(&posting.account);
+            }
+        }
+    }
+    ctx.all_accounts()
+}
 
 /// Loads the given path and returns the iterator.
 pub fn load(path: &std::path::Path) -> Result<Vec<repl::LedgerEntry>, LoadError> {

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -1,5 +1,7 @@
 //! eval module contains functions for Ledger file evaluation.
 
+mod context;
+
 use std::path::PathBuf;
 
 use crate::repl::{

--- a/core/src/eval/context.rs
+++ b/core/src/eval/context.rs
@@ -1,0 +1,73 @@
+use std::{collections::HashSet, marker::PhantomData};
+
+use bumpalo::Bump;
+
+#[derive(Debug, Eq)]
+pub struct Interned<'bump, Tag>(&'bump str, PhantomData<Tag>);
+
+impl<'bump, Tag> PartialEq for Interned<'bump, Tag> {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+
+impl<'bump, Tag> Interned<'bump, Tag> {
+    pub fn as_str(&'bump self) -> &'bump str {
+        return self.0;
+    }
+}
+
+pub struct Interner<'bump, Tag> {
+    idx: HashSet<&'bump str>,
+    allocator: &'bump Bump,
+    phantom: PhantomData<Tag>,
+}
+
+impl<'bump, Tag> Interner<'bump, Tag> {
+    pub fn new(allocator: &'bump Bump) -> Self {
+        Self {
+            idx: HashSet::new(),
+            allocator: allocator,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn from_str(&mut self, value: &str) -> Interned<'bump, Tag> {
+        if let Some(found) = self.idx.get(value) {
+            return Interned(*found, self.phantom);
+        }
+        let copied: &'bump str = self.allocator.alloc_str(value);
+        self.idx.insert(copied);
+        return Interned(copied, self.phantom);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug)]
+    struct FakeTag();
+
+    #[test]
+    fn interner_gives_distinct_strings() {
+        let bump = Bump::new();
+        let mut interner = Interner::new(&bump);
+        let foo: Interned<'_, FakeTag> = interner.from_str("foo");
+        let bar: Interned<'_, FakeTag> = interner.from_str("bar");
+        assert_eq!(foo.as_str(), "foo");
+        assert_eq!(bar.as_str(), "bar");
+    }
+
+    #[test]
+    fn interner_gives_same_obj() {
+        let bump = Bump::new();
+        let mut interner = Interner::new(&bump);
+        let foo1: Interned<'_, FakeTag> = interner.from_str("foo");
+        let foo2: Interned<'_, FakeTag> = interner.from_str("foo");
+        assert_eq!(foo1, foo2);
+        assert_eq!(foo2.as_str(), "foo");
+    }
+}

--- a/core/src/eval/context.rs
+++ b/core/src/eval/context.rs
@@ -1,73 +1,21 @@
-use std::{collections::HashSet, marker::PhantomData};
+use crate::eval::types;
 
 use bumpalo::Bump;
 
-#[derive(Debug, Eq)]
-pub struct Interned<'bump, Tag>(&'bump str, PhantomData<Tag>);
-
-impl<'bump, Tag> PartialEq for Interned<'bump, Tag> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
-    }
+/// EvalContext is a context object extensively used across Ledger evaluation.
+pub struct EvalContext<'ctx> {
+    pub(super) accounts: types::AccountStore<'ctx>,
 }
 
-impl<'bump, Tag> Interned<'bump, Tag> {
-    pub fn as_str(&'bump self) -> &'bump str {
-        return self.0;
-    }
-}
-
-pub struct Interner<'bump, Tag> {
-    idx: HashSet<&'bump str>,
-    allocator: &'bump Bump,
-    phantom: PhantomData<Tag>,
-}
-
-impl<'bump, Tag> Interner<'bump, Tag> {
-    pub fn new(allocator: &'bump Bump) -> Self {
-        Self {
-            idx: HashSet::new(),
-            allocator: allocator,
-            phantom: PhantomData,
-        }
+impl<'ctx> EvalContext<'ctx> {
+    pub fn new(allocator: &'ctx Bump) -> Self {
+        let accounts = types::AccountStore::new(allocator);
+        Self { accounts }
     }
 
-    pub fn from_str(&mut self, value: &str) -> Interned<'bump, Tag> {
-        if let Some(found) = self.idx.get(value) {
-            return Interned(*found, self.phantom);
-        }
-        let copied: &'bump str = self.allocator.alloc_str(value);
-        self.idx.insert(copied);
-        return Interned(copied, self.phantom);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use pretty_assertions::assert_eq;
-
-    #[derive(Debug)]
-    struct FakeTag();
-
-    #[test]
-    fn interner_gives_distinct_strings() {
-        let bump = Bump::new();
-        let mut interner = Interner::new(&bump);
-        let foo: Interned<'_, FakeTag> = interner.from_str("foo");
-        let bar: Interned<'_, FakeTag> = interner.from_str("bar");
-        assert_eq!(foo.as_str(), "foo");
-        assert_eq!(bar.as_str(), "bar");
-    }
-
-    #[test]
-    fn interner_gives_same_obj() {
-        let bump = Bump::new();
-        let mut interner = Interner::new(&bump);
-        let foo1: Interned<'_, FakeTag> = interner.from_str("foo");
-        let foo2: Interned<'_, FakeTag> = interner.from_str("foo");
-        assert_eq!(foo1, foo2);
-        assert_eq!(foo2.as_str(), "foo");
+    pub fn all_accounts(&'ctx self) -> Vec<types::Account<'ctx>> {
+        let mut r: Vec<types::Account<'ctx>> = self.accounts.iter().collect();
+        r.sort_unstable_by_key(|x| x.as_str());
+        r
     }
 }

--- a/core/src/eval/types.rs
+++ b/core/src/eval/types.rs
@@ -1,0 +1,137 @@
+//! Module `types` defines eval specific types.
+
+use std::{collections::HashSet, marker::PhantomData};
+
+use bumpalo::Bump;
+
+/// `&str` for accounts, interned by `Interner`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Account<'arena>(InternedStr<'arena>);
+
+impl<'arena> FromInterned<'arena> for Account<'arena> {
+    fn from_interned(v: InternedStr<'arena>) -> Self {
+        Self(v)
+    }
+}
+
+impl<'arena> Account<'arena> {
+    /// Returns the `&str`.
+    pub fn as_str(&self) -> &'arena str {
+        self.0.as_str()
+    }
+}
+
+/// `Interner` for `Account`.
+pub type AccountStore<'arena> = Interner<'arena, Account<'arena>>;
+
+/// Internal type to wrap `&str` to be clear about interning.
+/// Equality is compared over it's pointer, not the content.
+#[derive(Debug, Eq, Clone, Copy)]
+struct InternedStr<'arena>(&'arena str);
+
+impl<'arena> InternedStr<'arena> {
+    fn as_str(&self) -> &'arena str {
+        self.0
+    }
+}
+
+impl<'arena> PartialEq for InternedStr<'arena> {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+
+trait FromInterned<'arena> {
+    fn from_interned(v: InternedStr<'arena>) -> Self;
+}
+
+pub struct Interner<'arena, T> {
+    idx: HashSet<&'arena str>,
+    allocator: &'arena Bump,
+    phantom: PhantomData<T>,
+}
+
+#[allow(private_bounds)]
+impl<'arena, T: FromInterned<'arena>> Interner<'arena, T> {
+    pub fn new(allocator: &'arena Bump) -> Self {
+        Self {
+            idx: HashSet::new(),
+            allocator,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn intern(&mut self, value: &str) -> T {
+        if let Some(found) = self.idx.get(value) {
+            return <T as FromInterned>::from_interned(InternedStr(found));
+        }
+        let copied: &'arena str = self.allocator.alloc_str(value);
+        self.idx.insert(copied);
+        return <T as FromInterned>::from_interned(InternedStr(copied));
+    }
+
+    pub fn iter(&'arena self) -> Iter<'arena, T> {
+        Iter {
+            base: self.idx.iter(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// an iterator over the items of a `Interner`.
+/// Compared to the underlying HashSet iterator,
+/// this struct ensures the `T` type.
+pub struct Iter<'arena, T> {
+    base: std::collections::hash_set::Iter<'arena, &'arena str>,
+    phantom: PhantomData<T>,
+}
+
+impl<'arena, T> Iterator for Iter<'arena, T>
+where
+    T: FromInterned<'arena>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.base
+            .next()
+            .map(|x| <T as FromInterned>::from_interned(InternedStr(x)))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct TestInterned<'arena>(InternedStr<'arena>);
+
+    impl<'arena> FromInterned<'arena> for TestInterned<'arena> {
+        fn from_interned(v: InternedStr<'arena>) -> Self {
+            Self(v)
+        }
+    }
+
+    #[test]
+    fn interner_gives_distinct_strings() {
+        let bump = Bump::new();
+        let mut interner = Interner::new(&bump);
+        let foo: TestInterned = interner.intern("foo");
+        let bar: TestInterned = interner.intern("bar");
+        assert_ne!(foo, bar);
+        assert_eq!(foo.0.as_str(), "foo");
+        assert_eq!(bar.0.as_str(), "bar");
+    }
+
+    #[test]
+    fn interner_gives_same_obj() {
+        let bump = Bump::new();
+        let mut interner = Interner::new(&bump);
+        let foo1: TestInterned = interner.intern("foo");
+        let foo2: TestInterned = interner.intern("foo");
+        assert!(std::ptr::eq(foo1.0 .0, foo2.0 .0));
+        assert_eq!(foo1, foo2);
+        assert_eq!(foo2.0.as_str(), "foo");
+    }
+}


### PR DESCRIPTION
`accounts` command is one of the most primitive command to list all accounts without any transaction details.

This change includes `EvalContext` carrying all evaluation context (such as commodity, accounts)
and Arena-based allocation plus local String interner.