### PR TITLE
Fix SingleEntry to emit charge commodity rate.

### DIFF
--- a/cli/src/import.rs
+++ b/cli/src/import.rs
@@ -1,6 +1,6 @@
 // Define converter interface here.
 
-pub mod amount;
+mod amount;
 pub mod config;
 pub mod csv;
 pub mod extract;

--- a/cli/src/import/amount.rs
+++ b/cli/src/import/amount.rs
@@ -1,3 +1,5 @@
+//! Defines extra amount types useful for import.
+
 use rust_decimal::Decimal;
 
 /// Represents simple owned Amount.
@@ -7,36 +9,46 @@ pub struct OwnedAmount {
     pub commodity: String,
 }
 
-impl OwnedAmount {
-    /// Returns `true` if the amount is zero.
-    pub fn is_zero(&self) -> bool {
-        self.value.is_zero()
-    }
-
-    /// Returns `true` if the amount is positive.
-    pub fn is_sign_positive(&self) -> bool {
-        self.value.is_sign_positive()
-    }
-
-    /// Returns `true` if the amount is negative.
-    pub fn is_sign_negative(&self) -> bool {
-        self.value.is_sign_negative()
+impl std::ops::Neg for OwnedAmount {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self {
+            value: -self.value,
+            commodity: self.commodity,
+        }
     }
 }
 
-/// # Examples
-///
-/// ```
-/// # use rust_decimal_macros::dec;
-/// let x = okane::import::amount::OwnedAmount{
-///     value: dec!(-5),
-///     commodity: "JPY".to_string(),
-/// };
-/// let y = -x.clone();
-/// assert_eq!(y.value, dec!(5));
-/// assert_eq!(y.commodity, "JPY");
-/// ```
-impl std::ops::Neg for OwnedAmount {
+/// AmountRef unifies [OwnedAmount] reference and [BorrowedAmount].
+pub trait AmountRef<'a> {
+    fn into_borrowed(self) -> BorrowedAmount<'a>;
+}
+
+impl<'a> AmountRef<'a> for &'a OwnedAmount {
+    fn into_borrowed(self) -> BorrowedAmount<'a> {
+        BorrowedAmount {
+            value: self.value,
+            commodity: &self.commodity,
+        }
+    }
+}
+
+/// Represents a reference to [OwnedAmount].
+/// it's actually pretty close to [okane_core::syntax::expr::Amount],
+/// but without any formatting nor Cow.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct BorrowedAmount<'a> {
+    pub value: Decimal,
+    pub commodity: &'a str,
+}
+
+impl<'a> AmountRef<'a> for BorrowedAmount<'a> {
+    fn into_borrowed(self) -> BorrowedAmount<'a> {
+        self
+    }
+}
+
+impl<'a> std::ops::Neg for BorrowedAmount<'a> {
     type Output = Self;
     fn neg(self) -> Self {
         Self {

--- a/cli/tests/testdata/iso_camt.ledger
+++ b/cli/tests/testdata/iso_camt.ledger
@@ -27,7 +27,7 @@
     Expenses:Grocery                           11.58 EUR @ 1.092059 CHF
     Expenses:Commissions                        1.50 CHF
     ; Payee: Okane Bank (fee)
-    Expenses:Commissions                        0.02 EUR
+    Expenses:Commissions                        0.02 EUR @ 1.092059 CHF
     ; Payee: Okane Bank (fee)
 
 2021/10/06 * (20211031/6/1) Hanako Steinmann


### PR DESCRIPTION
Now the `import` emits commodity rate on charges as well.

This also simplifies single entry transaction to syntax conversion.