### PR TITLE
Print correct line number for the parse error

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,7 @@
+//! okane-core crate is the library to support
+//! [okane](https://crates.io/crates/okane) CLI tool functionality,
+//! with reusable components.
+
 pub mod datamodel;
 pub mod format;
 pub mod load;

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -213,10 +213,22 @@ mod tests {
 
     #[test]
     fn load_valid_input_real_file() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/root.ledger").canonicalize().unwrap();
-        let child1 = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/child1.ledger").canonicalize().unwrap();
-        let child2 = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/sub/child2.ledger").canonicalize().unwrap();
-        let child3 = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/child3.ledger").canonicalize().unwrap();
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata/root.ledger")
+            .canonicalize()
+            .unwrap();
+        let child1 = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata/child1.ledger")
+            .canonicalize()
+            .unwrap();
+        let child2 = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata/sub/child2.ledger")
+            .canonicalize()
+            .unwrap();
+        let child3 = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata/child3.ledger")
+            .canonicalize()
+            .unwrap();
         let want = parse_static_repl(&[
             (
                 &root,

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -55,9 +55,9 @@ impl ParseOptions {
         input: &'i str,
     ) -> impl Iterator<Item = Result<ParsedLedgerEntry<'i>, ParseError>> + 'i {
         ParsedIter {
+            initial: input,
             input: Located::new(input),
-            // TODO: Make line_numbers working.
-            renderer: self.error_style.clone().anonymized_line_numbers(true),
+            renderer: self.error_style.clone(),
         }
     }
 }
@@ -66,6 +66,7 @@ pub type ParsedLedgerEntry<'i> = repl::LedgerEntry<'i>;
 
 /// Iterator to return parsed ledger entry one-by-one.
 struct ParsedIter<'i> {
+    initial: &'i str,
     input: Located<&'i str>,
     renderer: annotate_snippets::Renderer,
 }
@@ -82,7 +83,7 @@ impl<'i> Iterator for ParsedIter<'i> {
             }
             parse_ledger_entry.parse_next(&mut self.input).map(Some)
         })()
-        .map_err(|e| ParseError::new(self.renderer.clone(), self.input, start, e))
+        .map_err(|e| ParseError::new(self.renderer.clone(), self.initial, self.input, start, e))
         .transpose()
     }
 }

--- a/core/src/parse/primitive.rs
+++ b/core/src/parse/primitive.rs
@@ -30,10 +30,7 @@ where
     .parse_next(input)
 }
 
-const NON_COMMODITY_CHARS: [char; 37] = [
-    ' ', '\t', '\r', '\n', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', ',', ';', ':',
-    '?', '!', '-', '+', '*', '/', '^', '&', '|', '=', '<', '>', '[', ']', '(', ')', '{', '}', '@',
-];
+const NON_COMMODITY_CHARS: &'static [u8] = b" \t\r\n0123456789.,;:?!-+*/^&|=<>[](){}@";
 
 /// Parses commodity in greedy manner.
 /// Returns empty string if the upcoming characters are not valid as commodity to support empty commodity.

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -38,7 +38,7 @@ pub fn process<'ctx, L, F>(
 ) -> Result<(Vec<Transaction<'ctx>>, Balance<'ctx>), ReportError>
 where
     L: Borrow<load::Loader<F>>,
-    F: load::FileSystem
+    F: load::FileSystem,
 {
     let mut balance = Balance::default();
     let mut txns: Vec<Transaction<'ctx>> = Vec::new();


### PR DESCRIPTION
It used to have a wrong line number printed,
so now we compute the correct line number.