### PR TITLE
Support more diversed ISO Camt053 file format

### DIFF
--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -219,10 +219,10 @@ impl From<AccountCommodityConfig> for AccountCommoditySpec {
 /// FormatSpec describes the several format used in import target.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct FormatSpec {
-    /// Specify the date format, in chrono::format::strftime compatible format.
+    /// Specify the date format, in [chrono::format::strftime] compatible format.
     #[serde(default)]
     pub date: String,
-    /// Commodity (currency) styling
+    /// Commodity (currency) styling.
     #[serde(default)]
     pub commodity: HashMap<String, CommodityFormatSpec>,
     /// Mapping from abstracted field key to abstracted position.

--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -233,7 +233,7 @@ pub struct FormatSpec {
     pub delimiter: String,
     #[serde(default)]
     pub skip: SkipSpec,
-    /// Order of the row.
+    /// Order of the row. By default, old to new order.
     #[serde(default)]
     pub row_order: RowOrder,
 }

--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -451,6 +451,7 @@ pub enum RewriteField {
     DebtorAccountId,
     UltimateDebtorName,
     RemittanceUnstructuredInfo,
+    AdditionalEntryInfo,
     AdditionalTransactionInfo,
     Category,
     Payee,

--- a/cli/src/import/iso_camt053.rs
+++ b/cli/src/import/iso_camt053.rs
@@ -195,6 +195,7 @@ enum MatchField {
     DebtorAccountId,
     UltimateDebtorName,
     RemittanceUnstructuredInfo,
+    AdditionalEntryInfo,
     AdditionalTransactionInfo,
     Payee,
 }
@@ -210,6 +211,7 @@ fn to_field(f: config::RewriteField) -> Result<MatchField, ImportError> {
         config::RewriteField::RemittanceUnstructuredInfo => {
             Some(MatchField::RemittanceUnstructuredInfo)
         }
+        config::RewriteField::AdditionalEntryInfo => Some(MatchField::AdditionalEntryInfo),
         config::RewriteField::AdditionalTransactionInfo => {
             Some(MatchField::AdditionalTransactionInfo)
         }
@@ -301,6 +303,7 @@ impl extract::EntityMatcher for FieldMatch {
                         .and_then(|t| t.remittance_info.as_ref())
                         .and_then(|i| i.unstructured.as_ref())
                         .map(|v| v.as_str()),
+                    MatchField::AdditionalEntryInfo => Some(&entry.additional_info),
                     MatchField::AdditionalTransactionInfo => transaction
                         .and_then(|t| t.additional_info.as_ref())
                         .map(|ai| ai.as_str()),

--- a/cli/src/import/iso_camt053/xmlnode.rs
+++ b/cli/src/import/iso_camt053/xmlnode.rs
@@ -455,6 +455,8 @@ pub struct Date {
 mod tests {
     use super::*;
 
+    use std::path::{Path, PathBuf};
+
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -548,5 +550,21 @@ mod tests {
         "};
         let party: RelatedParty = quick_xml::de::from_str(input).unwrap();
         assert_eq!("Albert Einstein", party.name());
+    }
+
+    #[test]
+    fn parse_complete_camt_file() {
+        let input: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("testdata")
+            .join("iso_camt.xml");
+        let encoded = std::fs::read(&input).expect("must read iso_camt.xml");
+
+        let decoded: Document =
+            quick_xml::de::from_reader(encoded.as_slice()).expect("must ok to parse");
+
+        assert_eq!(decoded.bank_to_customer.statements.len(), 1);
+        assert_eq!(decoded.bank_to_customer.statements[0].balance.len(), 2);
+        assert_eq!(decoded.bank_to_customer.statements[0].entries.len(), 10);
     }
 }

--- a/cli/tests/test_import_iso_camt.rs
+++ b/cli/tests/test_import_iso_camt.rs
@@ -1,7 +1,5 @@
 pub mod testing;
 
-use pretty_assertions::assert_str_eq;
-
 #[ctor::ctor]
 fn init() {
     env_logger::init();
@@ -11,7 +9,7 @@ fn init() {
 fn test_import() {
     let config = testing::TESTDATA_DIR.join("test_config.yml");
     let input = testing::TESTDATA_DIR.join("iso_camt.xml");
-    let want = testing::read_as_utf8("iso_camt.ledger").expect("cannot read want");
+    let golden = testing::Golden::new("iso_camt.ledger").expect("cannot read golden");
     let mut result: Vec<u8> = Vec::new();
 
     okane::cmd::ImportCmd {
@@ -22,5 +20,6 @@ fn test_import() {
     .expect("execution failed");
 
     let got = String::from_utf8(result).expect("invalid UTF-8");
-    assert_str_eq!(want, got);
+
+    golden.assert(&got);
 }

--- a/cli/tests/testdata/iso_camt_wise.xml
+++ b/cli/tests/testdata/iso_camt_wise.xml
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.10">
+  <BkToCstmrStmt>
+    <GrpHdr>
+      <MsgId>123456-1730472609678</MsgId>
+      <CreDtTm>2024-11-01T14:50:09.678834942Z</CreDtTm>
+    </GrpHdr>
+    <Stmt>
+      <Id>123456-123456789-1730472609678</Id>
+      <CreDtTm>2024-11-01T14:50:09.678834942Z</CreDtTm>
+      <FrToDt>
+        <FrDtTm>2024-01-01T00:00:00+01:00</FrDtTm>
+        <ToDtTm>2024-11-01T00:00:00+01:00</ToDtTm>
+      </FrToDt>
+      <Acct>
+        <Id>
+          <Othr>
+            <Id>123456789</Id>
+            <SchmeNm>
+              <Prtry>Wise Balance ID</Prtry>
+            </SchmeNm>
+            <Issr>Wise Payments Ltd.</Issr>
+          </Othr>
+        </Id>
+        <Ccy>CHF</Ccy>
+        <Ownr>
+          <Nm>Wilhelm Tell</Nm>
+          <PstlAdr>
+            <AdrTp>
+              <Cd>ADDR</Cd>
+            </AdrTp>
+            <PstCd>6460</PstCd>
+            <TwnNm>Altdorf</TwnNm>
+            <AdrLine>Rynächtstrasse 999</AdrLine>
+          </PstlAdr>
+          <Id>
+            <PrvtId>
+              <Othr>
+                <Id>123456</Id>
+                <SchmeNm>
+                  <Cd>CUST</Cd>
+                </SchmeNm>
+              </Othr>
+            </PrvtId>
+          </Id>
+        </Ownr>
+        <Svcr>
+          <FinInstnId>
+            <Nm>Wise Payments Ltd.</Nm>
+            <PstlAdr>
+              <AdrTp>
+                <Cd>ADDR</Cd>
+              </AdrTp>
+              <PstCd>E1 6JJ</PstCd>
+              <TwnNm>London</TwnNm>
+              <AdrLine>6th Floor, The Tea Building, 56 Shoreditch High Street</AdrLine>
+            </PstlAdr>
+          </FinInstnId>
+        </Svcr>
+      </Acct>
+      <Bal>
+        <Tp>
+          <CdOrPrtry>
+            <Cd>CLBD</Cd>
+          </CdOrPrtry>
+        </Tp>
+        <Amt Ccy="CHF">1285.32</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Dt>
+          <DtTm>2024-11-01T00:00:00+01:00</DtTm>
+        </Dt>
+      </Bal>
+      <TxsSummry>
+        <TtlNtries>
+          <NbOfNtries>10</NbOfNtries>
+          <Sum>1285.32</Sum>
+          <TtlNetNtry>
+            <Amt>1285.32</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+          </TtlNetNtry>
+        </TtlNtries>
+        <TtlCdtNtries>
+          <NbOfNtries>3</NbOfNtries>
+          <Sum>2800.90</Sum>
+        </TtlCdtNtries>
+        <TtlDbtNtries>
+          <NbOfNtries>7</NbOfNtries>
+          <Sum>-1515.58</Sum>
+        </TtlDbtNtries>
+      </TxsSummry>
+      <Ntry>
+        <Amt Ccy="CHF">942.15</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-31T23:58:38.150347+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>BALANCE-3425897</Cd>
+          </Prtry>
+        </BkTxCd>
+        <AmtDtls>
+          <TxAmt>
+            <Amt Ccy="CHF">942.15</Amt>
+            <CcyXchg>
+              <SrcCcy>CHF</SrcCcy>
+              <TrgtCcy>EUR</TrgtCcy>
+              <UnitCcy>CHF</UnitCcy>
+              <XchgRate>1.06384</XchgRate>
+            </CcyXchg>
+          </TxAmt>
+        </AmtDtls>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">2.16</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Converted 942.15 CHF to 1,000.00 EUR</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">2000.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-31T11:34:16.863523+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>TRANSFER-453789</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Topped up balance</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">89.60</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-20T10:26:01.140704+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-9254382</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 89.60 CHF issued by Great Food Zürich</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">400.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-08T13:02:05.273214+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>BALANCE-5908432</Cd>
+          </Prtry>
+        </BkTxCd>
+        <AmtDtls>
+          <TxAmt>
+            <Amt Ccy="CHF">400.00</Amt>
+            <CcyXchg>
+              <SrcCcy>CHF</SrcCcy>
+              <TrgtCcy>EUR</TrgtCcy>
+              <UnitCcy>CHF</UnitCcy>
+              <XchgRate>1.06246</XchgRate>
+            </CcyXchg>
+          </TxAmt>
+        </AmtDtls>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.92</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Converted 400.00 CHF to 424.01 EUR</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">52.28</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-08T13:00:49.950922+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-23458903</Cd>
+          </Prtry>
+        </BkTxCd>
+        <AmtDtls>
+          <TxAmt>
+            <Amt Ccy="CHF">52.28</Amt>
+            <CcyXchg>
+              <SrcCcy>CHF</SrcCcy>
+              <TrgtCcy>EUR</TrgtCcy>
+              <UnitCcy>CHF</UnitCcy>
+              <XchgRate>1.06238</XchgRate>
+            </CcyXchg>
+          </TxAmt>
+        </AmtDtls>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.12</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 71.20 EUR issued by Ichiran Zürich</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">1.33</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-07T20:19:07.80857+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-54398024</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 1.33 CHF issued by Great Food Zürich</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">29.32</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-07T18:43:38.517265+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-2718493</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 29.32 CHF issued by Great Food Pending Zürich</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">0.90</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-07T18:42:57.26457+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-2390548</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 0.90 CHF issued by Great Food Zürich</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">0.90</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-07T18:42:49.545971+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>CARD-1871239575</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Card transaction of 0.90 CHF issued by Example Com help.example.com</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">800.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>
+          <Cd>BOOK</Cd>
+        </Sts>
+        <BookgDt>
+          <DtTm>2024-10-04T12:17:04.000971+01:00</DtTm>
+        </BookgDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>TRANSFER-385345</Cd>
+          </Prtry>
+        </BkTxCd>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">0.00</TtlChrgsAndTaxAmt>
+        </Chrgs>
+        <AddtlNtryInf>Topped up balance</AddtlNtryInf>
+      </Ntry>
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>

--- a/cli/tests/testdata/test_config.yml
+++ b/cli/tests/testdata/test_config.yml
@@ -143,7 +143,7 @@ rewrite:
     matcher:
     - category: NRA Tax Adj
 ---
-path: testdata/iso_camt
+path: testdata/iso_camt.
 encoding: UTF-8
 account_type: asset
 operator: Okane Bank (fee)

--- a/doc/import.ja.md
+++ b/doc/import.ja.md
@@ -118,10 +118,10 @@ rewrite:
 ```
 
 * `matcher`: 必須: このルールを適用する条件です。すぐ下で説明する属性を持つmapか、そのlistとして記述します。listの場合論理和(OR)になり、一つでも当てはまったら適用されます。
-    * `domain_code`, `domain_family`, `domain_sub_family`: ISO Camt053フォーマットのみで有効です。定数だけが指定可能です。詳細は省きます。
-    * `creditor_name`, `creditor_account_id`, `ultimate_creditor_name`: ISO Camt053フォーマットのみで有効です。正規表現が指定できます。詳細は省きます。
-    * `debtor_name`, `debtor_account_id`, `ultimate_debtor_name`: ISO Camt053フォーマットのみで有効です。正規表現が指定できます。詳細は省きます。
-    * `remittance_unstructured_info`, `additional_transaction_info`: ISO Camt053フォーマットのみで有効です。正規表現が指定できます。詳細は省きます。
+    * `domain_code`, `domain_family`, `domain_sub_family`: ISO Camt053フォーマットのみで有効です。取引のコードの定数だけが指定可能です。
+    * `creditor_name`, `creditor_account_id`, `ultimate_creditor_name`: ISO Camt053フォーマットのみで有効です。正規表現で支払側の名前やIDにマッチします。
+    * `debtor_name`, `debtor_account_id`, `ultimate_debtor_name`: ISO Camt053フォーマットのみで有効です。正規表現で受け取り側の名前やIDにマッチします。
+    * `remittance_unstructured_info`, `additional_entry_info`, `additional_transaction_info`: ISO Camt053フォーマットのみで有効です。正規表現で対応するフィールドにマッチします。
     * `category`: CSV/visecaのみで有効です。取引の種類、`fields`で`category`として指定された列の文字列です。正規表現が指定できます。
     * `payee`: この取引の相手方の名前です。正規表現が指定できます。以前のルールで上書きされた場合その値が適用されます。
 * `account`: ルールが適用された場合アカウントを指定された文字列にします。


### PR DESCRIPTION
Allows having more diversed ISO Camt053 files, such as

* Allows `<DtTm>` in addition to `<Dt>`
* Allows `<BkTxCd>` to have `<Prtry>` in addition to `<Domn>`
* Allows matcher over `AddtlNtryInf` as `additional_entry_info`