### PR TITLE
Support account and commodity alias

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ workflows:
   production:
     jobs:
       - rust/lint-test-build:
-          version: "1.75.0"
+          version: "1.76.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 version = "0.11.0-dev"
 authors = ["xkikeg"]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.76.0"
 license = "MIT"
 repository = "https://github.com/xkikeg/okane"
 

--- a/core/src/repl/pretty_decimal.rs
+++ b/core/src/repl/pretty_decimal.rs
@@ -5,7 +5,8 @@ use rust_decimal::Decimal;
 
 /// Decimal formatting type for pretty-printing.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, ToStatic)]
-enum Format {
+#[non_exhaustive]
+pub enum Format {
     /// Decimal without no formatting, such as
     /// `1234` or `1234.5`.
     Plain,
@@ -15,9 +16,10 @@ enum Format {
 
 /// Decimal with the original format information encoded.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[non_exhaustive] // Don't want to construct directly.
 pub struct PrettyDecimal {
     /// Format of the decimal, None means there's no associated information.
-    format: Option<Format>,
+    pub format: Option<Format>,
     pub value: Decimal,
 }
 
@@ -48,28 +50,27 @@ pub enum Error {
 }
 
 impl PrettyDecimal {
+    /// Constructs a new instance with [Format].
+    pub fn with_format(value: Decimal, format: Option<Format>) -> Self {
+        Self { format, value }
+    }
+
     /// Constructs unformatted PrettyDecimal.
+    #[inline]
     pub fn unformatted(value: Decimal) -> Self {
-        Self {
-            value,
-            format: None,
-        }
+        Self::with_format(value, None)
     }
 
     /// Constructs plain PrettyDecimal.
+    #[inline]
     pub fn plain(value: Decimal) -> Self {
-        Self {
-            format: Some(Format::Plain),
-            value,
-        }
+        Self::with_format(value, Some(Format::Plain))
     }
 
     /// Constructs comma3 PrettyDecimal.
+    #[inline]
     pub fn comma3dot(value: Decimal) -> Self {
-        Self {
-            format: Some(Format::Comma3Dot),
-            value,
-        }
+        Self::with_format(value, Some(Format::Comma3Dot))
     }
 
     /// Returns the current scale.
@@ -290,5 +291,11 @@ mod tests {
             "1,234,567.890120",
             PrettyDecimal::comma3dot(dec!(1234567.890120)).to_string()
         );
+    }
+
+    #[test]
+    fn scale_returns_correct_number() {
+        assert_eq!(0, PrettyDecimal::comma3dot(dec!(1230)).scale());
+        assert_eq!(1, PrettyDecimal::comma3dot(dec!(1230.4)).scale());
     }
 }

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -27,7 +27,7 @@ where
     loader.borrow().load_repl(|_path, _ctx, entry| {
         if let LedgerEntry::Txn(txn) = entry {
             for posting in &txn.posts {
-                ctx.accounts.intern(&posting.account);
+                ctx.accounts.ensure(&posting.account);
             }
         }
         Ok::<(), load::LoadError>(())

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -9,9 +9,8 @@ mod intern;
 use std::borrow::Borrow;
 
 pub use book_keeping::{process, Balance, Posting, Transaction};
-pub use context::ReportContext;
+pub use context::{Account, ReportContext};
 pub use error::ReportError;
-pub use intern::Account;
 
 use crate::{load, repl::LedgerEntry};
 
@@ -20,7 +19,7 @@ use crate::{load, repl::LedgerEntry};
 pub fn accounts<'ctx, L, F>(
     ctx: &'ctx mut context::ReportContext,
     loader: L,
-) -> Result<Vec<intern::Account<'ctx>>, load::LoadError>
+) -> Result<Vec<Account<'ctx>>, load::LoadError>
 where
     L: Borrow<load::Loader<F>>,
     F: load::FileSystem,

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -9,10 +9,9 @@ use chrono::NaiveDate;
 use crate::{load, repl};
 
 use super::{
-    context::ReportContext,
+    context::{Account, ReportContext},
     error::{self, ReportError},
     eval::{Amount, EvalError, Evaluable},
-    intern::Account,
 };
 
 /// Error related to transaction understanding.

--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -82,7 +82,7 @@ mod tests {
         let got: Amount<'_> = got.try_into().expect("not an amount");
         assert_eq!(
             hashmap! {
-                ctx.commodities.intern("USD") => dec!(100.12345),
+                ctx.commodities.ensure("USD") => dec!(100.12345),
             },
             got.into_values()
         );
@@ -98,8 +98,8 @@ mod tests {
         let got: Amount<'_> = got.try_into().expect("not an amount");
         assert_eq!(
             hashmap! {
-                ctx.commodities.intern("EUR") => dec!(300),
-                ctx.commodities.intern("JPY") => dec!(20000),
+                ctx.commodities.ensure("EUR") => dec!(300),
+                ctx.commodities.ensure("JPY") => dec!(20000),
             },
             got.into_values()
         );
@@ -115,8 +115,8 @@ mod tests {
         let got: Amount<'_> = got.try_into().expect("not an amount");
         assert_eq!(
             hashmap! {
-                ctx.commodities.intern("USD") => dec!(180),
-                ctx.commodities.intern("EUR") => dec!(400),
+                ctx.commodities.ensure("USD") => dec!(180),
+                ctx.commodities.ensure("EUR") => dec!(400),
             },
             got.into_values()
         );

--- a/core/src/report/eval/amount.rs
+++ b/core/src/report/eval/amount.rs
@@ -202,7 +202,7 @@ mod tests {
     fn test_from_value() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
+        let jpy = ctx.commodities.ensure("JPY");
         let amount = Amount::from_value(dec!(123.45), jpy);
         assert_eq!(format!("{}", amount.as_inline_display()), "123.45 JPY")
     }
@@ -211,8 +211,8 @@ mod tests {
     fn test_is_absolute_zero() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let usd = ctx.commodities.intern("USD");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
 
         assert!(Amount::default().is_absolute_zero());
         assert!(!Amount::from_value(dec!(0), jpy).is_absolute_zero());
@@ -223,8 +223,8 @@ mod tests {
     fn test_is_zero() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let usd = ctx.commodities.intern("USD");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
 
         assert!(Amount::default().is_zero());
         assert!(Amount::from_value(dec!(0), jpy).is_zero());
@@ -238,8 +238,8 @@ mod tests {
     fn test_neg() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let usd = ctx.commodities.intern("USD");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
 
         assert_eq!(-Amount::zero(), Amount::zero());
         assert_eq!(
@@ -256,10 +256,10 @@ mod tests {
     fn test_add() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let usd = ctx.commodities.intern("USD");
-        let eur = ctx.commodities.intern("EUR");
-        let chf = ctx.commodities.intern("CHF");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
+        let eur = ctx.commodities.ensure("EUR");
+        let chf = ctx.commodities.ensure("CHF");
 
         let zero_plus_zero = Amount::zero() + Amount::zero();
         assert_eq!(zero_plus_zero, Amount::zero());
@@ -288,10 +288,10 @@ mod tests {
     fn test_sub() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let usd = ctx.commodities.intern("USD");
-        let eur = ctx.commodities.intern("EUR");
-        let chf = ctx.commodities.intern("CHF");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
+        let eur = ctx.commodities.ensure("EUR");
+        let chf = ctx.commodities.ensure("CHF");
 
         let zero_minus_zero = Amount::zero() - Amount::zero();
         assert_eq!(zero_minus_zero, Amount::zero());
@@ -315,9 +315,9 @@ mod tests {
     fn test_mul() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let eur = ctx.commodities.intern("EUR");
-        let chf = ctx.commodities.intern("CHF");
+        let jpy = ctx.commodities.ensure("JPY");
+        let eur = ctx.commodities.ensure("EUR");
+        let chf = ctx.commodities.ensure("CHF");
 
         assert_eq!(Amount::zero() * dec!(5), Amount::zero());
         assert_eq!(
@@ -339,9 +339,9 @@ mod tests {
     fn test_check_div() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-        let jpy = ctx.commodities.intern("JPY");
-        let eur = ctx.commodities.intern("EUR");
-        let chf = ctx.commodities.intern("CHF");
+        let jpy = ctx.commodities.ensure("JPY");
+        let eur = ctx.commodities.ensure("EUR");
+        let chf = ctx.commodities.ensure("CHF");
 
         assert_eq!(Amount::zero().check_div(dec!(5)).unwrap(), Amount::zero());
         assert_eq!(

--- a/core/src/report/eval/amount.rs
+++ b/core/src/report/eval/amount.rs
@@ -6,7 +6,7 @@ use std::{
 
 use rust_decimal::Decimal;
 
-use crate::report::intern::Commodity;
+use crate::report::context::Commodity;
 
 use super::error::EvalError;
 

--- a/core/src/report/eval/evaluated.rs
+++ b/core/src/report/eval/evaluated.rs
@@ -46,7 +46,7 @@ impl<'ctx> Evaluated<'ctx> {
         if amount.commodity.is_empty() {
             return amount.value.value.into();
         }
-        let commodity = ctx.commodities.intern(&amount.commodity);
+        let commodity = ctx.commodities.ensure(&amount.commodity);
         Amount::from_value(amount.value.clone().into(), commodity).into()
     }
 
@@ -159,10 +159,10 @@ mod tests {
         assert_eq!(
             Amount::try_from(Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             )))
             .unwrap(),
-            Amount::from_value(dec!(1000), ctx.commodities.intern("USD"))
+            Amount::from_value(dec!(1000), ctx.commodities.ensure("USD"))
         );
     }
 
@@ -176,11 +176,11 @@ mod tests {
 
         assert!(Evaluated::from(Amount::zero()).is_zero());
         assert!(
-            Evaluated::from(Amount::from_value(dec!(0), ctx.commodities.intern("USD"))).is_zero()
+            Evaluated::from(Amount::from_value(dec!(0), ctx.commodities.ensure("USD"))).is_zero()
         );
         assert!(!Evaluated::from(Amount::from_value(
             dec!(1000),
-            ctx.commodities.intern("USD")
+            ctx.commodities.ensure("USD")
         ))
         .is_zero());
     }
@@ -198,12 +198,12 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
             .negate(),
             Evaluated::from(Amount::from_value(
                 dec!(-1000),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
         );
     }
@@ -223,16 +223,16 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_add(Evaluated::from(Amount::from_value(
                 dec!(100),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             )))
             .unwrap(),
             Evaluated::from(Amount::from_values([
-                (dec!(1000), ctx.commodities.intern("JPY")),
-                (dec!(100), ctx.commodities.intern("USD")),
+                (dec!(1000), ctx.commodities.ensure("JPY")),
+                (dec!(100), ctx.commodities.ensure("USD")),
             ]))
         );
 
@@ -240,7 +240,7 @@ mod tests {
             Evaluated::from(dec!(1))
                 .check_add(Evaluated::from(Amount::from_value(
                     dec!(1000),
-                    ctx.commodities.intern("JPY")
+                    ctx.commodities.ensure("JPY")
                 )))
                 .unwrap_err(),
             EvalError::UnmatchingOperation
@@ -248,7 +248,7 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_add(Evaluated::from(dec!(1)))
             .unwrap_err(),
@@ -271,16 +271,16 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_sub(Evaluated::from(Amount::from_value(
                 dec!(100),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             )))
             .unwrap(),
             Evaluated::from(Amount::from_values([
-                (dec!(1000), ctx.commodities.intern("JPY")),
-                (dec!(-100), ctx.commodities.intern("USD")),
+                (dec!(1000), ctx.commodities.ensure("JPY")),
+                (dec!(-100), ctx.commodities.ensure("USD")),
             ]))
         );
 
@@ -288,7 +288,7 @@ mod tests {
             Evaluated::from(dec!(1))
                 .check_sub(Evaluated::from(Amount::from_value(
                     dec!(1000),
-                    ctx.commodities.intern("JPY")
+                    ctx.commodities.ensure("JPY")
                 )))
                 .unwrap_err(),
             EvalError::UnmatchingOperation
@@ -296,7 +296,7 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_sub(Evaluated::from(dec!(1)))
             .unwrap_err(),
@@ -320,36 +320,36 @@ mod tests {
             Evaluated::from(dec!(-0.2))
                 .check_mul(Evaluated::from(Amount::from_value(
                     dec!(1000),
-                    ctx.commodities.intern("JPY")
+                    ctx.commodities.ensure("JPY")
                 )))
                 .unwrap(),
             Evaluated::from(Amount::from_value(
                 dec!(-200),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
         );
 
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(3.15),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
             .check_mul(Evaluated::from(dec!(0.5)))
             .unwrap(),
             Evaluated::from(Amount::from_value(
                 dec!(1.575),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
         );
 
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_mul(Evaluated::from(Amount::from_value(
                 dec!(100),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             )))
             .unwrap_err(),
             EvalError::UnmatchingOperation
@@ -378,13 +378,13 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(3.15),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
             .check_div(Evaluated::from(dec!(0.5)))
             .unwrap(),
             Evaluated::from(Amount::from_value(
                 dec!(6.30),
-                ctx.commodities.intern("USD")
+                ctx.commodities.ensure("USD")
             ))
         );
 
@@ -392,7 +392,7 @@ mod tests {
             Evaluated::from(dec!(-0.2))
                 .check_div(Evaluated::from(Amount::from_value(
                     dec!(1000),
-                    ctx.commodities.intern("JPY")
+                    ctx.commodities.ensure("JPY")
                 )))
                 .unwrap_err(),
             EvalError::UnmatchingOperation
@@ -403,11 +403,11 @@ mod tests {
         assert_eq!(
             Evaluated::from(Amount::from_value(
                 dec!(1000),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             ))
             .check_div(Evaluated::from(Amount::from_value(
                 dec!(100),
-                ctx.commodities.intern("JPY")
+                ctx.commodities.ensure("JPY")
             )))
             .unwrap_err(),
             EvalError::UnmatchingOperation

--- a/core/src/report/intern.rs
+++ b/core/src/report/intern.rs
@@ -1,17 +1,26 @@
 //! `intern` gives the String intern library combined with Bump allocator.
 
-use std::{collections::HashSet, hash::Hash, marker::PhantomData};
+use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use bumpalo::Bump;
 
 /// Internal type to wrap `&str` to be clear about interning.
 /// Equality is compared over it's pointer, not the content.
-#[derive(Debug, Eq, Clone, Copy)]
+#[derive(Eq, Clone, Copy)]
 pub(super) struct InternedStr<'arena>(&'arena str);
 
 impl<'arena> InternedStr<'arena> {
     pub fn as_str(&self) -> &'arena str {
         self.0
+    }
+}
+
+impl<'arena> Debug for InternedStr<'arena> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("InternedStr")
+            .field(&std::ptr::from_ref(self.0))
+            .field(&self.0)
+            .finish()
     }
 }
 
@@ -35,49 +44,145 @@ impl<'arena> Hash for InternedStr<'arena> {
 }
 
 /// `FromInterned` is the trait that the actual Interned object must implements.
-pub(super) trait FromInterned<'arena> {
+pub(super) trait FromInterned<'arena>: Copy {
     fn from_interned(v: InternedStr<'arena>) -> Self;
+
+    fn as_interned(&self) -> InternedStr<'arena>;
 }
 
-pub(super) struct Interner<'arena, T> {
-    idx: HashSet<&'arena str>,
+/// Error on InternStore operations.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum InternError {
+    #[error("given alias is already registered as canonical")]
+    AlreadyCanonical,
+    #[error("given canonical is already registered as an alias")]
+    AlreadyAlias,
+}
+
+/// Manage interned `&str` in the arena allocator.
+/// This can also handles alias.
+/// Semantics of alias:
+/// * There are two types of interned str.
+///   One is canonical, and the other is alias.
+/// * It's prohibited to change account type once registered.
+///   Caller can't register alias which is already registered as canonical,
+///   or vice versa.
+pub(super) struct InternStore<'arena, T> {
+    // Contains None for canonical, Some for alias.
+    records: HashMap<&'arena str, Option<&'arena str>>,
     allocator: &'arena Bump,
     phantom: PhantomData<T>,
 }
 
+/// Stored value in [InternStore].
+#[derive(Debug, PartialEq, Eq)]
+pub enum StoredValue<'arena, T> {
+    Canonical(T),
+    Alias { alias: &'arena str, canonical: T },
+}
+
+impl<'arena, T: Copy> StoredValue<'arena, T> {
+    fn as_canonical(&self) -> T {
+        match self {
+            StoredValue::Canonical(x) => *x,
+            StoredValue::Alias {
+                alias: _,
+                canonical,
+            } => *canonical,
+        }
+    }
+}
+
 #[allow(private_bounds)]
-impl<'arena, T: FromInterned<'arena>> Interner<'arena, T> {
+impl<'arena, T: FromInterned<'arena>> InternStore<'arena, T> {
     pub fn new(allocator: &'arena Bump) -> Self {
         Self {
-            idx: HashSet::new(),
+            records: HashMap::new(),
             allocator,
             phantom: PhantomData,
         }
     }
 
-    /// Interns the given str and returns the shared instance.
-    pub fn intern(&mut self, value: &str) -> T {
-        if let Some(found) = self.get(value) {
-            return found;
+    /// Interns given `str` and returns the shared instance.
+    /// Note if `value` is registered as alias, it'll resolve to the canonical one.
+    /// If `value` is not registered yet, registered as canonical value.
+    pub fn ensure(&mut self, value: &str) -> T {
+        match self.resolve(value) {
+            Some(found) => found,
+            None => self.insert(value, None),
         }
-        let copied: &'arena str = self.allocator.alloc_str(value);
-        self.idx.insert(copied);
-        return <T as FromInterned>::from_interned(InternedStr(copied));
+    }
+
+    /// Inserts given `value` as always canonical.
+    /// Returns the registered canonical, or error if given `value` is already registered as alias.
+    pub fn insert_canonical(&mut self, value: &str) -> Result<T, InternError> {
+        match self.get(value) {
+            None => Ok(self.insert(value, None)),
+            Some(StoredValue::Canonical(found)) => Ok(found),
+            Some(StoredValue::Alias {
+                alias: _,
+                canonical: _,
+            }) => Err(InternError::AlreadyAlias),
+        }
+    }
+
+    /// Inserts given `value` as always alias of `canonical`.
+    /// Returns error if given `value` is already registered as canonical.
+    pub fn insert_alias(&mut self, value: &str, canonical: T) -> Result<(), InternError> {
+        match self.get(value) {
+            Some(StoredValue::Canonical(_)) => Err(InternError::AlreadyCanonical),
+            Some(StoredValue::Alias { .. }) => Ok(()),
+            None => {
+                self.insert(value, Some(canonical.as_interned().as_str()));
+                Ok(())
+            }
+        }
     }
 
     /// Returns the specified value if found, otherwise None.
-    pub fn get(&self, value: &str) -> Option<T> {
-        self.idx
-            .get(value)
-            .map(|x| <T as FromInterned>::from_interned(InternedStr(x)))
+    pub fn resolve(&self, value: &str) -> Option<T> {
+        let x = self.get(value)?;
+        Some(x.as_canonical())
     }
 
     /// Returns the Iterator for all elements.
-    pub fn iter(&'arena self) -> Iter<'arena, T> {
+    pub fn iter<'a>(&'a self) -> Iter<'a, T>
+    where
+        'a: 'arena,
+    {
         Iter {
-            base: self.idx.iter(),
+            base: self.records.iter(),
             phantom: PhantomData,
         }
+    }
+
+    #[inline]
+    fn get(&self, value: &str) -> Option<StoredValue<'arena, T>> {
+        let v = match self.records.get_key_value(value)? {
+            (canonical, None) => StoredValue::Canonical(Self::as_type(canonical)),
+            (alias, Some(canonical)) => StoredValue::Alias {
+                alias,
+                canonical: Self::as_type(canonical),
+            },
+        };
+        Some(v)
+    }
+
+    #[inline]
+    fn insert(&mut self, value: &str, canonical: Option<&'arena str>) -> T {
+        let copied: &'arena str = self.allocator.alloc_str(value);
+        let ret = self.records.insert(copied, canonical);
+        debug_assert!(
+            ret.is_none(),
+            "insert must be called on non-existing key, but already found: {:#?}",
+            ret
+        );
+        Self::as_type(copied)
+    }
+
+    #[inline]
+    fn as_type(s: &'arena str) -> T {
+        <T as FromInterned>::from_interned(InternedStr(s))
     }
 }
 
@@ -85,72 +190,162 @@ impl<'arena, T: FromInterned<'arena>> Interner<'arena, T> {
 /// Compared to the underlying HashSet iterator,
 /// this struct ensures the `T` type.
 pub struct Iter<'arena, T> {
-    base: std::collections::hash_set::Iter<'arena, &'arena str>,
+    base: std::collections::hash_map::Iter<'arena, &'arena str, Option<&'arena str>>,
     phantom: PhantomData<T>,
+}
+
+fn to_interned<'arena, T: FromInterned<'arena>>(x: &'arena str) -> T {
+    <T as FromInterned>::from_interned(InternedStr(x))
 }
 
 impl<'arena, T> Iterator for Iter<'arena, T>
 where
     T: FromInterned<'arena>,
 {
-    type Item = T;
+    type Item = StoredValue<'arena, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.base
-            .next()
-            .map(|x| <T as FromInterned>::from_interned(InternedStr(x)))
+        self.base.next().map(|(key, value)| match value {
+            None => StoredValue::Canonical(to_interned(key)),
+            Some(value) => StoredValue::Alias {
+                alias: key,
+                canonical: to_interned(value),
+            },
+        })
     }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use pretty_assertions::assert_eq;
-
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     struct TestInterned<'arena>(InternedStr<'arena>);
 
     impl<'arena> FromInterned<'arena> for TestInterned<'arena> {
         fn from_interned(v: InternedStr<'arena>) -> Self {
             Self(v)
         }
+
+        fn as_interned(&self) -> InternedStr<'arena> {
+            self.0
+        }
     }
 
     #[test]
-    fn interner_gives_distinct_strings() {
+    fn interned_str_eq_uses_ptr() {
         let bump = Bump::new();
-        let mut interner = Interner::new(&bump);
-        let foo: TestInterned = interner.intern("foo");
-        let bar: TestInterned = interner.intern("bar");
+        // Use non 'static str.
+        let foo1 = InternedStr(bump.alloc_str(&String::from("foo")));
+        let foo2 = InternedStr(bump.alloc_str(&String::from("foo")));
+        assert_ne!(foo1, foo2);
+        let foo_copy = foo1.clone();
+        assert_eq!(foo1, foo_copy);
+    }
+
+    #[test]
+    fn ensure_gives_distinct_strings() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let foo: TestInterned = intern_store.ensure("foo");
+        let bar: TestInterned = intern_store.ensure("bar");
         assert_ne!(foo, bar);
         assert_eq!(foo.0.as_str(), "foo");
         assert_eq!(bar.0.as_str(), "bar");
     }
 
     #[test]
-    fn interner_gives_same_obj() {
+    fn ensure_gives_same_obj() {
         let bump = Bump::new();
-        let mut interner = Interner::new(&bump);
-        let foo1: TestInterned = interner.intern("foo");
-        let foo2: TestInterned = interner.intern("foo");
-        assert!(std::ptr::eq(foo1.0 .0, foo2.0 .0));
+        let mut intern_store = InternStore::new(&bump);
+        let foo1: TestInterned = intern_store.ensure("foo");
+        let foo2: TestInterned = intern_store.ensure("foo");
         assert_eq!(foo1, foo2);
         assert_eq!(foo2.0.as_str(), "foo");
     }
 
     #[test]
-    fn interner_iter_all_elements() {
+    fn insert_canonical_succeeds_on_non_alias() {
         let bump = Bump::new();
-        let mut interner = Interner::new(&bump);
-        let v1: TestInterned = interner.intern("abc");
-        let v2: TestInterned = interner.intern("def");
-        interner.intern("def");
-        let v3: TestInterned = interner.intern("ghi");
-        let want = vec![v1, v2, v3];
+        let mut intern_store = InternStore::new(&bump);
+        let foo1: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        let foo2: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        let bar: TestInterned = intern_store.insert_canonical("bar").unwrap();
+        assert_eq!(foo1, foo2);
+        assert_eq!(foo1.as_interned().as_str(), "foo");
+        assert_ne!(foo1, bar);
+        assert_eq!(bar.as_interned().as_str(), "bar");
+    }
 
-        let mut got: Vec<TestInterned> = interner.iter().collect();
-        got.sort_by_key(|x| x.0.as_str());
+    #[test]
+    fn insert_canonical_fails_when_already_alias() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let foo: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        intern_store.insert_alias("bar", foo).unwrap();
+        assert_eq!(
+            InternError::AlreadyAlias,
+            intern_store.insert_canonical("bar").unwrap_err()
+        );
+    }
 
-        assert_eq!(want, got);
+    #[test]
+    fn insert_alias_works_on_unregistered_value() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let foo: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        intern_store.insert_alias("bar", foo).unwrap();
+        let bar = intern_store.ensure("bar");
+        assert_eq!(foo, bar);
+    }
+
+    #[test]
+    fn insert_alias_works_on_already_alias_value() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let foo: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        intern_store.insert_alias("bar", foo).unwrap();
+        intern_store.insert_alias("bar", foo).unwrap();
+    }
+
+    #[test]
+    fn insert_alias_fails_on_canonical() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let foo: TestInterned = intern_store.insert_canonical("foo").unwrap();
+        intern_store.insert_canonical("bar").unwrap();
+        assert_eq!(
+            InternError::AlreadyCanonical,
+            intern_store.insert_alias("bar", foo).unwrap_err()
+        );
+    }
+
+    #[test]
+    fn intern_store_iter_all_elements() {
+        let bump = Bump::new();
+        let mut intern_store = InternStore::new(&bump);
+        let v1: TestInterned = intern_store.ensure("abc");
+        let v2: TestInterned = intern_store.ensure("def");
+        intern_store.ensure("def");
+        intern_store
+            .insert_alias("efg", v1)
+            .expect("efg must be an alias of abc");
+        let v3: TestInterned = intern_store.ensure("ghi");
+        let want = [
+            StoredValue::Canonical(v1),
+            StoredValue::Alias {
+                alias: "efg",
+                canonical: v1,
+            },
+            StoredValue::Canonical(v2),
+            StoredValue::Canonical(v3),
+        ];
+
+        let mut got: Vec<StoredValue<TestInterned>> = intern_store.iter().collect();
+        got.sort_by_key(|x| match x {
+            StoredValue::Canonical(x) => (x.as_interned().as_str(), ""),
+            StoredValue::Alias { alias, canonical } => (canonical.as_interned().as_str(), *alias),
+        });
+
+        assert_eq!(want.as_slice(), got.as_slice());
     }
 }

--- a/core/src/report/intern.rs
+++ b/core/src/report/intern.rs
@@ -4,53 +4,13 @@ use std::{collections::HashSet, hash::Hash, marker::PhantomData};
 
 use bumpalo::Bump;
 
-/// `&str` for accounts, interned within the `'arena` bounded allocator lifetime.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Account<'arena>(InternedStr<'arena>);
-
-impl<'arena> FromInterned<'arena> for Account<'arena> {
-    fn from_interned(v: InternedStr<'arena>) -> Self {
-        Self(v)
-    }
-}
-
-impl<'arena> Account<'arena> {
-    /// Returns the `&str`.
-    pub fn as_str(&self) -> &'arena str {
-        self.0.as_str()
-    }
-}
-
-/// `Interner` for `Account`.
-pub(super) type AccountStore<'arena> = Interner<'arena, Account<'arena>>;
-
-/// `&str` for commodities, interned within the `'arena` bounded allocator lifetime.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Commodity<'arena>(InternedStr<'arena>);
-
-impl<'arena> FromInterned<'arena> for Commodity<'arena> {
-    fn from_interned(v: InternedStr<'arena>) -> Self {
-        Self(v)
-    }
-}
-
-impl<'arena> Commodity<'arena> {
-    /// Returns the `&str`.
-    pub fn as_str(&self) -> &'arena str {
-        self.0.as_str()
-    }
-}
-
-/// `Interner` for `Commodity`.
-pub(super) type CommodityStore<'arena> = Interner<'arena, Commodity<'arena>>;
-
 /// Internal type to wrap `&str` to be clear about interning.
 /// Equality is compared over it's pointer, not the content.
 #[derive(Debug, Eq, Clone, Copy)]
-struct InternedStr<'arena>(&'arena str);
+pub(super) struct InternedStr<'arena>(&'arena str);
 
 impl<'arena> InternedStr<'arena> {
-    fn as_str(&self) -> &'arena str {
+    pub fn as_str(&self) -> &'arena str {
         self.0
     }
 }
@@ -75,7 +35,7 @@ impl<'arena> Hash for InternedStr<'arena> {
 }
 
 /// `FromInterned` is the trait that the actual Interned object must implements.
-trait FromInterned<'arena> {
+pub(super) trait FromInterned<'arena> {
     fn from_interned(v: InternedStr<'arena>) -> Self;
 }
 


### PR DESCRIPTION
Ledger supports alias for both account and commodity and which is a critical feature.

Behavior difference from Ledger:

-   We explicitly prohibits having a alias which used to be a canonical. For example, below snippets are invalid:
    ```
    accounts Foo
      alias Bar
    accounts Baz
      alias Foo
    ```
-   We explicitly prohibits having a canonical which used to be a alias. Below are invalid:
    ```
    accounts Foo
      alias Bar
    accounts Bar
      alias Baz
    ```
- [derived from those 2] We prohibits having a self referencing alias. Below are invalid:
    ```
    accounts Foo
      alias Foo
    ```

This is to avoid complicated cyclic alias detection