### PR TITLE
Move load module into separated out of eval.

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -1,7 +1,7 @@
 use crate::format;
 use crate::import::{self, Format, ImportError};
 use okane_core::repl::display::DisplayContext;
-use okane_core::{eval, repl};
+use okane_core::{eval, load, repl};
 
 use std::ffi::OsStr;
 use std::fs::File;
@@ -20,7 +20,7 @@ pub enum Error {
     #[error("failed to format")]
     Format(#[from] format::FormatError),
     #[error("failed to load")]
-    Load(#[from] eval::LoadError),
+    Load(#[from] load::LoadError),
 }
 
 #[derive(Subcommand, Debug)]
@@ -150,7 +150,7 @@ impl FlattenCmd {
     where
         W: std::io::Write,
     {
-        let entries = eval::load(&self.source)?;
+        let entries = load::load_repl(&self.source)?;
         // TODO: Pick DisplayContext from load results.
         let ctx = DisplayContext::default();
         for entry in entries.iter() {
@@ -170,7 +170,7 @@ impl AccountsCmd {
     where
         W: std::io::Write,
     {
-        let entries = eval::load(&self.source)?;
+        let entries = load::load_repl(&self.source)?;
         let arena = Bump::new();
         let mut ctx = eval::context::EvalContext::new(&arena);
         let accounts = eval::accounts(&mut ctx, &entries);

--- a/core/benches/eval_bench.rs
+++ b/core/benches/eval_bench.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use chrono::NaiveDate;
-use okane_core::eval::load;
+use okane_core::load::load_repl;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
@@ -136,7 +136,7 @@ fn load_benchmark(c: &mut Criterion) {
     let duration = after_input - before_input;
     log::info!("input creation took {:.3} seconds", duration.as_secs_f64());
     c.bench_function("load simple", |b| {
-        b.iter(|| black_box(load(&input.rootfile)))
+        b.iter(|| black_box(load_repl(&input.rootfile)))
     });
 }
 

--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -3,13 +3,7 @@
 pub mod context;
 pub mod types;
 
-use std::path::PathBuf;
-
-use crate::repl::{
-    self,
-    parser::{parse_ledger, ParseLedgerError},
-    LedgerEntry,
-};
+use crate::repl::{self, LedgerEntry};
 
 /// Returns all accounts for the given LedgerEntry.
 /// Note this function will be removed by the next release.
@@ -25,77 +19,4 @@ pub fn accounts<'ctx>(
         }
     }
     ctx.all_accounts()
-}
-
-/// Loads the given path and returns the iterator.
-pub fn load(path: &std::path::Path) -> Result<Vec<repl::LedgerEntry>, LoadError> {
-    let mut r = Vec::new();
-    load_impl(path, &mut r)?;
-    Ok(r)
-}
-
-fn load_impl(path: &std::path::Path, ret: &mut Vec<LedgerEntry>) -> Result<(), LoadError> {
-    let content = std::fs::read_to_string(path)?;
-    let vs = parse_ledger(&content)?;
-    for elem in vs.into_iter() {
-        match elem {
-            repl::LedgerEntry::Include(p) => {
-                let include_path: PathBuf = p.0.into();
-                let target = path
-                    .parent()
-                    .ok_or_else(|| LoadError::IncludePath(path.to_owned()))?
-                    .join(include_path);
-                load_impl(target.as_path(), ret)?
-            }
-            _ => ret.push(elem),
-        }
-    }
-    Ok(())
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum LoadError {
-    #[error("failed to perform IO")]
-    IO(#[from] std::io::Error),
-    #[error("failed to parse file {0}")]
-    Parse(#[from] ParseLedgerError),
-    #[error("unexpected include path {0}")]
-    IncludePath(PathBuf),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use crate::repl::parser::parse_ledger;
-
-    use indoc::indoc;
-    use pretty_assertions::assert_eq;
-    use std::path::Path;
-
-    #[test]
-    fn load_valid_input() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/root.ledger");
-        let got = load(&root).unwrap();
-        let want = parse_ledger(indoc! {"
-            account Expenses:Grocery
-                note スーパーマーケットで買ったやつ全部
-                ; comment
-                alias Expenses:CVS
-
-            2024/1/1 Initial Balance
-                Equity:Opening Balance       -1000.00 CHF
-                Assets:Bank:ZKB               1000.00 CHF
-
-            2024/1/1 * SBB CFF FFS
-                Assets:Bank:ZKB                 -5.60 CHF
-                Expenses:Travel:Train            5.60 CHF
-
-            2024/5/1 * Migros
-                Expenses:Grocery               -10.00 CHF
-                Assets:Bank:ZKB                 10.00 CHF
-        "})
-        .unwrap();
-        assert_eq!(got, want);
-    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod datamodel;
 pub mod eval;
+pub mod load;
 pub mod repl;

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -1,0 +1,83 @@
+//! Module `load` contains the functions useful for loading Ledger file,
+//! recursively resolving the `include` directives.
+
+use crate::repl;
+
+use std::path::PathBuf;
+
+/// Error caused by `load_*` functions.
+#[derive(thiserror::Error, Debug)]
+pub enum LoadError {
+    #[error("failed to perform IO")]
+    IO(#[from] std::io::Error),
+    #[error("failed to parse file {0}")]
+    Parse(#[from] repl::parser::ParseLedgerError),
+    #[error("unexpected include path {0}, maybe filesystem root is passed")]
+    IncludePath(PathBuf),
+}
+
+/// Returns `repl` format of ledger file entry, recursively resolving `include` directives.
+pub fn load_repl(path: &std::path::Path) -> Result<Vec<repl::LedgerEntry>, LoadError> {
+    let mut r = Vec::new();
+    load_repl_impl(path, &mut r)?;
+    Ok(r)
+}
+
+fn load_repl_impl(
+    path: &std::path::Path,
+    ret: &mut Vec<repl::LedgerEntry>,
+) -> Result<(), LoadError> {
+    let content = std::fs::read_to_string(path)?;
+    let vs = repl::parser::parse_ledger(&content)?;
+    for elem in vs.into_iter() {
+        match elem {
+            repl::LedgerEntry::Include(p) => {
+                let include_path: PathBuf = p.0.into();
+                let target = path
+                    .parent()
+                    .ok_or_else(|| LoadError::IncludePath(path.to_owned()))?
+                    .join(include_path);
+                load_repl_impl(target.as_path(), ret)?
+            }
+            _ => ret.push(elem),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::repl::parser::parse_ledger;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+    use std::path::Path;
+
+    #[test]
+    fn load_valid_input() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/root.ledger");
+        let got = load_repl(&root).unwrap();
+        let want = parse_ledger(indoc! {"
+            account Expenses:Grocery
+                note スーパーマーケットで買ったやつ全部
+                ; comment
+                alias Expenses:CVS
+
+            2024/1/1 Initial Balance
+                Equity:Opening Balance       -1000.00 CHF
+                Assets:Bank:ZKB               1000.00 CHF
+
+            2024/1/1 * SBB CFF FFS
+                Assets:Bank:ZKB                 -5.60 CHF
+                Expenses:Travel:Train            5.60 CHF
+
+            2024/5/1 * Migros
+                Expenses:Grocery               -10.00 CHF
+                Assets:Bank:ZKB                 10.00 CHF
+        "})
+        .unwrap();
+        assert_eq!(got, want);
+    }
+}


### PR DESCRIPTION
Now we put too much items into `eval` module, while the current plan is to limit the `eval` module only focusing on expression evaluation, and leave any other larger scope functionality to `report` module.

This PR is part of #126 .