### PR TITLE
Bump main branch version to 0.13.0-dev.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "okane"
-version = "0.12.0-dev"
+version = "0.13.0-dev"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "okane-core"
-version = "0.12.0-dev"
+version = "0.13.0-dev"
 dependencies = [
  "annotate-snippets",
  "bounded-static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0-dev"
+version = "0.13.0-dev"
 authors = ["xkikeg"]
 edition = "2021"
 rust-version = "1.76.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 repository.workspace = true
 
 [dependencies]
-okane-core = { version = "0.12.0-dev", path = "../core" }
+okane-core = { version = "0.13.0-dev", path = "../core" }
 
 annotate-snippets.workspace = true
 # anstream = "0.6"


### PR DESCRIPTION
We released 0.12, so bump to 0.13.