### PR TITLE
Fix Clippy warnings

### DIFF
--- a/core/src/parse/primitive.rs
+++ b/core/src/parse/primitive.rs
@@ -30,7 +30,7 @@ where
     .parse_next(input)
 }
 
-const NON_COMMODITY_CHARS: &'static [u8] = b" \t\r\n0123456789.,;:?!-+*/^&|=<>[](){}@";
+const NON_COMMODITY_CHARS: &[u8] = b" \t\r\n0123456789.,;:?!-+*/^&|=<>[](){}@";
 
 /// Parses commodity in greedy manner.
 /// Returns empty string if the upcoming characters are not valid as commodity to support empty commodity.

--- a/core/src/report/error.rs
+++ b/core/src/report/error.rs
@@ -12,7 +12,7 @@ use super::book_keeping;
 #[derive(thiserror::Error, Debug)]
 pub enum ReportError {
     Load(#[from] load::LoadError),
-    BookKeep(book_keeping::BookKeepError, ErrorContext),
+    BookKeep(book_keeping::BookKeepError, Box<ErrorContext>),
 }
 
 impl Display for ReportError {
@@ -56,12 +56,12 @@ impl ErrorContext {
         renderer: annotate_snippets::Renderer,
         path: PathBuf,
         pctx: &parse::ParsedContext,
-    ) -> Self {
-        Self {
+    ) -> Box<Self> {
+        Box::new(Self {
             renderer,
             path,
             line_start: pctx.compute_line_start(),
             text: pctx.as_str().to_owned(),
-        }
+        })
     }
 }


### PR DESCRIPTION
* Reduced `ReportError` size
* Removed redundant `'static` from const