### PR TITLE
Refactoring: Updated visibility, added comments

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,6 @@
 
 pub mod format;
 pub mod load;
-pub(crate) mod parse;
+pub mod parse;
 pub mod report;
 pub mod syntax;

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -1,4 +1,5 @@
 //! Defines parser for the Ledger format.
+//! Currently only the parser for the entire file format is provieded as public.
 
 mod character;
 mod combinator;
@@ -97,12 +98,14 @@ impl ParsedContext<'_> {
             .expect("ParsedContext::span must be a valid UTF-8 boundary")
     }
 
+    /// Returns the position of the parsed string within the original `&str`,
+    /// which can be used to find the position of the [`Tracked`][syntax::tracked::Tracked] item.
     pub fn span(&self) -> ParsedSpan {
         ParsedSpan(self.span.clone())
     }
 }
 
-/// Span of the parsed str.
+/// Range parsed with the given parser within the original input `&str`.
 #[derive(Debug)]
 pub struct ParsedSpan(Range<usize>);
 

--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -39,7 +39,7 @@ impl<'ctx> Balance<'ctx> {
     }
 
     /// Adds a particular account value with the specified commodity, and returns the updated balance.
-    pub fn add_posting_amount(
+    pub(super) fn add_posting_amount(
         &mut self,
         account: Account<'ctx>,
         amount: PostingAmount<'ctx>,
@@ -51,7 +51,7 @@ impl<'ctx> Balance<'ctx> {
 
     /// Tries to set the particular account's balance with the specified commodity,
     /// and returns the delta which should have caused the difference.
-    pub fn set_partial(
+    pub(super) fn set_partial(
         &mut self,
         account: Account<'ctx>,
         amount: PostingAmount<'ctx>,

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -199,7 +199,7 @@ fn add_transaction<'ctx>(
                     .transpose()?;
                 let current = bal.add_posting_amount(account, amount);
                 if let Some(expected) = expected_balance {
-                    if !current.is_consistent(expected) {
+                    if !current.is_consistent(&expected) {
                         return Err(BookKeepError::BalanceAssertionFailure(
                             format!("{}", current.as_inline_display()),
                             format!("{}", expected),

--- a/core/src/report/eval/amount.rs
+++ b/core/src/report/eval/amount.rs
@@ -160,15 +160,10 @@ impl Mul<Decimal> for SingleAmount<'_> {
     }
 }
 
-impl<'ctx> PostingAmount<'ctx> {
+impl PostingAmount<'_> {
     /// Returns absolute zero.
     pub fn zero() -> Self {
         Self::default()
-    }
-
-    /// Constructs an instance with single commodity.
-    pub fn from_value(value: Decimal, commodity: Commodity<'ctx>) -> Self {
-        PostingAmount::Single(SingleAmount::from_value(value, commodity))
     }
 
     /// Adds the amount with keeping commodity single.
@@ -185,6 +180,14 @@ impl<'ctx> PostingAmount<'ctx> {
     /// Subtracts the amount with keeping the commodity single.
     pub fn check_sub(self, rhs: Self) -> Result<Self, EvalError> {
         self.check_add(-rhs)
+    }
+}
+
+#[cfg(test)]
+impl<'ctx> PostingAmount<'ctx> {
+    /// Constructs an instance with single commodity.
+    pub(crate) fn from_value(value: Decimal, commodity: Commodity<'ctx>) -> Self {
+        PostingAmount::Single(SingleAmount::from_value(value, commodity))
     }
 }
 
@@ -393,7 +396,7 @@ impl<'ctx> Amount<'ctx> {
     /// *   If the [PostingAmount] is zero, then the amount must be zero.
     /// *   If the [PostingAmount] is a value with commodity,
     ///     then the amount should be equal to given value only on the commodity.
-    pub fn is_consistent(&self, rhs: PostingAmount<'ctx>) -> bool {
+    pub(crate) fn is_consistent(&self, rhs: &PostingAmount<'ctx>) -> bool {
         match rhs {
             PostingAmount::Zero => self.is_zero(),
             PostingAmount::Single(single) => self.get_part(single.commodity) == single.value,

--- a/core/src/syntax/tracked.rs
+++ b/core/src/syntax/tracked.rs
@@ -34,8 +34,9 @@ pub type Posting<'i> = super::Posting<'i, Tracking>;
 pub type PostingAmount<'i> = super::PostingAmount<'i, Tracking>;
 pub type Lot<'i> = super::Lot<'i, Tracking>;
 
-/// Span of the tracked position.
-/// Only useful within [ParsedContext][crate::parse::ParsedContext].
+/// Span of the tracked item within the original `&str`.
+/// Later one can convert this span into the range within the parsed str with
+/// [`ParsedSpan::resolve()`][crate::parse::ParsedSpan::resolve()].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TrackedSpan(Range<usize>);
 


### PR DESCRIPTION
* Hide `report::eval::PostingAmount`, which won't be useful (at least for now) for users.
* Expose `parse::parse_ledger` as API, this is useful.
* Added comments to book keeping logic, as it's getting complex.