### PR TITLE
Add annotate-snippets support to pretty print errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +775,8 @@ dependencies = [
 name = "okane"
 version = "0.10.0-dev"
 dependencies = [
+ "annotate-snippets",
+ "anstream",
  "assert_cmd",
  "bumpalo",
  "chrono",
@@ -797,6 +809,7 @@ dependencies = [
 name = "okane-core"
 version = "0.10.0-dev"
 dependencies = [
+ "annotate-snippets",
  "bumpalo",
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ repository = "https://github.com/xkikeg/okane"
 
 [workspace.dependencies]
 # dependencies
+annotate-snippets = "0.11"
+anstream = "0.6"
 bumpalo = {version = "3.16", features = ["collections"]}
 chrono = "0.4.38"
 log = "0.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 
 [dependencies]
 okane-core = { version = "0.10.0-dev", path = "../core" }
+
+annotate-snippets.workspace = true
+anstream.workspace = true
 bumpalo.workspace = true
 chrono.workspace = true
 clap = { version = "4.5", features = ["derive", "unicode"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,11 @@
+//! okane is a tool to have a plain text accounting, inspired by [Ledger CLI](https://ledger-cli.org/).
+//!
+//! For the detailed usage, see [README](https://github.com/xkikeg/okane/blob/main/README.md) or
+//! [Japanese README](https://github.com/xkikeg/okane/blob/main/README.md).
+//!
+//! As a library, [`okane-core`](https://crates.io/crates/okane-core) provides reusable functionalities.
+//! As oppose to that, this library mainly provides binary specific functionalities, mainly for integration tests.
+
 pub mod cmd;
 pub mod format;
 pub mod import;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ readme.workspace = true
 repository.workspace = true
 
 [dependencies]
+annotate-snippets.workspace = true
 bumpalo.workspace = true
 chrono.workspace = true
 log.workspace = true

--- a/core/src/parse/error.rs
+++ b/core/src/parse/error.rs
@@ -1,0 +1,60 @@
+use std::{fmt::Display, ops::Range};
+
+use annotate_snippets::{Level, Renderer, Snippet};
+use winnow::{error::{ContextError, ErrMode, StrContext}, stream::{Offset, Stream}};
+
+#[derive(Debug)]
+pub struct ParseError {
+    renderer: Renderer,
+    error_span: Range<usize>,
+    input: String,
+    winnow_error: ContextError,
+}
+
+impl ParseError {
+    /// Create a new instance of ParseError.
+    pub(super) fn new(
+        renderer: Renderer,
+        input: &str,
+        start: <&str as Stream>::Checkpoint,
+        error: ErrMode<ContextError<StrContext>>,
+    ) -> Self {
+
+        let mut input: &str = input;
+        let offset = input.offset_from(&start);
+        input.reset(&start);
+        let error = error.into_inner().expect("partial input can't be used");
+        // Assume the error span is only for the first `char`.
+        // Semantic errors are free to choose the entire span returned by `Parser::with_span`.
+        let end = (offset + 1..)
+            .find(|e| input.is_char_boundary(*e))
+            .unwrap_or(offset);
+        Self {
+            renderer,
+            error_span: offset..end,
+            input: input.to_owned(),
+            winnow_error: error,
+        }
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = self.winnow_error.to_string();
+        let message = Level::Error.title(&message).snippet(
+            Snippet::source(&self.input)
+                .fold(true)
+                .annotation(Level::Error.span(self.error_span.clone())),
+        );
+        let rendered = self.renderer.render(message);
+        rendered.fmt(f)
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.winnow_error
+            .cause()
+            .map(|x| x as &(dyn std::error::Error + 'static))
+    }
+}


### PR DESCRIPTION
This makes the error much readable.
Curerntly line_number is wrong, so anonymized for now. Eventually it should be solved.