### PR TITLE
Provide okane commodity eval command to test --price-db and --exchange logic.

### DIFF
--- a/core/src/parse/expr.rs
+++ b/core/src/parse/expr.rs
@@ -123,6 +123,7 @@ where
 }
 
 /// Parses amount expression, possibly with negative op.
+// Only used for [`Amount`] `TryFrom<&'str>` implementation.
 fn unary_amount<'i, I, E>(input: &mut I) -> PResult<expr::Amount<'i>, E>
 where
     I: Stream<Slice = &'i str> + StreamIsPartial,

--- a/core/src/parse/price.rs
+++ b/core/src/parse/price.rs
@@ -45,7 +45,7 @@ where
             _: space1,
             target: primitive::commodity.map(Cow::Borrowed),
             _: space1,
-            rate: expr::value_expr,
+            rate: expr::amount,
             _: line_ending,
         }},
     )
@@ -78,10 +78,10 @@ mod tests {
                         NaiveTime::from_hms_opt(0, 0, 0).expect("00:00:00 must exist")
                     ),
                     target: Cow::Borrowed("JRTOK"),
-                    rate: syntax::expr::ValueExpr::Amount(Amount {
+                    rate: Amount {
                         value: PrettyDecimal::comma3dot(dec!(3584)),
                         commodity: Cow::Borrowed("JPY")
-                    })
+                    },
                 }
             )
         );
@@ -98,10 +98,10 @@ mod tests {
                         NaiveTime::from_hms_opt(0, 0, 0).expect("00:00:00 must exist")
                     ),
                     target: Cow::Borrowed("EUR"),
-                    rate: syntax::expr::ValueExpr::Amount(Amount {
+                    rate: Amount {
                         value: PrettyDecimal::unformatted(dec!(0.9367)),
                         commodity: Cow::Borrowed("CHF")
-                    })
+                    },
                 }
             )
         );
@@ -121,10 +121,10 @@ mod tests {
                         NaiveTime::from_hms_opt(17, 6, 0).expect("17:06:00 must exist")
                     ),
                     target: Cow::Borrowed("DCTOPIX"),
-                    rate: syntax::expr::ValueExpr::Amount(Amount {
+                    rate: Amount {
                         value: PrettyDecimal::comma3dot(dec!(22745)),
                         commodity: Cow::Borrowed("JPY")
-                    })
+                    },
                 }
             )
         );

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -17,8 +17,8 @@ pub use balance::Balance;
 pub use book_keeping::{process, ProcessOptions};
 pub use context::{Account, ReportContext};
 pub use error::ReportError;
-pub use eval::Amount;
-pub use price_db::{load_price_db, PriceDBError};
+pub use eval::{Amount, SingleAmount};
+pub use price_db::LoadError;
 pub use transaction::{Posting, Transaction};
 
 use crate::{load, syntax::plain::LedgerEntry};

--- a/core/src/report/commodity.rs
+++ b/core/src/report/commodity.rs
@@ -1,6 +1,6 @@
 //! Defines commodity and its related types.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use bumpalo::Bump;
 
@@ -26,6 +26,40 @@ impl<'arena> Commodity<'arena> {
     /// Returns the `&str`.
     pub fn as_str(&self) -> &'arena str {
         self.0.as_str()
+    }
+}
+
+/// Owned [`Commodity`], which is just [`String`].
+/// Useful to store in the error.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct OwnedCommodity(String);
+
+impl OwnedCommodity {
+    /// Creates a new [`OwnedCommodity`] instance.
+    pub fn from_string(v: String) -> Self {
+        Self(v)
+    }
+
+    /// Returns the underlying [`&str`].
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns the underlying [`String`].
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl From<Commodity<'_>> for OwnedCommodity {
+    fn from(value: Commodity<'_>) -> Self {
+        Self(value.as_str().to_string())
+    }
+}
+
+impl Display for OwnedCommodity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/core/src/report/commodity.rs
+++ b/core/src/report/commodity.rs
@@ -22,6 +22,12 @@ impl<'arena> FromInterned<'arena> for Commodity<'arena> {
     }
 }
 
