### PR TITLE
Fix leak book keeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/xkikeg/okane"
 [workspace.dependencies]
 # dependencies
 annotate-snippets = "0.11"
-bumpalo = {version = "3.16", features = ["collections"]}
+bumpalo = {version = "3.16", features = ["collections", "boxed"]}
 chrono = "0.4.38"
 log = "0.4"
 rust_decimal = "1.35"
@@ -32,3 +32,6 @@ indoc = "2.0"
 maplit = "1.0"
 pretty_assertions = "1.4"
 rust_decimal_macros = "1.35"
+
+[profile.bench]
+debug = "limited"

--- a/cli/src/import/iso_camt053/xmlnode.rs
+++ b/cli/src/import/iso_camt053/xmlnode.rs
@@ -321,6 +321,7 @@ impl<'de> serde::de::Visitor<'de> for RelatedPartyVisitor<'de> {
 }
 
 impl RelatedParty {
+    #[cfg(test)]
     pub fn from_inner(party: PartyDetails) -> Self {
         RelatedParty::Nested(Party { party })
     }


### PR DESCRIPTION
It used to leaked all `transaction.posting.amount`.

it'll be tricky to move `Amount` map into `Bump`, as mostly it's temporal and having it in arena can consume memory more than needed.