### PR TITLE
Fix: include support glob pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +858,7 @@ dependencies = [
  "ctor",
  "derive-where",
  "env_logger",
+ "glob",
  "indoc",
  "log",
  "maplit",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ bounded-static = { version = "0.8", default-features = false, features = ["deriv
 bumpalo.workspace = true
 chrono.workspace = true
 derive-where = "1.2"
+glob = "0.3.2"
 log.workspace = true
 rust_decimal.workspace = true
 strum = { version = "0.26", features = ["derive"] }

--- a/core/src/syntax/plain.rs
+++ b/core/src/syntax/plain.rs
@@ -10,9 +10,10 @@ use super::decoration::{AsUndecorated, Decoration};
 pub struct Ident;
 
 impl Decoration for Ident {
-    type Decorated<T> = T
+    type Decorated<T>
+        = T
     where
-        T: AsUndecorated<T> + Debug + PartialEq + Eq ;
+        T: AsUndecorated<T> + Debug + PartialEq + Eq;
 
     fn decorate_parser<PIn, I, O, E>(parser: PIn) -> impl winnow::Parser<I, Self::Decorated<O>, E>
     where

--- a/core/src/syntax/tracked.rs
+++ b/core/src/syntax/tracked.rs
@@ -10,7 +10,8 @@ use super::decoration::{AsUndecorated, Decoration};
 pub struct Tracking;
 
 impl Decoration for Tracking {
-    type Decorated<T> = Tracked<T>
+    type Decorated<T>
+        = Tracked<T>
     where
         T: AsUndecorated<T> + Debug + PartialEq + Eq;
 

--- a/core/testdata/child1.ledger
+++ b/core/testdata/child1.ledger
@@ -1,4 +1,4 @@
-include sub/child2.ledger
+include sub/child*.ledger
 
 2024/5/1 * Migros
     Expenses:Grocery        -10.00 CHF

--- a/core/testdata/sub/child4.ledger
+++ b/core/testdata/sub/child4.ledger
@@ -1,0 +1,3 @@
+2024/7/1 * Send money
+    Assets:Bank:ZKB                         -1000.00 CHF
+    Assets:Wire:Wise                         1000.00 CHF


### PR DESCRIPTION
This PR fixes #204, supports glob pattern like "**/*.ledger" in `include` directive.