### PR TITLE
Fix: Correctly handle balance condition

### DIFF
--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -35,6 +35,7 @@ impl<'ctx> Balance<'ctx> {
     pub fn add_amount(&mut self, account: Account<'ctx>, amount: Amount<'ctx>) -> &Amount<'ctx> {
         let curr: &mut Amount = self.accounts.entry(account).or_default();
         *curr += amount;
+        curr.remove_zero_entries();
         curr
     }
 
@@ -46,6 +47,7 @@ impl<'ctx> Balance<'ctx> {
     ) -> &Amount<'ctx> {
         let curr: &mut Amount = self.accounts.entry(account).or_default();
         *curr += amount;
+        curr.remove_zero_entries();
         curr
     }
 
@@ -60,7 +62,7 @@ impl<'ctx> Balance<'ctx> {
             PostingAmount::Zero => {
                 let prev: Amount<'ctx> = self
                     .accounts
-                    .insert(account, amount.into())
+                    .insert(account, Amount::zero())
                     .unwrap_or_default();
                 (&prev)
                     .try_into()

--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -98,6 +98,7 @@ mod tests {
         let got: Amount<'_> = got.try_into().expect("not an amount");
         assert_eq!(
             hashmap! {
+                ctx.commodities.ensure("USD") => dec!(0),
                 ctx.commodities.ensure("EUR") => dec!(300),
                 ctx.commodities.ensure("JPY") => dec!(20000),
             },


### PR DESCRIPTION
#211 broke the balance condition by treating `0` and `0 X` equally.
This PR reverts the behavior, and instead force leaving the commodity with `0` in `Amount`.
