### PR TITLE
Add plain / tracked to syntax types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +851,7 @@ dependencies = [
  "chrono",
  "criterion",
  "ctor",
+ "derive-where",
  "env_logger",
  "indoc",
  "log",

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -7,6 +7,7 @@ use clap::{Args, Subcommand};
 use encoding_rs_io::DecodeReaderBytesBuilder;
 
 use okane_core::repl::display::DisplayContext;
+use okane_core::repl::plain::LedgerEntry;
 use okane_core::{load, repl, report};
 
 use crate::format;
@@ -97,7 +98,7 @@ impl ImportCmd {
                 .collect(),
         };
         for xact in xacts {
-            let xact: repl::Transaction = xact.to_double_entry(&config_entry.account)?;
+            let xact: repl::plain::Transaction = xact.to_double_entry(&config_entry.account)?;
             writeln!(w, "{}", ctx.as_display(&xact))?;
         }
         Ok(())
@@ -161,10 +162,12 @@ impl FlattenCmd {
     {
         // TODO: Pick DisplayContext from load results.
         let ctx = DisplayContext::default();
-        load::new_loader(self.source).load_repl(|_path, _ctx, entry| -> Result<(), Error> {
-            writeln!(w, "{}", ctx.as_display(entry))?;
-            Ok(())
-        })?;
+        load::new_loader(self.source).load_repl(
+            |_path, _ctx, entry: &LedgerEntry| -> Result<(), Error> {
+                writeln!(w, "{}", ctx.as_display(entry))?;
+                Ok(())
+            },
+        )?;
         Ok(())
     }
 }

--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -162,7 +162,7 @@ impl Txn {
         self
     }
 
-    fn amount(&self) -> repl::PostingAmount {
+    fn amount(&self) -> repl::plain::PostingAmount {
         repl::PostingAmount {
             amount: as_syntax_amount(&self.amount).into(),
             cost: self.rate(&self.amount.commodity),
@@ -170,7 +170,7 @@ impl Txn {
         }
     }
 
-    fn dest_amount(&self) -> repl::PostingAmount {
+    fn dest_amount(&self) -> repl::plain::PostingAmount {
         self.transferred_amount
             .as_ref()
             .map(|transferred| repl::PostingAmount {
@@ -194,8 +194,8 @@ impl Txn {
     pub fn to_double_entry<'a>(
         &'a self,
         src_account: &'a str,
-    ) -> Result<repl::Transaction<'a>, ImportError> {
-        let mut posts: Vec<repl::Posting> = Vec::new();
+    ) -> Result<repl::plain::Transaction<'a>, ImportError> {
+        let mut posts: Vec<repl::plain::Posting> = Vec::new();
         let post_clear = self.clear_state.unwrap_or(match &self.dest_account {
             Some(_) => repl::ClearState::Uncleared,
             None => repl::ClearState::Pending,
@@ -270,7 +270,7 @@ fn negate_amount(mut amount: repl::expr::Amount) -> repl::expr::Amount {
     amount
 }
 
-fn to_posting_amount(amount: repl::expr::Amount) -> repl::PostingAmount {
+fn to_posting_amount(amount: repl::expr::Amount) -> repl::plain::PostingAmount {
     repl::PostingAmount {
         amount: amount.into(),
         cost: None,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ annotate-snippets.workspace = true
 bounded-static = { version = "0.8", default-features = false, features = ["derive", "alloc", "chrono"] }
 bumpalo.workspace = true
 chrono.workspace = true
+derive-where = "1.2"
 log.workspace = true
 rust_decimal.workspace = true
 strum = { version = "0.26", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 annotate-snippets.workspace = true
-bounded-static = { version = "0.8", default-features=false, features = ["derive", "alloc", "chrono"] }
+bounded-static = { version = "0.8", default-features = false, features = ["derive", "alloc", "chrono"] }
 bumpalo.workspace = true
 chrono.workspace = true
 log.workspace = true

--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -4,7 +4,7 @@ use bumpalo::Bump;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use okane_core::{
     load::{self, LoadError},
-    report,
+    repl, report,
 };
 
 pub mod testing;
@@ -15,7 +15,7 @@ fn load_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut count = 0;
             load::new_loader(input.rootpath().to_owned())
-                .load_repl(|_, _, _| {
+                .load_repl(|_, _, _: &repl::tracked::LedgerEntry| {
                     count += 1;
                     Ok::<(), LoadError>(())
                 })

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     parse::{parse_ledger, ParseError},
-    repl::display::DisplayContext,
+    repl::{self, display::DisplayContext},
 };
 
 use std::io::{Read, Write};
@@ -54,7 +54,7 @@ impl FormatOptions {
         // TODO: Grab DisplayContext externally, or from LedgerEntry.
         let ctx = DisplayContext::default();
         for parsed in parse_ledger(&buf) {
-            let (_, entry) = parsed.map_err(Box::new)?;
+            let (_, entry): (_, repl::plain::LedgerEntry) = parsed.map_err(Box::new)?;
             writeln!(w, "{}", ctx.as_display(&entry))?;
         }
         Ok(())

--- a/core/src/parse/testing.rs
+++ b/core/src/parse/testing.rs
@@ -1,21 +1,17 @@
 //! Utility only meant for the tests.
 
-use winnow::{
-    error::ContextError,
-    stream::{AsBStr, AsChar, Stream, StreamIsPartial},
-    token::take_while,
-    Parser,
-};
+use winnow::{error::ContextError, stream::Stream, token::take_while, Located, Parser};
 
 /// Run the given `parser` with the `input`, and returns a tuple of reamining input and output.
 /// Panic when the parsing failed.
-pub fn expect_parse_ok<I, O, F>(parser: F, input: I) -> (<I as Stream>::Slice, O)
+pub fn expect_parse_ok<'i, O, F>(
+    parser: F,
+    input: &'i str,
+) -> (<Located<&'i str> as Stream>::Slice, O)
 where
-    I: Stream + StreamIsPartial + Clone + AsBStr,
-    <I as Stream>::Token: AsChar,
-    F: Parser<I, O, ContextError>,
+    F: Parser<Located<&'i str>, O, ContextError>,
 {
-    match (parser, take_while(0.., |_x| true)).parse(input) {
+    match (parser, take_while(0.., |_x| true)).parse(Located::new(input)) {
         Ok((ret, remaining)) => (remaining, ret),
         Err(e) => panic!("failed to parse: \n{}", e),
     }

--- a/core/src/repl.rs
+++ b/core/src/repl.rs
@@ -14,6 +14,7 @@ use std::{borrow::Cow, fmt};
 
 use bounded_static::ToStatic;
 use chrono::NaiveDate;
+use derive_where::derive_where;
 
 #[cfg(test)]
 use bounded_static::ToBoundedStatic;
@@ -21,7 +22,7 @@ use bounded_static::ToBoundedStatic;
 use decoration::Decoration;
 
 /// Top-level entry of the LedgerFile.
-#[derive(Debug, PartialEq, Eq)]
+#[derive_where(Debug, PartialEq, Eq)]
 pub enum LedgerEntry<'i, Deco: Decoration> {
     /// Transaction
     Txn(Transaction<'i, Deco>),
@@ -116,7 +117,7 @@ pub enum CommodityDetail<'i> {
 }
 
 /// Represents a transaction where the money transfered across the accounts.
-#[derive(Debug, PartialEq, Eq)]
+#[derive_where(Debug, PartialEq, Eq)]
 pub struct Transaction<'i, Deco: Decoration> {
     /// Date when the transaction issued.
     pub date: NaiveDate,
@@ -171,7 +172,7 @@ impl<'i, Deco: Decoration> Transaction<'i, Deco> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive_where(Debug, PartialEq, Eq)]
 /// Posting in a transaction to represent a particular account amount increase / decrease.
 pub struct Posting<'i, Deco: Decoration> {
     /// Account of the post target.
@@ -252,7 +253,7 @@ pub enum MetadataValue<'i> {
 /// - how much the asset is increased.
 /// - what was the cost in the other commodity.
 /// - lot information.
-#[derive(Debug, PartialEq, Eq)]
+#[derive_where(Debug, PartialEq, Eq)]
 pub struct PostingAmount<'i, Deco: Decoration> {
     pub amount: Deco::Decorated<expr::ValueExpr<'i>>,
     pub cost: Option<Deco::Decorated<Exchange<'i>>>,
@@ -281,7 +282,7 @@ impl<'i> From<expr::ValueExpr<'i>> for PostingAmount<'i, plain::Ident> {
 }
 
 /// Lot information is a set of metadata to record the original lot which the commodity is acquired with.
-#[derive(Debug, PartialEq, Eq)]
+#[derive_where(Debug, PartialEq, Eq)]
 pub struct Lot<'i, Deco: Decoration> {
     pub price: Option<Deco::Decorated<Exchange<'i>>>,
     pub date: Option<NaiveDate>,

--- a/core/src/repl/decoration.rs
+++ b/core/src/repl/decoration.rs
@@ -12,10 +12,7 @@ pub trait AsUndecorated<T: ?Sized> {
 /// Decoration associates the extra information attached to
 /// [crate::repl::Transaction] or any other [crate::repl] data.
 /// See [super::plain] or [super::tracked] for implementations.
-///
-/// Note this Decoration does not need to implement these traits,
-/// it's only required because we use trait GATs as a higher kinded type.
-pub trait Decoration: Debug + PartialEq + Eq + 'static {
+pub trait Decoration: 'static {
     type Decorated<T>: AsUndecorated<T> + Debug + PartialEq + Eq
     where
         T: AsUndecorated<T> + Debug + PartialEq + Eq;
@@ -27,7 +24,7 @@ pub trait Decoration: Debug + PartialEq + Eq + 'static {
         PIn: winnow::Parser<I, O, E>;
 }
 
-macro_rules! define_as_ref {
+macro_rules! define_as_undecorated {
     ([$($impl_generics:tt)*],
      $type_name:ty) => {
         impl<$($impl_generics)*> AsUndecorated<$type_name> for $type_name {
@@ -38,9 +35,9 @@ macro_rules! define_as_ref {
     };
 }
 
-define_as_ref!(['i, Deco: Decoration], super::LedgerEntry<'i, Deco>);
-define_as_ref!(['i, Deco: Decoration], super::Transaction<'i, Deco>);
-define_as_ref!(['i, Deco: Decoration], super::Posting<'i, Deco>);
-define_as_ref!(['i, Deco: Decoration], super::PostingAmount<'i, Deco>);
-define_as_ref!(['i], super::Exchange<'i>);
-define_as_ref!(['i], super::expr::ValueExpr<'i>);
+define_as_undecorated!(['i, Deco: Decoration], super::LedgerEntry<'i, Deco>);
+define_as_undecorated!(['i, Deco: Decoration], super::Transaction<'i, Deco>);
+define_as_undecorated!(['i, Deco: Decoration], super::Posting<'i, Deco>);
+define_as_undecorated!(['i, Deco: Decoration], super::PostingAmount<'i, Deco>);
+define_as_undecorated!(['i], super::Exchange<'i>);
+define_as_undecorated!(['i], super::expr::ValueExpr<'i>);

--- a/core/src/repl/decoration.rs
+++ b/core/src/repl/decoration.rs
@@ -1,0 +1,46 @@
+//! Module decoration defines the trait,
+//! which describes the extra information attached to [crate::repl] data.
+
+use std::fmt::Debug;
+
+/// AsUndecorated<T> is equivalent to AsRef, with specific meaning.
+/// AsRef can be too generic and not suitable for use case.
+pub trait AsUndecorated<T: ?Sized> {
+    fn as_undecorated(&self) -> &T;
+}
+
+/// Decoration associates the extra information attached to
+/// [crate::repl::Transaction] or any other [crate::repl] data.
+/// See [super::plain] or [super::tracked] for implementations.
+///
+/// Note this Decoration does not need to implement these traits,
+/// it's only required because we use trait GATs as a higher kinded type.
+pub trait Decoration: Debug + PartialEq + Eq + 'static {
+    type Decorated<T>: AsUndecorated<T> + Debug + PartialEq + Eq
+    where
+        T: AsUndecorated<T> + Debug + PartialEq + Eq;
+
+    fn decorate_parser<PIn, I, O, E>(parser: PIn) -> impl winnow::Parser<I, Self::Decorated<O>, E>
+    where
+        I: winnow::stream::Stream + winnow::stream::Location,
+        O: AsUndecorated<O> + Debug + PartialEq + Eq,
+        PIn: winnow::Parser<I, O, E>;
+}
+
+macro_rules! define_as_ref {
+    ([$($impl_generics:tt)*],
+     $type_name:ty) => {
+        impl<$($impl_generics)*> AsUndecorated<$type_name> for $type_name {
+            fn as_undecorated(&self) -> &$type_name {
+                self
+            }
+        }
+    };
+}
+
+define_as_ref!(['i, Deco: Decoration], super::LedgerEntry<'i, Deco>);
+define_as_ref!(['i, Deco: Decoration], super::Transaction<'i, Deco>);
+define_as_ref!(['i, Deco: Decoration], super::Posting<'i, Deco>);
+define_as_ref!(['i, Deco: Decoration], super::PostingAmount<'i, Deco>);
+define_as_ref!(['i], super::Exchange<'i>);
+define_as_ref!(['i], super::expr::ValueExpr<'i>);

--- a/core/src/repl/plain.rs
+++ b/core/src/repl/plain.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use super::decoration::{AsUndecorated, Decoration};
 
 /// Ident attaches no extra information.
-#[derive(Debug, PartialEq, Eq)]
 pub struct Ident;
 
 impl Decoration for Ident {

--- a/core/src/repl/plain.rs
+++ b/core/src/repl/plain.rs
@@ -1,0 +1,28 @@
+use std::fmt::Debug;
+
+use super::decoration::{AsUndecorated, Decoration};
+
+/// Ident attaches no extra information.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Ident;
+
+impl Decoration for Ident {
+    type Decorated<T> = T
+    where
+        T: AsUndecorated<T> + Debug + PartialEq + Eq ;
+
+    fn decorate_parser<PIn, I, O, E>(parser: PIn) -> impl winnow::Parser<I, Self::Decorated<O>, E>
+    where
+        I: winnow::stream::Stream + winnow::stream::Location,
+        O: AsUndecorated<O> + Debug + PartialEq + Eq,
+        PIn: winnow::Parser<I, O, E>,
+    {
+        parser
+    }
+}
+
+pub type LedgerEntry<'i> = super::LedgerEntry<'i, Ident>;
+pub type Transaction<'i> = super::Transaction<'i, Ident>;
+pub type Posting<'i> = super::Posting<'i, Ident>;
+pub type PostingAmount<'i> = super::PostingAmount<'i, Ident>;
+pub type Lot<'i> = super::Lot<'i, Ident>;

--- a/core/src/repl/tracked.rs
+++ b/core/src/repl/tracked.rs
@@ -4,7 +4,6 @@ use std::ops::Range;
 use super::decoration::{AsUndecorated, Decoration};
 
 /// Tracking provides [Tracked] decoration for syntax types.
-#[derive(Debug, PartialEq, Eq)]
 pub struct Tracking;
 
 impl Decoration for Tracking {

--- a/core/src/repl/tracked.rs
+++ b/core/src/repl/tracked.rs
@@ -1,0 +1,45 @@
+use std::fmt::Debug;
+use std::ops::Range;
+
+use super::decoration::{AsUndecorated, Decoration};
+
+/// Tracking provides [Tracked] decoration for syntax types.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Tracking;
+
+impl Decoration for Tracking {
+    type Decorated<T> = Tracked<T>
+    where
+        T: AsUndecorated<T> + Debug + PartialEq + Eq;
+
+    fn decorate_parser<PIn, I, O, E>(parser: PIn) -> impl winnow::Parser<I, Self::Decorated<O>, E>
+    where
+        I: winnow::stream::Stream + winnow::stream::Location,
+        O: AsUndecorated<O> + Debug + PartialEq + Eq,
+        PIn: winnow::Parser<I, O, E>,
+    {
+        use winnow::Parser;
+        parser
+            .with_span()
+            .map(|(value, position)| Tracked { position, value })
+    }
+}
+
+pub type LedgerEntry<'i> = super::LedgerEntry<'i, Tracking>;
+pub type Transaction<'i> = super::Transaction<'i, Tracking>;
+pub type Posting<'i> = super::Posting<'i, Tracking>;
+pub type PostingAmount<'i> = super::PostingAmount<'i, Tracking>;
+pub type Lot<'i> = super::Lot<'i, Tracking>;
+
+/// Tracked provides the struct with maybe position tracking.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Tracked<T> {
+    position: Range<usize>,
+    value: T,
+}
+
+impl<T> AsUndecorated<T> for Tracked<T> {
+    fn as_undecorated(&self) -> &T {
+        &self.value
+    }
+}

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -15,7 +15,7 @@ pub use book_keeping::{process, Posting, Transaction};
 pub use context::{Account, ReportContext};
 pub use error::ReportError;
 
-use crate::{load, repl::LedgerEntry};
+use crate::{load, repl::plain::LedgerEntry};
 
 /// Returns all accounts for the given LedgerEntry.
 /// WARNING: interface are subject to change.


### PR DESCRIPTION
Depending on the context, we may want to have a value with extra information `Tracked<T>`, or simple `T`.
Concretely, we want the original bytes position `Range<u64>`  on parser, while we don't have such an information on generating the value.
This could be allowed with GAT behaving like a higher kinded type.