### PR TITLE
Fix: Reject same commodity exchange on import

### DIFF
--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -111,6 +111,7 @@ impl TryFrom<ConfigFragment> for ConfigEntry {
 /// One flagment of config corresponding to particular path prefix.
 /// It'll be merged into `ConfigEntry`.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 struct ConfigFragment {
     /// Path pattern which file the entry will match against.
     pub path: String,
@@ -268,6 +269,7 @@ impl From<AccountCommodityConfig> for AccountCommoditySpec {
 
 /// FormatSpec describes the several format used in import target.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct FormatSpec {
     /// Specify the date format, in [chrono::format::strftime] compatible format.
     #[serde(default)]
@@ -289,6 +291,7 @@ pub struct FormatSpec {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct SkipSpec {
     /// The number of lines skipped at head.
     /// Only supported for CSV.
@@ -304,6 +307,7 @@ pub enum RowOrder {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct CommodityFormatSpec {
     pub precision: u8,
 }
@@ -408,12 +412,14 @@ impl<'de> de::Visitor<'de> for FieldPosVisitor {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct TemplateField {
     pub template: String,
 }
 
 /// RewriteRule specifies the rewrite rule matched against transaction.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct RewriteRule {
     /// matcher for the rewrite.
     pub matcher: RewriteMatcher,
@@ -450,6 +456,8 @@ pub struct CommodityConversionSpec {
     pub commodity: Option<String>,
     /// Decides `rate` meaning.
     pub rate: ConversionRateMode,
+    /// Disable all conversions.
+    pub disabled: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -503,6 +511,7 @@ pub enum RewriteField {
     RemittanceUnstructuredInfo,
     AdditionalEntryInfo,
     AdditionalTransactionInfo,
+    SecondaryCommodity,
     Category,
     Payee,
 }
@@ -913,6 +922,7 @@ mod tests {
                 amount: ConversionAmountMode::Extract,
                 commodity: None,
                 rate: ConversionRateMode::PriceOfPrimary,
+                disabled: false,
             }),
         };
         assert_eq!(matcher, RewriteRule::deserialize(de).unwrap());

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -61,7 +61,7 @@ impl std::ops::AddAssign for Fragment<'_> {
         self.account = other.account.or(self.account);
         self.code = other.code.or(self.code);
         if let Some(c) = other.conversion {
-            let _ = self.conversion.insert(c);
+            self.conversion = Some(c);
         }
     }
 }

--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -113,6 +113,12 @@ impl Txn {
     }
 
     pub fn add_rate(&mut self, key: CommodityPair, rate: Decimal) -> Result<&mut Txn, ImportError> {
+        if key.source == key.target {
+            return Err(ImportError::Other(format!(
+                "cannot handle rate with the same commodity {}",
+                key.source
+            )));
+        }
         match self.rates.insert(
             key.target.clone(),
             OwnedAmount {


### PR DESCRIPTION
Prohibit emitting 1 EUR @ 1.2 EUR like conversion, that's an error.

Also provide a feature to disable conversion to avoid hitting this error on certain condition.

This solves #200.