+impl Display for Commodity<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 impl<'arena> Commodity<'arena> {
     /// Returns the `&str`.
     pub fn as_str(&self) -> &'arena str {
@@ -59,7 +65,7 @@ impl From<Commodity<'_>> for OwnedCommodity {
 
 impl Display for OwnedCommodity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -86,7 +92,6 @@ impl<'arena> CommodityStore<'arena> {
     }
 
     /// Returns the Commodity with the given `value` if and only if it's already registered.
-    #[cfg(test)]
     pub fn resolve(&self, value: &str) -> Option<Commodity<'arena>> {
         self.intern.resolve(value)
     }

--- a/core/src/report/error.rs
+++ b/core/src/report/error.rs
@@ -9,12 +9,16 @@ use crate::{
     parse::{self, ParsedSpan},
 };
 
-use super::book_keeping::{self, BookKeepError};
+use super::{
+    book_keeping::{self, BookKeepError},
+    price_db,
+};
 
 /// Error arised in report APIs.
 #[derive(thiserror::Error, Debug)]
 pub enum ReportError {
     Load(#[from] load::LoadError),
+    PriceDB(#[from] price_db::LoadError),
     BookKeep(book_keeping::BookKeepError, Box<ErrorContext>),
 }
 
@@ -22,6 +26,7 @@ impl Display for ReportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReportError::Load(_) => write!(f, "failed to load the given file"),
+            ReportError::PriceDB(_) => write!(f, "failed to load the Price DB"),
             ReportError::BookKeep(err, ctx) => ctx.print(f, err),
         }
     }

--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -20,7 +20,7 @@ pub(crate) trait Evaluable {
 
     /// Evaluate the self with mutable `ctx`, which allows unknown commodities in the expressions to be registered.
     fn eval_mut<'ctx>(&self, ctx: &mut ReportContext<'ctx>) -> Result<Evaluated<'ctx>, EvalError> {
-        self.eval_visit(&mut |amount| Ok(Evaluated::from_expr_amount(ctx, amount)))
+        self.eval_visit(&mut |amount| Ok(Evaluated::from_expr_amount_mut(ctx, amount)))
     }
 }
 

--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -4,7 +4,8 @@ mod amount;
 mod error;
 mod evaluated;
 
-pub use amount::{Amount, PostingAmount, SingleAmount};
+pub(super) use amount::PostingAmount;
+pub use amount::{Amount, SingleAmount};
 pub use error::EvalError;
 pub use evaluated::Evaluated;
 
@@ -21,6 +22,11 @@ pub(crate) trait Evaluable {
     /// Evaluate the self with mutable `ctx`, which allows unknown commodities in the expressions to be registered.
     fn eval_mut<'ctx>(&self, ctx: &mut ReportContext<'ctx>) -> Result<Evaluated<'ctx>, EvalError> {
         self.eval_visit(&mut |amount| Ok(Evaluated::from_expr_amount_mut(ctx, amount)))
+    }
+
+    /// Evaluate the self with immutable `ctx`, which raises error on unknown commoditieis.
+    fn eval<'ctx>(&self, ctx: &ReportContext<'ctx>) -> Result<Evaluated<'ctx>, EvalError> {
+        self.eval_visit(&mut |amount| Evaluated::from_expr_amount(ctx, amount))
     }
 }
 

