### PR TITLE
Feature: Support correct balance

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -204,7 +204,7 @@ impl BalanceCmd {
         let (_, balance) = report::process(&mut ctx, load::new_loader(self.source))?;
         let accounts = ctx.all_accounts();
         for account in &accounts {
-            if let Some(amount) = balance.get_balance(account) {
+            if let Some(amount) = balance.get(account) {
                 writeln!(w, "{}: {}", account.as_str(), amount.as_inline_display())?;
             } else {
                 writeln!(w, "{}: not found, probably zero", account.as_str())?;
@@ -236,7 +236,7 @@ impl RegisterCmd {
         for txn in txns {
             if let Some(account) = &account {
                 if let Some(p) = txn.postings.iter().find(|p| p.account == *account) {
-                    let b = balance.increment(*account, p.amount.clone());
+                    let b = balance.add_amount(*account, p.amount.clone());
                     writeln!(
                         w,
                         "{} {} {}",

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -8,7 +8,7 @@ mod expr;
 mod metadata;
 mod posting;
 mod primitive;
-mod transaction;
+pub(crate) mod transaction;
 
 #[cfg(test)]
 pub(crate) mod testing;

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -1,5 +1,6 @@
 //! eval module contains functions for Ledger file evaluation.
 
+mod balance;
 mod book_keeping;
 mod context;
 mod error;
@@ -8,7 +9,8 @@ mod intern;
 
 use std::borrow::Borrow;
 
-pub use book_keeping::{process, Balance, Posting, Transaction};
+pub use balance::Balance;
+pub use book_keeping::{process, Posting, Transaction};
 pub use context::{Account, ReportContext};
 pub use error::ReportError;
 

--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -1,28 +1,87 @@
 use std::collections::HashMap;
 
-use super::{context::Account, eval::Amount};
+use super::{
+    context::Account,
+    eval::{Amount, EvalError, PostingAmount},
+};
+
+/// Error related to [Balance] operations.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BalanceError {
+    #[error("balance = 0 cannot deduce posting amount when balance has multi commodities")]
+    MultiCommodityWithPartialSet(#[from] EvalError),
+}
 
 /// Accumulated balance of accounts.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct Balance<'ctx> {
     accounts: HashMap<Account<'ctx>, Amount<'ctx>>,
 }
 
+impl<'ctx> FromIterator<(Account<'ctx>, Amount<'ctx>)> for Balance<'ctx> {
+    /// Constructs [Balance] instance out of Iterator.
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (Account<'ctx>, Amount<'ctx>)>,
+    {
+        Self {
+            accounts: iter.into_iter().collect(),
+        }
+    }
+}
+
 impl<'ctx> Balance<'ctx> {
     /// Adds a particular account value, and returns the updated balance.
-    pub fn increment(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> Amount<'ctx> {
+    pub fn add_amount(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> &Amount<'ctx> {
         let curr: &mut Amount = self.accounts.entry(account).or_default();
         *curr += amount;
-        curr.clone()
+        curr
     }
 
-    /// Sets the particular account's balance, and returns the previous balance.
-    pub fn set_balance(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> Amount<'ctx> {
-        self.accounts.insert(account, amount).unwrap_or_default()
+    /// Adds a particular account value with the specified commodity, and returns the updated balance.
+    pub fn add_posting_amount(
+        &mut self,
+        account: Account<'ctx>,
+        amount: PostingAmount<'ctx>,
+    ) -> &Amount<'ctx> {
+        let curr: &mut Amount = self.accounts.entry(account).or_default();
+        *curr += amount;
+        curr
+    }
+
+    /// Tries to set the particular account's balance with the specified commodity,
+    /// and returns the delta which should have caused the difference.
+    pub fn set_partial(
+        &mut self,
+        account: Account<'ctx>,
+        amount: PostingAmount<'ctx>,
+    ) -> Result<PostingAmount<'ctx>, BalanceError> {
+        match amount {
+            PostingAmount::Zero => {
+                let prev: Amount<'ctx> = self
+                    .accounts
+                    .insert(account, amount.into())
+                    .unwrap_or_default();
+                (&prev)
+                    .try_into()
+                    .map_err(BalanceError::MultiCommodityWithPartialSet)
+            }
+            PostingAmount::Single { value, commodity } => {
+                let prev = self
+                    .accounts
+                    .entry(account)
+                    .or_default()
+                    .set_partial(value, commodity);
+                Ok(PostingAmount::Single {
+                    value: prev,
+                    commodity,
+                })
+            }
+        }
     }
 
     /// Gets the balance of the given account.
-    pub fn get_balance(&self, account: &Account<'ctx>) -> Option<&Amount<'ctx>> {
+    pub fn get(&self, account: &Account<'ctx>) -> Option<&Amount<'ctx>> {
         self.accounts.get(account)
     }
 }
@@ -43,7 +102,7 @@ mod tests {
         let mut ctx = ReportContext::new(&arena);
 
         let balance = Balance::default();
-        assert_eq!(balance.get_balance(&ctx.accounts.ensure("Expenses")), None);
+        assert_eq!(balance.get(&ctx.accounts.ensure("Expenses")), None);
     }
 
     #[test]
@@ -52,67 +111,190 @@ mod tests {
         let mut ctx = ReportContext::new(&arena);
 
         let mut balance = Balance::default();
-        let updated = balance.increment(
-            ctx.accounts.ensure("Expenses"),
-            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
-        );
+        let updated = balance
+            .add_posting_amount(
+                ctx.accounts.ensure("Expenses"),
+                PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            )
+            .clone();
 
         assert_eq!(
             updated,
             Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
         );
         assert_eq!(
-            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            balance.get(&ctx.accounts.ensure("Expenses")),
             Some(&updated)
         );
 
-        let updated = balance.increment(
-            ctx.accounts.ensure("Expenses"),
-            Amount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
-        );
+        let updated = balance
+            .add_posting_amount(
+                ctx.accounts.ensure("Expenses"),
+                PostingAmount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+            )
+            .clone();
 
         assert_eq!(updated, Amount::zero());
         assert_eq!(
-            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            balance.get(&ctx.accounts.ensure("Expenses")),
             Some(&updated)
         );
     }
 
     #[test]
-    fn test_balance_set_balance() {
+    fn test_balance_set_partial_from_absolute_zero() {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
-
         let mut balance = Balance::default();
-        let prev = balance.set_balance(
-            ctx.accounts.ensure("Expenses"),
-            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
-        );
 
-        assert_eq!(prev, Amount::zero());
+        let prev = balance
+            .set_partial(
+                ctx.accounts.ensure("Expenses"),
+                PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            )
+            .unwrap();
+
+        // Note it won't be PostingAmount::zero(),
+        // as set_partial is called with commodity amount.
         assert_eq!(
-            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            prev,
+            PostingAmount::from_value(dec!(0), ctx.commodities.ensure("JPY"))
+        );
+        assert_eq!(
+            balance.get(&ctx.accounts.ensure("Expenses")),
             Some(&Amount::from_value(
                 dec!(1000),
                 ctx.commodities.ensure("JPY")
             ))
         );
+    }
 
-        let prev = balance.set_balance(
+    #[test]
+    fn test_balance_set_partial_hit_same_commodity() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut balance = Balance::default();
+        balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            Amount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
         );
+
+        let prev = balance
+            .set_partial(
+                ctx.accounts.ensure("Expenses"),
+                PostingAmount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+            )
+            .unwrap();
 
         assert_eq!(
             prev,
-            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
         );
         assert_eq!(
-            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            balance.get(&ctx.accounts.ensure("Expenses")),
             Some(&Amount::from_value(
                 dec!(-1000),
                 ctx.commodities.ensure("JPY")
             ))
+        );
+    }
+
+    #[test]
+    fn test_balance_set_partial_multi_commodities() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut balance = Balance::default();
+        balance.add_posting_amount(
+            ctx.accounts.ensure("Expenses"),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+        balance.add_posting_amount(
+            ctx.accounts.ensure("Expenses"),
+            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF")),
+        );
+
+        let prev = balance
+            .set_partial(
+                ctx.accounts.ensure("Expenses"),
+                PostingAmount::from_value(dec!(100), ctx.commodities.ensure("CHF")),
+            )
+            .unwrap();
+
+        assert_eq!(
+            prev,
+            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF"))
+        );
+        assert_eq!(
+            balance.get(&ctx.accounts.ensure("Expenses")),
+            Some(&Amount::from_values([
+                (dec!(1000), ctx.commodities.ensure("JPY")),
+                (dec!(100), ctx.commodities.ensure("CHF")),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_balance_set_partial_zero_on_zero() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut balance = Balance::default();
+
+        let prev = balance
+            .set_partial(ctx.accounts.ensure("Expenses"), PostingAmount::zero())
+            .unwrap();
+
+        assert_eq!(prev, PostingAmount::zero());
+        assert_eq!(
+            balance.get(&ctx.accounts.ensure("Expenses")),
+            Some(&Amount::zero())
+        );
+    }
+
+    #[test]
+    fn test_balance_set_partial_zero_on_single_commodity() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut balance = Balance::default();
+        balance.add_posting_amount(
+            ctx.accounts.ensure("Expenses"),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+
+        let prev = balance
+            .set_partial(ctx.accounts.ensure("Expenses"), PostingAmount::zero())
+            .unwrap();
+
+        assert_eq!(
+            prev,
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
+        );
+        assert_eq!(
+            balance.get(&ctx.accounts.ensure("Expenses")),
+            Some(&Amount::zero())
+        );
+    }
+
+    #[test]
+    fn test_balance_set_partial_zero_fails_on_multi_commodities() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut balance = Balance::default();
+        balance.add_posting_amount(
+            ctx.accounts.ensure("Expenses"),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+        balance.add_posting_amount(
+            ctx.accounts.ensure("Expenses"),
+            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF")),
+        );
+
+        let err = balance
+            .set_partial(ctx.accounts.ensure("Expenses"), PostingAmount::zero())
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            BalanceError::MultiCommodityWithPartialSet(EvalError::SingleCommodityAmountRequired)
         );
     }
 }

--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use super::{context::Account, eval::Amount};
+
+/// Accumulated balance of accounts.
+#[derive(Debug, Default)]
+pub struct Balance<'ctx> {
+    accounts: HashMap<Account<'ctx>, Amount<'ctx>>,
+}
+
+impl<'ctx> Balance<'ctx> {
+    /// Adds a particular account value, and returns the updated balance.
+    pub fn increment(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> Amount<'ctx> {
+        let curr: &mut Amount = self.accounts.entry(account).or_default();
+        *curr += amount;
+        curr.clone()
+    }
+
+    /// Sets the particular account's balance, and returns the previous balance.
+    pub fn set_balance(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> Amount<'ctx> {
+        self.accounts.insert(account, amount).unwrap_or_default()
+    }
+
+    /// Gets the balance of the given account.
+    pub fn get_balance(&self, account: &Account<'ctx>) -> Option<&Amount<'ctx>> {
+        self.accounts.get(account)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bumpalo::Bump;
+    use pretty_assertions::assert_eq;
+    use rust_decimal_macros::dec;
+
+    use super::super::context::ReportContext;
+
+    #[test]
+    fn balance_gives_zero_amount_when_not_initalized() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+
+        let balance = Balance::default();
+        assert_eq!(balance.get_balance(&ctx.accounts.ensure("Expenses")), None);
+    }
+
+    #[test]
+    fn test_balance_increment_adds_value() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+
+        let mut balance = Balance::default();
+        let updated = balance.increment(
+            ctx.accounts.ensure("Expenses"),
+            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+
+        assert_eq!(
+            updated,
+            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
+        );
+        assert_eq!(
+            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            Some(&updated)
+        );
+
+        let updated = balance.increment(
+            ctx.accounts.ensure("Expenses"),
+            Amount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+        );
+
+        assert_eq!(updated, Amount::zero());
+        assert_eq!(
+            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            Some(&updated)
+        );
+    }
+
+    #[test]
+    fn test_balance_set_balance() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+
+        let mut balance = Balance::default();
+        let prev = balance.set_balance(
+            ctx.accounts.ensure("Expenses"),
+            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+
+        assert_eq!(prev, Amount::zero());
+        assert_eq!(
+            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            Some(&Amount::from_value(
+                dec!(1000),
+                ctx.commodities.ensure("JPY")
+            ))
+        );
+
+        let prev = balance.set_balance(
+            ctx.accounts.ensure("Expenses"),
+            Amount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+        );
+
+        assert_eq!(
+            prev,
+            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
+        );
+        assert_eq!(
+            balance.get_balance(&ctx.accounts.ensure("Expenses")),
+            Some(&Amount::from_value(
+                dec!(-1000),
+                ctx.commodities.ensure("JPY")
+            ))
+        );
+    }
+}

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -9,25 +9,29 @@ use chrono::NaiveDate;
 use crate::{load, repl};
 
 use super::{
-    balance::Balance,
+    balance::{Balance, BalanceError},
     context::{Account, ReportContext},
     error::{self, ReportError},
-    eval::{Amount, EvalError, Evaluable},
+    eval::{Amount, EvalError, Evaluable, PostingAmount},
     intern::InternError,
 };
 
 /// Error related to transaction understanding.
 // TODO: Reconsider the error in details.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum BookKeepError {
-    #[error("failed to evaluate the expression")]
+    #[error("failed to evaluate the expression: {0}")]
     EvalFailure(#[from] EvalError),
+    #[error("failed to meet balance condition: {0}")]
+    BalanceFailure(#[from] BalanceError),
     #[error("posting amount must be resolved as a simple value with commodity or zero")]
     ComplexPostingAmount,
     #[error("transaction cannot have multiple postings without amount: {0} {1}")]
     UndeduciblePostingAmount(usize, usize),
     #[error("transaction cannot have unbalanced postings: {0}")]
     UnbalancedPostings(String),
+    #[error("balance assertion failed: got {0} but expected {1}")]
+    BalanceAssertionFailure(String, String),
     #[error("failed to register account: {0}")]
     InvalidAccount(#[source] InternError),
     #[error("failed to register commodity: {0}")]
@@ -119,7 +123,7 @@ impl<'ctx> ProcessAccumulator<'ctx> {
 
 /// Evaluated transaction, already processed to have right balance.
 // TODO: Rename it to EvaluatedTxn?
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Transaction<'ctx> {
     pub date: NaiveDate,
     // Posting in the transaction.
@@ -130,9 +134,11 @@ pub struct Transaction<'ctx> {
 }
 
 /// Evaluated posting of the transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Posting<'ctx> {
     pub account: Account<'ctx>,
+    /// Note this Amount is not PostingAmount,
+    /// as deduced posting may have non-single commodity amount.
     pub amount: Amount<'ctx>,
 }
 
@@ -147,40 +153,51 @@ fn add_transaction<'ctx>(
     let mut balance = Amount::default();
     for (i, posting) in txn.posts.iter().enumerate() {
         let account = ctx.accounts.ensure(&posting.account);
-        let posting = match (&posting.amount, &posting.balance) {
+        let amount = match (&posting.amount, &posting.balance) {
             (None, None) => {
                 if let Some(j) = unfilled.replace(i) {
                     Err(BookKeepError::UndeduciblePostingAmount(j, i))
                 } else {
-                    Ok(Posting {
-                        account,
-                        amount: Amount::default(),
-                    })
+                    Ok(PostingAmount::zero())
                 }
             }
             (None, Some(balance_constraints)) => {
-                let current: Amount = balance_constraints.eval(ctx)?.try_into()?;
-                let prev = bal.set_balance(account, current.clone());
+                let current: PostingAmount = balance_constraints.eval(ctx)?.try_into()?;
+                let prev: PostingAmount = bal.set_partial(account, current)?;
 
-                Ok(Posting {
-                    account,
-                    amount: current - prev,
-                })
+                Ok(current.check_sub(prev)?)
             }
-            (Some(amount), _) => {
+            (Some(amount), balance_constraints) => {
                 // TODO: add balance constraints check.
-                let amount: Amount = amount.amount.eval(ctx)?.try_into()?;
-                bal.increment(account, amount.clone());
-                balance += amount.clone();
-                Ok(Posting { account, amount })
+                let amount: PostingAmount = amount.amount.eval(ctx)?.try_into()?;
+                let expected_balance: Option<PostingAmount> = balance_constraints
+                    .as_ref()
+                    .map(|x| x.eval(ctx))
+                    .transpose()?
+                    .map(|x| x.try_into())
+                    .transpose()?;
+                let current = bal.add_posting_amount(account, amount);
+                if let Some(expected) = expected_balance {
+                    if !current.is_consistent(expected) {
+                        return Err(BookKeepError::BalanceAssertionFailure(
+                            format!("{}", current.as_inline_display()),
+                            format!("{}", expected),
+                        ));
+                    }
+                }
+                Ok(amount)
             }
         }?;
-        postings.push(posting);
+        balance += amount;
+        postings.push(Posting {
+            account,
+            amount: amount.into(),
+        });
     }
     if let Some(u) = unfilled {
-        let deduced = balance.clone().negate();
+        let deduced: Amount = balance.clone().negate();
         postings[u].amount = deduced.clone();
-        bal.increment(postings[u].account, deduced);
+        bal.add_amount(postings[u].account, deduced);
     } else if !balance.is_zero() {
         // TODO: restore balance checks here.
         // let's ignore this for now, as we're not checking balance properly.
@@ -194,4 +211,204 @@ fn add_transaction<'ctx>(
         date: txn.date,
         postings: postings.into_boxed_slice(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bumpalo::Bump;
+    use indoc::indoc;
+    use maplit::hashmap;
+    use pretty_assertions::assert_eq;
+    use rust_decimal_macros::dec;
+    use winnow::Parser;
+
+    use crate::parse;
+
+    #[test]
+    fn add_transaction_maintains_balance() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut bal = Balance::default();
+        bal.add_posting_amount(
+            ctx.accounts.ensure("Account 1"),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+        bal.add_posting_amount(
+            ctx.accounts.ensure("Account 1"),
+            PostingAmount::from_value(dec!(123), ctx.commodities.ensure("EUR")),
+        );
+        bal.add_posting_amount(
+            ctx.accounts.ensure("Account 4"),
+            PostingAmount::from_value(dec!(10), ctx.commodities.ensure("CHF")),
+        );
+        let input = indoc! {"
+            2024/08/01 Sample
+              Account 1      200 JPY = 1200 JPY
+              Account 2     -100 JPY = -100 JPY
+              Account 2     -100 JPY = -200 JPY
+              Account 3      300 JPY
+              Account 4              = -300 JPY
+        "};
+        let txn = parse::transaction::transaction.parse(input).unwrap();
+        let _ = add_transaction(&mut ctx, &mut bal, &txn).expect("must succeed");
+        let want_balance: Balance = hashmap! {
+            ctx.accounts.ensure("Account 1") =>
+                Amount::from_values([
+                    (dec!(1200), ctx.commodities.ensure("JPY")),
+                    (dec!(123), ctx.commodities.ensure("EUR")),
+                ]),
+            ctx.accounts.ensure("Account 2") =>
+                Amount::from_value(dec!(-200), ctx.commodities.ensure("JPY")),
+            ctx.accounts.ensure("Account 3") =>
+                Amount::from_value(dec!(300), ctx.commodities.ensure("JPY")),
+            ctx.accounts.ensure("Account 4") =>
+                Amount::from_values([
+                    (dec!(-300), ctx.commodities.ensure("JPY")),
+                    (dec!(10), ctx.commodities.ensure("CHF")),
+                ]),
+        }
+        .into_iter()
+        .collect();
+        assert_eq!(want_balance, bal);
+    }
+
+    #[test]
+    fn add_transaction_emits_transaction_with_postings() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut bal = Balance::default();
+        let input = indoc! {"
+            2024/08/01 Sample
+              Account 1      200 JPY = 200 JPY
+              Account 2     -100 JPY = -100 JPY
+              Account 2     -100 JPY = -200 JPY
+        "};
+        let txn = parse::transaction::transaction.parse(input).unwrap();
+        let got = add_transaction(&mut ctx, &mut bal, &txn).expect("must succeed");
+        let want = Transaction {
+            date: NaiveDate::from_ymd_opt(2024, 8, 1).unwrap(),
+            postings: bcc::Vec::from_iter_in(
+                [
+                    Posting {
+                        account: ctx.accounts.ensure("Account 1"),
+                        amount: Amount::from_value(dec!(200), ctx.commodities.ensure("JPY")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 2"),
+                        amount: Amount::from_value(dec!(-100), ctx.commodities.ensure("JPY")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 2"),
+                        amount: Amount::from_value(dec!(-100), ctx.commodities.ensure("JPY")),
+                    },
+                ],
+                &arena,
+            )
+            .into_boxed_slice(),
+        };
+        assert_eq!(want, got);
+    }
+
+    #[test]
+    fn add_transaction_emits_transaction_with_deduce_and_balance_concern() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut bal = Balance::default();
+        bal.add_posting_amount(
+            ctx.accounts.ensure("Account 1"),
+            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+        );
+        bal.add_posting_amount(
+            ctx.accounts.ensure("Account 1"),
+            PostingAmount::from_value(dec!(123), ctx.commodities.ensure("USD")),
+        );
+        let input = indoc! {"
+            2024/08/01 Sample
+              Account 1              = 1200 JPY
+              Account 2
+        "};
+        let txn = parse::transaction::transaction.parse(input).unwrap();
+        let got = add_transaction(&mut ctx, &mut bal, &txn).expect("must succeed");
+        let want = Transaction {
+            date: NaiveDate::from_ymd_opt(2024, 8, 1).unwrap(),
+            postings: bcc::Vec::from_iter_in(
+                [
+                    Posting {
+                        account: ctx.accounts.ensure("Account 1"),
+                        amount: Amount::from_value(dec!(200), ctx.commodities.ensure("JPY")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 2"),
+                        amount: Amount::from_value(dec!(-200), ctx.commodities.ensure("JPY")),
+                    },
+                ],
+                &arena,
+            )
+            .into_boxed_slice(),
+        };
+        assert_eq!(want, got);
+    }
+
+    #[test]
+    fn add_transaction_deduced_amount_contains_multi_commodity() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut bal = Balance::default();
+        let input = indoc! {"
+            2024/08/01 Sample
+              Account 1         1200 JPY
+              Account 2         234 EUR
+              Account 3         34.56 CHF
+              Account 4
+        "};
+        let txn = parse::transaction::transaction.parse(input).unwrap();
+        let got = add_transaction(&mut ctx, &mut bal, &txn).expect("must succeed");
+        let want = Transaction {
+            date: NaiveDate::from_ymd_opt(2024, 8, 1).unwrap(),
+            postings: bcc::Vec::from_iter_in(
+                [
+                    Posting {
+                        account: ctx.accounts.ensure("Account 1"),
+                        amount: Amount::from_value(dec!(1200), ctx.commodities.ensure("JPY")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 2"),
+                        amount: Amount::from_value(dec!(234), ctx.commodities.ensure("EUR")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 3"),
+                        amount: Amount::from_value(dec!(34.56), ctx.commodities.ensure("CHF")),
+                    },
+                    Posting {
+                        account: ctx.accounts.ensure("Account 4"),
+                        amount: Amount::from_values([
+                            (dec!(-1200), ctx.commodities.ensure("JPY")),
+                            (dec!(-234), ctx.commodities.ensure("EUR")),
+                            (dec!(-34.56), ctx.commodities.ensure("CHF")),
+                        ]),
+                    },
+                ],
+                &arena,
+            )
+            .into_boxed_slice(),
+        };
+        assert_eq!(want, got);
+    }
+
+    #[test]
+    fn add_transaction_fails_when_two_posting_does_not_have_amount() {
+        let input = indoc! {"
+            2024/08/01 Sample
+              Account 1 ; no amount
+              Account 2 ; no amount
+        "};
+        let txn = parse::transaction::transaction.parse(input).unwrap();
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let mut bal = Balance::default();
+        let got = add_transaction(&mut ctx, &mut bal, &txn).expect_err("must fail");
+        assert_eq!(got, BookKeepError::UndeduciblePostingAmount(0, 1));
+    }
 }

--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -4,7 +4,7 @@ mod amount;
 mod error;
 mod evaluated;
 
-pub use amount::Amount;
+pub use amount::{Amount, PostingAmount};
 pub use error::EvalError;
 pub use evaluated::Evaluated;
 

--- a/core/src/report/eval/error.rs
+++ b/core/src/report/eval/error.rs
@@ -1,12 +1,16 @@
 /// Errors specific to expression evaluation.
-#[derive(Debug, thiserror::Error, PartialEq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum EvalError {
     #[error("operator can't be applied to unmatched types")]
     UnmatchingOperation,
+    #[error("unmatching commodities {0} and {1}")]
+    UnmatchingCommodities(String, String),
     #[error("cannot divide by zero")]
     DivideByZero,
     #[error("overflow happened")]
     NumberOverflow,
     #[error("expected 0 or amount with commodity")]
     CommodityAmountRequired,
+    #[error("0 or amount with single commodity expected")]
+    SingleCommodityAmountRequired,
 }

--- a/core/src/report/eval/evaluated.rs
+++ b/core/src/report/eval/evaluated.rs
@@ -4,13 +4,25 @@ use rust_decimal::Decimal;
 
 use crate::{repl::expr, report::ReportContext};
 
-use super::{amount::Amount, error::EvalError};
+use super::{
+    amount::{Amount, PostingAmount},
+    error::EvalError,
+};
 
 /// Represents any evaluated value.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Evaluated<'ctx> {
     Number(Decimal),
     Commodities(Amount<'ctx>),
+}
+
+impl<'ctx> TryFrom<Evaluated<'ctx>> for PostingAmount<'ctx> {
+    type Error = EvalError;
+
+    fn try_from(value: Evaluated<'ctx>) -> Result<Self, Self::Error> {
+        let amount: Amount<'ctx> = value.try_into()?;
+        amount.try_into()
+    }
 }
 
 impl<'ctx> TryFrom<Evaluated<'ctx>> for Amount<'ctx> {

--- a/core/src/report/intern.rs
+++ b/core/src/report/intern.rs
@@ -51,7 +51,7 @@ pub(super) trait FromInterned<'arena>: Copy {
 }
 
 /// Error on InternStore operations.
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum InternError {
     #[error("given alias is already registered as canonical")]
     AlreadyCanonical,
@@ -102,7 +102,7 @@ impl<'arena, T: FromInterned<'arena>> InternStore<'arena, T> {
 
     /// Interns given `str` and returns the shared instance.
     /// Note if `value` is registered as alias, it'll resolve to the canonical one.
-    /// If `value` is not registered yet, registered as canonical value.
+    /// If `value` is not registered yet, register the value as canonical value.
     pub fn ensure(&mut self, value: &str) -> T {
         match self.resolve(value) {
             Some(found) => found,


### PR DESCRIPTION
It used to deduce the following balance assertion in a wrong way when `Account 1` has multi commodities balance.

```
2024/08/01 Foo
   Account 1           = 10 JPY
   Account 2
```

It must set the balance of `Account 1` to 10 JPY + X other commodities, but it used to set exactly 10 JPY.