### PR TITLE
Feature: Allow column index to be a template field

### DIFF
--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -324,14 +324,7 @@ impl FieldMap {
         let mut ki: HashMap<config::FieldKey, Field> = HashMap::with_capacity(config_mapping.len());
         for (&k, pos) in config_mapping {
             let field = match &pos {
-                config::FieldPos::Index(i) => {
-                    if *i == 0 {
-                        return Err(ImportError::Other(
-                            "column index is 1-origin, must be larger than 0".to_string(),
-                        ));
-                    }
-                    Ok(Field::ColumnIndex(*i - 1))
-                }
+                config::FieldPos::Index(i) => Ok(Field::ColumnIndex(i.as_zero_based())),
                 config::FieldPos::Label(label) => hm
                     .get(label.as_str())
                     .cloned()
@@ -450,10 +443,13 @@ impl extract::EntityMatcher for CsvMatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::*;
+
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
     use rust_decimal_macros::dec;
+
+    use super::config::{AccountType, FieldPos};
+    use crate::one_based;
 
     #[test]
     fn field_map_try_new_label_credit_debit() {
@@ -493,9 +489,9 @@ mod tests {
     #[test]
     fn field_map_try_new_index_amount() {
         let config: HashMap<FieldKey, FieldPos> = hashmap! {
-            FieldKey::Date => FieldPos::Index(1),
-            FieldKey::Payee => FieldPos::Index(2),
-            FieldKey::Amount => FieldPos::Index(3),
+            FieldKey::Date => FieldPos::Index(one_based!(1)),
+            FieldKey::Payee => FieldPos::Index(one_based!(2)),
+            FieldKey::Amount => FieldPos::Index(one_based!(3)),
         };
         let got = FieldMap::try_new(&config, &csv::StringRecord::from(vec!["unrelated"])).unwrap();
         assert_eq!(
@@ -517,15 +513,15 @@ mod tests {
     #[test]
     fn field_map_try_new_optionals() {
         let config: HashMap<FieldKey, FieldPos> = hashmap! {
-            FieldKey::Date => FieldPos::Index(1),
-            FieldKey::Payee => FieldPos::Index(2),
-            FieldKey::Amount => FieldPos::Index(3),
-            FieldKey::Balance => FieldPos::Index(4),
-            FieldKey::Category => FieldPos::Index(5),
-            FieldKey::Commodity => FieldPos::Index(6),
-            FieldKey::Rate => FieldPos::Index(7),
-            FieldKey::SecondaryAmount => FieldPos::Index(8),
-            FieldKey::SecondaryCommodity => FieldPos::Index(9),
+            FieldKey::Date => FieldPos::Index(one_based!(1)),
+            FieldKey::Payee => FieldPos::Index(one_based!(2)),
+            FieldKey::Amount => FieldPos::Index(one_based!(3)),
+            FieldKey::Balance => FieldPos::Index(one_based!(4)),
+            FieldKey::Category => FieldPos::Index(one_based!(5)),
+            FieldKey::Commodity => FieldPos::Index(one_based!(6)),
+            FieldKey::Rate => FieldPos::Index(one_based!(7)),
+            FieldKey::SecondaryAmount => FieldPos::Index(one_based!(8)),
+            FieldKey::SecondaryCommodity => FieldPos::Index(one_based!(9)),
         };
         let got = FieldMap::try_new(&config, &csv::StringRecord::from(vec!["unrelated"])).unwrap();
         assert_eq!(
@@ -553,11 +549,11 @@ mod tests {
     #[test]
     fn field_map_extract() {
         let config: HashMap<FieldKey, FieldPos> = hashmap! {
-            FieldKey::Date => FieldPos::Index(1),
+            FieldKey::Date => FieldPos::Index(one_based!(1)),
             FieldKey::Payee => FieldPos::Template(TemplateField { template: "{category} - {note}".parse().expect("this must be the correct template") }),
-            FieldKey::Amount => FieldPos::Index(2),
-            FieldKey::Category => FieldPos::Index(3),
-            FieldKey::Note => FieldPos::Index(4),
+            FieldKey::Amount => FieldPos::Index(one_based!(2)),
+            FieldKey::Category => FieldPos::Index(one_based!(3)),
+            FieldKey::Note => FieldPos::Index(one_based!(4)),
         };
         let fm = FieldMap::try_new(
             &config,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,3 +9,4 @@
 pub mod cmd;
 pub mod format;
 pub mod import;
+pub mod one_based;

--- a/cli/src/one_based.rs
+++ b/cli/src/one_based.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// From human point of view, often 1-based index is easier than 0-based.
 /// But program solely needs 0-based. `OneBasedIndex` provides
 /// safety and easiness to use.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct OneBasedIndex(usize);
 
 impl Display for OneBasedIndex {

--- a/cli/src/one_based.rs
+++ b/cli/src/one_based.rs
@@ -1,0 +1,93 @@
+//! Provides OneBasedIndex, which wraps usize as 1-based index.
+
+use std::{fmt::Display, num::ParseIntError, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+/// Represents 1-based index.
+///
+/// From human point of view, often 1-based index is easier than 0-based.
+/// But program solely needs 0-based. `OneBasedIndex` provides
+/// safety and easiness to use.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct OneBasedIndex(usize);
+
+impl Display for OneBasedIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_one_based())
+    }
+}
+
+impl FromStr for OneBasedIndex {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v: usize = s.parse()?;
+        Self::from_one_based(v).map_err(ParseError::InvalidInput)
+    }
+}
+
+impl Serialize for OneBasedIndex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.as_one_based() as u64)
+    }
+}
+
+impl<'de> Deserialize<'de> for OneBasedIndex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let v: u64 = Deserialize::deserialize(deserializer)?;
+        use serde::de::{self, Error};
+        Self::from_one_based(v as usize).map_err(|_| {
+            D::Error::invalid_value(de::Unexpected::Unsigned(v), &"a positive integer")
+        })
+    }
+}
+
+impl OneBasedIndex {
+    /// Creates OneBasedindex from 1-based index.
+    pub fn from_one_based(v: usize) -> Result<Self, Error> {
+        if v == 0 {
+            Err(Error::InvalidIndex)
+        } else {
+            Ok(OneBasedIndex(v - 1))
+        }
+    }
+
+    /// Returns regular 0-based index.
+    pub fn as_zero_based(&self) -> usize {
+        self.0
+    }
+
+    /// Returns 1-based index.
+    pub fn as_one_based(&self) -> usize {
+        self.as_zero_based() + 1
+    }
+}
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! one_based {
+    ( $x:expr ) => {
+        one_based::OneBasedIndex::from_one_based($x).unwrap()
+    };
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("1-based origin must not be greater than zero")]
+    InvalidIndex,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("invalid input: {0:?}")]
+    InvalidInput(#[from] Error),
+    #[error("failed to parse as integer: {0:?}")]
+    ParseFailure(#[from] ParseIntError),
+}


### PR DESCRIPTION
We used to allow template with field key

```yaml
payee:
  template: "{category} - {note}"
```

This PR allows specifying int as well.


```yaml
payee:
  template: "{category} - {2}"
```