--- a/core/src/report/eval/amount.rs
+++ b/core/src/report/eval/amount.rs
@@ -202,8 +202,8 @@ impl<'ctx> SingleAmount<'ctx> {
     pub fn check_add(self, rhs: Self) -> Result<Self, EvalError> {
         if self.commodity != rhs.commodity {
             Err(EvalError::UnmatchingCommodities(
-                self.commodity.as_str().to_string(),
-                rhs.commodity.as_str().to_string(),
+                self.commodity.into(),
+                rhs.commodity.into(),
             ))
         } else {
             Ok(Self {

--- a/core/src/report/eval/error.rs
+++ b/core/src/report/eval/error.rs
@@ -1,10 +1,12 @@
+use crate::report::commodity::OwnedCommodity;
+
 /// Errors specific to expression evaluation.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum EvalError {
     #[error("operator can't be applied to unmatched types")]
     UnmatchingOperation,
     #[error("unmatching commodities {0} and {1}")]
-    UnmatchingCommodities(String, String),
+    UnmatchingCommodities(OwnedCommodity, OwnedCommodity),
     #[error("cannot divide by zero")]
     DivideByZero,
     #[error("overflow happened")]

--- a/core/src/report/eval/error.rs
+++ b/core/src/report/eval/error.rs
@@ -7,6 +7,8 @@ pub enum EvalError {
     UnmatchingOperation,
     #[error("unmatching commodities {0} and {1}")]
     UnmatchingCommodities(OwnedCommodity, OwnedCommodity),
+    #[error("unknown commodity {0}")]
+    UnknownCommodity(OwnedCommodity),
     #[error("cannot divide by zero")]
     DivideByZero,
     #[error("overflow happened")]

--- a/core/src/report/eval/evaluated.rs
+++ b/core/src/report/eval/evaluated.rs
@@ -75,6 +75,23 @@ impl<'ctx> Evaluated<'ctx> {
         Amount::from_value(amount.value.clone().into(), commodity).into()
     }
 
+    /// Creates [`Evaluated`] from [`expr::Amount`],
+    /// with just looking up the commodity.
+    pub(super) fn from_expr_amount(
+        ctx: &ReportContext<'ctx>,
+        amount: &expr::Amount,
+    ) -> Result<Evaluated<'ctx>, EvalError> {
+        if amount.commodity.is_empty() {
+            return Ok(amount.value.value.into());
+        }
+        let commodity = ctx.commodities.resolve(&amount.commodity).ok_or_else(|| {
+            EvalError::UnknownCommodity(OwnedCommodity::from_string(
+                amount.commodity.clone().into_owned(),
+            ))
+        })?;
+        Ok(Amount::from_value(amount.value.clone().into(), commodity).into())
+    }
+
     /// Returns if the amount is zero.
     pub fn is_zero(&self) -> bool {
         match self {

--- a/core/src/report/eval/evaluated.rs
+++ b/core/src/report/eval/evaluated.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use rust_decimal::Decimal;
 
-use crate::{report::ReportContext, syntax::expr};
+use crate::{
+    report::{commodity::OwnedCommodity, ReportContext},
+    syntax::expr,
+};
 
 use super::{
     amount::{Amount, PostingAmount, SingleAmount},
@@ -59,8 +62,9 @@ impl<'ctx> From<Amount<'ctx>> for Evaluated<'ctx> {
 }
 
 impl<'ctx> Evaluated<'ctx> {
-    /// Creates [`Evaluated`] from [`expr::Amount`].
-    pub(super) fn from_expr_amount(
+    /// Creates [`Evaluated`] from [`expr::Amount`],
+    /// with registering the commodity.
+    pub(super) fn from_expr_amount_mut(
         ctx: &mut ReportContext<'ctx>,
         amount: &expr::Amount,
     ) -> Evaluated<'ctx> {

--- a/core/src/report/price_db.rs
+++ b/core/src/report/price_db.rs
@@ -1,32 +1,513 @@
-use std::path::Path;
+//! Provides [PriceRepository], which can compute the commodity (currency) conversion.
+
+use std::{
+    collections::{hash_map, BinaryHeap, HashMap},
+    path::Path,
+};
+
+use chrono::{NaiveDate, TimeDelta};
+use rust_decimal::Decimal;
 
 use crate::parse;
 
+use super::{
+    commodity::Commodity,
+    context::ReportContext,
+    eval::{Amount, SingleAmount},
+};
+
 #[derive(Debug, thiserror::Error)]
-pub enum PriceDBError {
+pub enum LoadError {
     #[error("failed to perform IO")]
     IO(#[from] std::io::Error),
     #[error("failed to parse price DB entry: {0}")]
     Parse(#[from] parse::ParseError),
 }
 
-/// Loads PriceDB information from the given file.
-pub fn load_price_db(path: &Path) -> Result<(), PriceDBError> {
-    // Even though price db can be up to a few megabytes,
-    // still it's much easier to load everything into memory.
-    let before = chrono::Local::now();
-    let content = std::fs::read_to_string(path)?;
-    let mut num = 0;
-    for entry in parse::price::parse_price_db(&parse::ParseOptions::default(), &content) {
-        entry?;
-        num += 1;
+/// Source of the price information.
+/// In the DB, latter one (larger one as Ord) has priority,
+/// and if you have events with higher priority,
+/// lower priority events are discarded.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub(super) enum PriceSource {
+    Ledger,
+    PriceDB,
+}
+
+#[derive(Debug)]
+struct Entry(PriceSource, Vec<(NaiveDate, Decimal)>);
+
+/// Builder of [`PriceRepository`].
+#[derive(Debug, Default)]
+pub(super) struct PriceRepositoryBuilder<'ctx> {
+    records: HashMap<Commodity<'ctx>, HashMap<Commodity<'ctx>, Entry>>,
+}
+
+/// Event of commodity price.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct PriceEvent<'ctx> {
+    pub date: NaiveDate,
+    pub price_x: SingleAmount<'ctx>,
+    pub price_y: SingleAmount<'ctx>,
+}
+
+#[cfg(test)]
+impl<'ctx> PriceEvent<'ctx> {
+    fn sort_key<'a>(&'a self) -> (NaiveDate, &'ctx str, &'ctx str, &'a Decimal, &'a Decimal) {
+        let PriceEvent {
+            date,
+            price_x:
+                SingleAmount {
+                    value: value_x,
+                    commodity: commodity_x,
+                },
+            price_y:
+                SingleAmount {
+                    value: value_y,
+                    commodity: commodity_y,
+                },
+        } = self;
+        (
+            *date,
+            commodity_x.as_str(),
+            commodity_y.as_str(),
+            value_x,
+            value_y,
+        )
     }
-    let after = chrono::Local::now();
-    log::info!("TODO: use this for DB: {} entries", num);
-    let time_spent = after - before;
-    log::info!(
-        "Took {} seconds to load price DB",
-        time_spent.num_milliseconds() as f64 / 1000.
-    );
-    Ok(())
+}
+
+impl<'ctx> PriceRepositoryBuilder<'ctx> {
+    pub fn insert_price(&mut self, source: PriceSource, event: PriceEvent<'ctx>) {
+        if event.price_x.commodity == event.price_y.commodity {
+            // this must be an error returned, instead of log error.
+            log::error!("price log should not contain the self-mention rate");
+        }
+        self.insert_impl(source, event.date, event.price_x, event.price_y);
+        self.insert_impl(source, event.date, event.price_y, event.price_x);
+    }
+
+    fn insert_impl(
+        &mut self,
+        source: PriceSource,
+        date: NaiveDate,
+        price_of: SingleAmount<'ctx>,
+        price_with: SingleAmount<'ctx>,
+    ) {
+        let Entry(stored_source, entries): &mut _ = self
+            .records
+            .entry(price_with.commodity)
+            .or_default()
+            .entry(price_of.commodity)
+            .or_insert(Entry(PriceSource::Ledger, Vec::new()));
+        if *stored_source < source {
+            *stored_source = source;
+            entries.clear();
+        }
+        // price_of: x X
+        // price_with: y Y
+        //
+        // typical use: price_of: 1 X
+        // then records[Y][X] == y (/ 1)
+        entries.push((date, price_with.value / price_of.value));
+    }
+
+    /// Loads PriceDB information from the given file.
+    pub fn load_price_db(
+        &mut self,
+        ctx: &mut ReportContext<'ctx>,
+        path: &Path,
+    ) -> Result<(), LoadError> {
+        // Even though price db can be up to a few megabytes,
+        // still it's much easier to load everything into memory.
+        let content = std::fs::read_to_string(path)?;
+        for entry in parse::price::parse_price_db(&parse::ParseOptions::default(), &content) {
+            let (_, entry) = entry?;
+            // we cannot skip commodities we don't know, as the price might be indirected in DB.
+            // For example, if we have only AUD and JPY in Ledger,
+            // price DB might just expose AUD/EUR EUR/CHF CHF/JPY.
+            let target = ctx.commodities.ensure(entry.target.as_ref());
+            let rate: SingleAmount<'ctx> = SingleAmount::from_value(
+                entry.rate.value.value,
+                ctx.commodities.ensure(&entry.rate.commodity),
+            );
+            self.insert_price(
+                PriceSource::PriceDB,
+                PriceEvent {
+                    price_x: SingleAmount::from_value(Decimal::ONE, target),
+                    price_y: rate,
+                    date: entry.datetime.date(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn into_events(self) -> Vec<PriceEvent<'ctx>> {
+        let mut ret = Vec::new();
+        for (price_with, v) in self.records {
+            for (price_of, Entry(_, v)) in v {
+                for (date, rate) in v {
+                    ret.push(PriceEvent {
+                        price_x: SingleAmount::from_value(Decimal::ONE, price_of),
+                        price_y: SingleAmount::from_value(rate, price_with),
+                        date,
+                    });
+                }
+            }
+        }
+        ret.sort_by(|x, y| x.sort_key().cmp(&y.sort_key()));
+        ret
+    }
+
+    pub fn build(self) -> PriceRepository<'ctx> {
+        PriceRepository::new(self.build_naive())
+    }
+
+    fn build_naive(mut self) -> NaivePriceRepository<'ctx> {
+        self.records
+            .values_mut()
+            .for_each(|x| x.values_mut().for_each(|x| x.1.sort()));
+        NaivePriceRepository {
+            records: self.records,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionError<'ctx> {
+    #[error("commodity rate {0} into {1} at {2} not found")]
+    RateNotFound(SingleAmount<'ctx>, Commodity<'ctx>, NaiveDate),
+}
+
+/// Converts the given amount into the specified commodity.
+pub fn convert_amount<'ctx>(
+    price_repos: &mut PriceRepository<'ctx>,
+    amount: &Amount<'ctx>,
+    commodity_with: Commodity<'ctx>,
+    date: NaiveDate,
+) -> Result<Amount<'ctx>, ConversionError<'ctx>> {
+    let mut result = Amount::zero();
+    for v in amount.iter() {
+        result += price_repos.convert_single(v, commodity_with, date)?;
+    }
+    Ok(result)
+}
+
+/// Repository which user can query the conversion rate with.
+pub struct PriceRepository<'ctx> {
+    inner: NaivePriceRepository<'ctx>,
+    // TODO: add price_with as a key, otherwise it's wrong.
+    // BTreeMap could be used if cursor support is ready.
+    // Then, we can avoid computing rates over and over if no rate update happens.
+    cache: HashMap<(Commodity<'ctx>, NaiveDate), HashMap<Commodity<'ctx>, WithDistance<Decimal>>>,
+}
+
+impl<'ctx> PriceRepository<'ctx> {
+    fn new(inner: NaivePriceRepository<'ctx>) -> Self {
+        Self {
+            inner,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Converts the given `value` into the `commodity_with`.
+    /// If the given value has already the `commodity_with`,
+    /// returns `Ok(value)` as-is.
+    pub fn convert_single(
+        &mut self,
+        value: SingleAmount<'ctx>,
+        commodity_with: Commodity<'ctx>,
+        date: NaiveDate,
+    ) -> Result<SingleAmount<'ctx>, ConversionError<'ctx>> {
+        if value.commodity == commodity_with {
+            return Ok(value);
+        }
+        let rate = self
+            .cache
+            .entry((commodity_with, date))
+            .or_insert_with(|| self.inner.compute_price_table(commodity_with, date))
+            .get(&value.commodity);
+        match rate {
+            Some(WithDistance(_, rate)) => {
+                Ok(SingleAmount::from_value(value.value * rate, commodity_with))
+            }
+            None => Err(ConversionError::RateNotFound(value, commodity_with, date)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NaivePriceRepository<'ctx> {
+    // from comodity -> to commodity -> date -> price.
+    // e.g. USD AAPL 2024-01-01 100 means 1 AAPL == 100 USD at 2024-01-01.
+    // the value are sorted in NaiveDate order.
+    records: HashMap<Commodity<'ctx>, HashMap<Commodity<'ctx>, Entry>>,
+}
+
+impl<'ctx> NaivePriceRepository<'ctx> {
+    /// Copied from CachedPriceRepository, needs to be factored out properly.
+    #[cfg(test)]
+    fn convert(
+        &self,
+        value: SingleAmount<'ctx>,
+        commodity_with: Commodity<'ctx>,
+        date: NaiveDate,
+    ) -> Result<SingleAmount<'ctx>, SingleAmount<'ctx>> {
+        if value.commodity == commodity_with {
+            return Ok(value);
+        }
+        let rate = self
+            .compute_price_table(commodity_with, date)
+            .get(&value.commodity)
+            .map(|x| x.1.clone());
+        match rate {
+            Some(rate) => Ok(SingleAmount::from_value(value.value * rate, commodity_with)),
+            None => Err(value),
+        }
+    }
+
+    fn compute_price_table(
+        &self,
+        price_with: Commodity<'ctx>,
+        date: NaiveDate,
+    ) -> HashMap<Commodity<'ctx>, WithDistance<Decimal>> {
+        // minimize the distance, and then minimize the staleness.
+        let mut queue: BinaryHeap<WithDistance<(Commodity<'ctx>, Decimal)>> = BinaryHeap::new();
+        let mut distances: HashMap<Commodity<'ctx>, WithDistance<Decimal>> = HashMap::new();
+        queue.push(WithDistance(
+            Distance {
+                num_ledger_conversions: 0,
+                num_all_conversions: 0,
+                staleness: TimeDelta::zero(),
+            },
+            (price_with, Decimal::ONE),
+        ));
+        while let Some(curr) = queue.pop() {
+            log::debug!("curr: {:?}", curr);
+            let WithDistance(curr_dist, (prev, prev_rate)) = curr;
+            if let Some(WithDistance(prev_dist, _)) = distances.get(&prev) {
+                if *prev_dist < curr_dist {
+                    log::debug!(
+                        "no need to update, prev_dist {:?} is smaller than curr_dist {:?}",
+                        prev_dist,
+                        curr_dist
+                    );
+                    continue;
+                }
+            }
+            for (j, Entry(source, rates)) in match self.records.get(&prev) {
+                None => continue,
+                Some(x) => x,
+            } {
+                let bound = rates.partition_point(|(record_date, _)| record_date <= &date);
+                log::debug!(
+                    "found next commodity {} with date bound {}",
+                    j.as_str(),
+                    bound
+                );
+                if bound == 0 {
+                    // we cannot find any rate information at the date (all rates are in future).
+                    // let's treat rates are not available.
+                    continue;
+                }
+                let (record_date, rate) = rates[bound - 1];
+                let next_dist = curr_dist.extend(*source, date - record_date);
+                let rate = prev_rate * rate;
+                let next = WithDistance(next_dist.clone(), (*j, rate));
+                let updated = match distances.entry(*j) {
+                    hash_map::Entry::Occupied(mut e) => {
+                        if e.get() <= &next_dist {
+                            false
+                        } else {
+                            e.insert(WithDistance(next_dist, rate));
+                            true
+                        }
+                    }
+                    hash_map::Entry::Vacant(e) => {
+                        e.insert(WithDistance(next_dist, rate));
+                        true
+                    }
+                };
+                if !updated {
+                    continue;
+                }
+                queue.push(next);
+            }
+        }
+        distances
+    }
+}
+
+/// Distance to minimize during the price DB computation.
+///
+/// Now this is using simple derived [Ord] logic,
+/// but we can work on heuristic cost function instead.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+struct Distance {
+    /// Number of conversions with [`PriceSource::Ledger`] used to compute the rate.
+    /// Minimize this because we assume [`PriceSource::PriceDB`] is more reliable
+    /// than the one in Ledger.
+    num_ledger_conversions: usize,
+    /// Number of conversions used to compute the rate.
+    num_all_conversions: usize,
+    /// Staleness of the conversion rate.
+    staleness: TimeDelta,
+}
+
+impl Distance {
+    fn extend(&self, source: PriceSource, staleness: TimeDelta) -> Self {
+        let num_ledger_conversions = self.num_ledger_conversions
+            + match source {
+                PriceSource::Ledger => 1,
+                PriceSource::PriceDB => 0,
+            };
+        Self {
+            num_ledger_conversions,
+            num_all_conversions: self.num_all_conversions + 1,
+            staleness: std::cmp::max(self.staleness, staleness),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WithDistance<T>(Distance, T);
+
+impl<T> PartialEq for WithDistance<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> PartialEq<Distance> for WithDistance<T> {
+    fn eq(&self, other: &Distance) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<T> Eq for WithDistance<T> {}
+
+impl<T> PartialOrd for WithDistance<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T: Eq> PartialOrd<Distance> for WithDistance<T> {
+    fn partial_cmp(&self, other: &Distance) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl<T: Eq> Ord for WithDistance<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bumpalo::Bump;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn price_db_computes_direct_price() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let chf = ctx.commodities.ensure("CHF");
+        let eur = ctx.commodities.ensure("EUR");
+        let mut builder = PriceRepositoryBuilder::default();
+        builder.insert_price(
+            PriceSource::Ledger,
+            PriceEvent {
+                date: NaiveDate::from_ymd_opt(2024, 10, 1).unwrap(),
+                price_x: SingleAmount::from_value(dec!(1), eur),
+                price_y: SingleAmount::from_value(dec!(0.8), chf),
+            },
+        );
+
+        let db = builder.build_naive();
+
+        // before the event date, we can't convert the value, thus see Right.
+        let got = db.convert(
+            SingleAmount::from_value(dec!(1), eur),
+            chf,
+            NaiveDate::from_ymd_opt(2024, 9, 30).unwrap(),
+        );
+        assert_eq!(got, Err(SingleAmount::from_value(dec!(1), eur)));
+
+        let got = db.convert(
+            SingleAmount::from_value(dec!(10), chf),
+            eur,
+            NaiveDate::from_ymd_opt(2024, 9, 30).unwrap(),
+        );
+        assert_eq!(got, Err(SingleAmount::from_value(dec!(10), chf)));
+
+        let got = db.convert(
+            SingleAmount::from_value(dec!(1.0), eur),
+            chf,
+            NaiveDate::from_ymd_opt(2024, 10, 1).unwrap(),
+        );
+        assert_eq!(got, Ok(SingleAmount::from_value(dec!(0.8), chf)));
+
+        let got = db.convert(
+            SingleAmount::from_value(dec!(10.0), chf),
+            eur,
+            NaiveDate::from_ymd_opt(2024, 10, 1).unwrap(),
+        );
+        assert_eq!(got, Ok(SingleAmount::from_value(dec!(12.5), eur)));
+    }
+
+    #[test]
+    fn price_db_computes_indirect_price() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let chf = ctx.commodities.ensure("CHF");
+        let eur = ctx.commodities.ensure("EUR");
+        let usd = ctx.commodities.ensure("USD");
+        let jpy = ctx.commodities.ensure("JPY");
+        let mut builder = PriceRepositoryBuilder::default();
+
+        builder.insert_price(
+            PriceSource::Ledger,
+            PriceEvent {
+                date: NaiveDate::from_ymd_opt(2024, 10, 1).unwrap(),
+                price_x: SingleAmount::from_value(dec!(0.8), chf),
+                price_y: SingleAmount::from_value(dec!(1), eur),
+            },
+        );
+        builder.insert_price(
+            PriceSource::Ledger,
+            PriceEvent {
+                date: NaiveDate::from_ymd_opt(2024, 10, 2).unwrap(),
+                price_x: SingleAmount::from_value(dec!(0.8), eur),
+                price_y: SingleAmount::from_value(dec!(1), usd),
+            },
+        );
+        builder.insert_price(
+            PriceSource::Ledger,
+            PriceEvent {
+                date: NaiveDate::from_ymd_opt(2024, 10, 3).unwrap(),
+                price_x: SingleAmount::from_value(dec!(100), jpy),
+                price_y: SingleAmount::from_value(dec!(1), usd),
+            },
+        );
+
+        // 1 EUR = 0.8 CHF
+        // 1 USD = 0.8 EUR
+        // 1 USD = 100 JPY
+        // 1 CHF == 5/4 EUR == (5/4)*(5/4) USD == 156.25 JPY
+
+        let db = builder.build_naive();
+
+        let got = db.convert(
+            SingleAmount::from_value(dec!(1), chf),
+            jpy,
+            NaiveDate::from_ymd_opt(2024, 10, 3).unwrap(),
+        );
+        assert_eq!(got, Ok(SingleAmount::from_value(dec!(156.25), jpy)));
+    }
 }

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -2,9 +2,16 @@
 
 use std::{borrow::Cow, collections::HashSet};
 
+use chrono::NaiveDate;
+
+use crate::{parse, syntax};
+
 use super::{
     balance::Balance,
+    commodity::OwnedCommodity,
     context::{Account, ReportContext},
+    eval::{Amount, EvalError, Evaluable},
+    price_db::{self, PriceRepository},
     transaction::{Posting, Transaction},
 };
 
@@ -12,6 +19,21 @@ use super::{
 pub struct Ledger<'ctx> {
     pub(super) transactions: Vec<Transaction<'ctx>>,
     pub(super) raw_balance: Balance<'ctx>,
+    pub(super) price_repos: PriceRepository<'ctx>,
+}
+
+/// Error type for [`Ledger`] methods.
+// TODO: Organize errors.
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    #[error("failed to parse the given value")]
+    ParseFailed(#[from] parse::ParseError),
+    #[error("failed to evaluate the expr")]
+    EvalFailed(#[from] EvalError),
+    #[error("commodity {0} not found")]
+    CommodityNotFound(OwnedCommodity),
+    #[error("cannot convert amount: {0}")]
+    CommodityConversionFailure(String),
 }
 
 /// Query to list postings matching the criteria.
@@ -20,6 +42,13 @@ pub struct PostingQuery {
     /// Select the specified account if specified.
     /// Note this will be changed to list of regex eventually.
     pub account: Option<String>,
+}
+
+/// Context passed to [`Ledger::eval()`].
+#[derive(Debug)]
+pub struct EvalContext {
+    pub date: NaiveDate,
+    pub exchange: Option<String>,
 }
 
 impl<'ctx> Ledger<'ctx> {
@@ -48,9 +77,38 @@ impl<'ctx> Ledger<'ctx> {
 
     /// Returns a balance matching the given query.
     /// Note that currently we don't have the query,
-    /// that will be implemented soon.
+    /// that will be added soon.
     pub fn balance(&self) -> Cow<'_, Balance<'ctx>> {
         Cow::Borrowed(&self.raw_balance)
+    }
+
+    pub fn eval(
+        &mut self,
+        ctx: &ReportContext<'ctx>,
+        expression: &str,
+        eval_ctx: &EvalContext,
+    ) -> Result<Amount<'ctx>, QueryError> {
+        let exchange = eval_ctx
+            .exchange
+            .as_ref()
+            .map(|x| {
+                ctx.commodities.resolve(&x).ok_or_else(|| {
+                    QueryError::CommodityNotFound(OwnedCommodity::from_string(x.to_owned()))
+                })
+            })
+            .transpose()?;
+        let parsed: syntax::expr::ValueExpr = expression
+            .try_into()
+            .map_err(|err| QueryError::ParseFailed(err))?;
+        let evaled: Amount<'ctx> = parsed.eval(ctx)?.try_into()?;
+        let evaled = match exchange {
+            None => evaled,
+            Some(price_with) => {
+                price_db::convert_amount(&mut self.price_repos, &evaled, price_with, eval_ctx.date)
+                    .map_err(|err| QueryError::CommodityConversionFailure(err.to_string()))?
+            }
+        };
+        Ok(evaled)
     }
 }
 

--- a/core/src/syntax.rs
+++ b/core/src/syntax.rs
@@ -330,5 +330,6 @@ pub struct PriceDBEntry<'i> {
     /// Target commodity of the price.
     pub target: Cow<'i, str>,
     /// The rate of the target commodity.
-    pub rate: expr::ValueExpr<'i>,
+    /// 1 target == rate.
+    pub rate: expr::Amount<'i>,
 }


### PR DESCRIPTION
With `--exchange` option user can convert the commodities in Ledger into specified commodity.
Also `--price-db` would give the separated price information 

This PR won't support `balance` or `register` yet, but allows user to try out evaluation with `--exchange` option.

Once this PR is merged, adding conversion to `balance` or `register` won't be hard.