### PR TITLE
feat: Use self defined ParseError instead of winnow error

### DIFF
--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -1,7 +1,7 @@
 //! format functionalities of Ledger format files.
 
 use crate::{
-    parse::{parse_ledger, ParseError},
+    parse::{parse_ledger, ParseError, ParseOptions},
     syntax::{self, display::DisplayContext},
 };
 
@@ -53,7 +53,7 @@ impl FormatOptions {
         r.read_to_string(&mut buf)?;
         // TODO: Grab DisplayContext externally, or from LedgerEntry.
         let ctx = DisplayContext::default();
-        for parsed in parse_ledger(&buf) {
+        for parsed in parse_ledger(&ParseOptions::default(), &buf) {
             let (_, entry): (_, syntax::plain::LedgerEntry) = parsed?;
             writeln!(w, "{}", ctx.as_display(&entry))?;
         }

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -13,7 +13,7 @@ pub enum FormatError {
     #[error("failed to perform IO")]
     IO(#[from] std::io::Error),
     #[error("failed to parse the file")]
-    Parse(#[from] Box<ParseError>),
+    Parse(#[from] ParseError),
     // TODO: Remove this once supported.
     #[error("recursive format isn't supported yet")]
     UnsupportedRecursiveFormat,

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -15,7 +15,7 @@ pub enum LoadError {
     #[error("failed to perform IO")]
     IO(#[from] std::io::Error),
     #[error("failed to parse file {1}")]
-    Parse(#[source] Box<parse::ParseError>, PathBuf),
+    Parse(#[source] parse::ParseError, PathBuf),
     #[error("loading file path {0} doesn't have parent, maybe filesystem root is passed")]
     RootLoadingPath(PathBuf),
     #[error("invalid Unicode path is not supported: {0}")]
@@ -234,7 +234,7 @@ mod tests {
 
     fn parse_static_ledger_entry(
         input: &[(&Path, &'static str)],
-    ) -> Result<Vec<(PathBuf, syntax::plain::LedgerEntry<'static>)>, Box<parse::ParseError>> {
+    ) -> Result<Vec<(PathBuf, syntax::plain::LedgerEntry<'static>)>, parse::ParseError> {
         let opts = parse::ParseOptions::default();
         input
             .iter()

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -87,7 +87,7 @@ impl<F: FileSystem> Loader<F> {
             .filesystem
             .file_content_utf8(&path)
             .map_err(LoadError::IO)?;
-        for parsed in parse_options.parse_ledger(&content) {
+        for parsed in parse::parse_ledger(parse_options, &content) {
             let (ctx, entry) =
                 parsed.map_err(|e| LoadError::Parse(e, path.clone().into_owned()))?;
             match entry {
@@ -224,24 +224,22 @@ impl FileSystem for FakeFileSystem {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::{borrow::Borrow, path::Path, vec::Vec};
 
     use indoc::indoc;
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
 
-    use crate::parse::{self, ParseOptions};
-
-    use super::*;
-
     fn parse_static_ledger_entry(
         input: &[(&Path, &'static str)],
     ) -> Result<Vec<(PathBuf, syntax::plain::LedgerEntry<'static>)>, Box<parse::ParseError>> {
-        let opts = ParseOptions::default();
+        let opts = parse::ParseOptions::default();
         input
             .iter()
             .flat_map(|(p, content)| {
-                opts.parse_ledger(content)
+                parse::parse_ledger(&opts, content)
                     .map(|elem| elem.map(|(_ctx, entry)| (p.to_path_buf(), entry)))
             })
             .collect()

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -34,8 +34,7 @@ use crate::syntax::{self, decoration::Decoration};
 pub fn parse_ledger<'i, Deco: 'i + Decoration>(
     options: &ParseOptions,
     input: &'i str,
-) -> impl Iterator<Item = Result<(ParsedContext<'i>, syntax::LedgerEntry<'i, Deco>), Box<ParseError>>>
-{
+) -> impl Iterator<Item = Result<(ParsedContext<'i>, syntax::LedgerEntry<'i, Deco>), ParseError>> {
     options.parse_repeated(parse_ledger_entry, character::newlines.void(), input)
 }
 
@@ -87,7 +86,7 @@ mod tests {
     use syntax::plain::LedgerEntry;
 
     fn parse_ledger_into(input: &str) -> Vec<(ParsedContext, LedgerEntry)> {
-        let r: Result<Vec<(ParsedContext, LedgerEntry)>, Box<ParseError>> =
+        let r: Result<Vec<(ParsedContext, LedgerEntry)>, ParseError> =
             parse_ledger(&ParseOptions::default(), input).collect();
         match r {
             Ok(x) => x,

--- a/core/src/parse/adaptor.rs
+++ b/core/src/parse/adaptor.rs
@@ -1,0 +1,151 @@
+//! Provides utilities to use winnow parser easily with [`ParseError`].
+
+use std::{marker::PhantomData, ops::Range};
+
+use winnow::{LocatingSlice, Parser};
+
+use crate::syntax;
+
+use super::error::{self, ParseError};
+
+/// Options to control parse behavior.
+#[derive(Debug, Clone)]
+pub struct ParseOptions {
+    error_style: annotate_snippets::Renderer,
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        Self {
+            error_style: annotate_snippets::Renderer::plain(),
+        }
+    }
+}
+
+impl ParseOptions {
+    /// Sets the given [`annotate_snippets::Renderer`] to `self`.
+    pub fn with_error_style(mut self, error_style: annotate_snippets::Renderer) -> Self {
+        self.error_style = error_style;
+        self
+    }
+
+    /// Parses the given `parser` object, separated with `separator`.
+    pub(super) fn parse_repeated<'i, Out, Sep, P, Q>(
+        &self,
+        parser: P,
+        separator: Q,
+        input: &'i str,
+    ) -> impl Iterator<Item = Result<(ParsedContext<'i>, Out), Box<ParseError>>> + 'i
+    where
+        Out: 'i,
+        Sep: 'i,
+        P: Parser<LocatingSlice<&'i str>, Out, winnow::error::ContextError> + 'i,
+        Q: Parser<LocatingSlice<&'i str>, Sep, winnow::error::ContextError> + 'i,
+    {
+        ParsedIter {
+            parser,
+            separator,
+            initial: input,
+            input: LocatingSlice::new(input),
+            renderer: self.error_style.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Context information carrying the metadata of the entry.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsedContext<'i> {
+    pub(super) initial: &'i str,
+    pub(super) span: Range<usize>,
+}
+
+impl ParsedContext<'_> {
+    /// Computes the starting line number from this context.
+    /// Note this function is O(N), not a cheap function.
+    pub fn compute_line_start(&self) -> usize {
+        error::compute_line_number(self.initial, self.span.start)
+    }
+
+    /// Returns the [`str`] slice corresponding to this context.
+    pub fn as_str(&self) -> &str {
+        self.initial
+            .get(self.span.clone())
+            .expect("ParsedContext::span must be a valid UTF-8 boundary")
+    }
+
+    /// Returns the position of the parsed string within the original `&str`,
+    /// which can be used to find the position of the [`Tracked`][syntax::tracked::Tracked] item.
+    pub fn span(&self) -> ParsedSpan {
+        ParsedSpan(self.span.clone())
+    }
+}
+
+/// Range parsed with the given parser within the original input `&str`.
+#[derive(Debug)]
+pub struct ParsedSpan(Range<usize>);
+
+impl ParsedSpan {
+    /// Returns the span of the given span relative to this span.
+    pub fn resolve(&self, span: &syntax::tracked::TrackedSpan) -> Range<usize> {
+        let target = span.as_range();
+        clip(self.0.clone(), target)
+    }
+}
+
+fn clip(parent: Range<usize>, child: Range<usize>) -> Range<usize> {
+    let start = std::cmp::max(parent.start, child.start) - parent.start;
+    let end = std::cmp::min(parent.end, child.end) - parent.start;
+    start..end
+}
+
+/// Iterator to return parsed ledger entry one-by-one.
+struct ParsedIter<'i, Out, Sep, P, Q> {
+    parser: P,
+    separator: Q,
+    initial: &'i str,
+    input: LocatingSlice<&'i str>,
+    renderer: annotate_snippets::Renderer,
+    _phantom: PhantomData<(Out, Sep)>,
+}
+
+impl<'i, Out, Sep, P, Q> Iterator for ParsedIter<'i, Out, Sep, P, Q>
+where
+    P: Parser<LocatingSlice<&'i str>, Out, winnow::error::ContextError>,
+    Q: Parser<LocatingSlice<&'i str>, Sep, winnow::error::ContextError>,
+{
+    type Item = Result<(ParsedContext<'i>, Out), Box<ParseError>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use winnow::stream::Stream as _;
+        let start = self.input.checkpoint();
+        (|| {
+            self.separator.parse_next(&mut self.input)?;
+            if self.input.is_empty() {
+                return Ok(None);
+            }
+            let (entry, span) = self
+                .parser
+                .by_ref()
+                .with_span()
+                .parse_next(&mut self.input)?;
+            Ok(Some((
+                ParsedContext {
+                    initial: self.initial,
+                    span,
+                },
+                entry,
+            )))
+        })()
+        .map_err(|e| {
+            Box::new(ParseError::new(
+                self.renderer.clone(),
+                self.initial,
+                self.input,
+                start,
+                e,
+            ))
+        })
+        .transpose()
+    }
+}

--- a/core/src/parse/adaptor.rs
+++ b/core/src/parse/adaptor.rs
@@ -35,7 +35,7 @@ impl ParseOptions {
         parser: P,
         separator: Q,
         input: &'i str,
-    ) -> impl Iterator<Item = Result<(ParsedContext<'i>, Out), Box<ParseError>>> + 'i
+    ) -> impl Iterator<Item = Result<(ParsedContext<'i>, Out), ParseError>> + 'i
     where
         Out: 'i,
         Sep: 'i,
@@ -114,7 +114,7 @@ where
     P: Parser<LocatingSlice<&'i str>, Out, winnow::error::ContextError>,
     Q: Parser<LocatingSlice<&'i str>, Sep, winnow::error::ContextError>,
 {
-    type Item = Result<(ParsedContext<'i>, Out), Box<ParseError>>;
+    type Item = Result<(ParsedContext<'i>, Out), ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         use winnow::stream::Stream as _;
@@ -137,15 +137,7 @@ where
                 entry,
             )))
         })()
-        .map_err(|e| {
-            Box::new(ParseError::new(
-                self.renderer.clone(),
-                self.initial,
-                self.input,
-                start,
-                e,
-            ))
-        })
+        .map_err(|e| ParseError::new(self.renderer.clone(), self.initial, self.input, start, e))
         .transpose()
     }
 }

--- a/core/src/parse/character.rs
+++ b/core/src/parse/character.rs
@@ -5,7 +5,7 @@ use winnow::{
     combinator::{alt, delimited, eof, trace},
     error::ParserError,
     stream::{AsChar, Compare, Stream, StreamIsPartial},
-    token::{one_of, take_till},
+    token::{one_of, take_till, take_while},
     PResult, Parser,
 };
 
@@ -48,6 +48,16 @@ where
     trace("character::line_ending_or_eof", alt((eof, line_ending)))
         .void()
         .parse_next(input)
+}
+
+/// Consume all newlines.
+pub fn newlines<I, E>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+where
+    I: Stream + StreamIsPartial + winnow::stream::Compare<&'static str>,
+    <I as Stream>::Token: AsChar,
+    E: ParserError<I>,
+{
+    trace("character::newlines", take_while(0.., b"\r\n")).parse_next(input)
 }
 
 /// Parses unnested string in paren.

--- a/core/src/parse/error.rs
+++ b/core/src/parse/error.rs
@@ -5,7 +5,7 @@ use std::{
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use winnow::{
-    error::{ContextError, ErrMode, StrContext},
+    error::{ContextError, StrContext},
     stream::{Location, Offset, Stream},
     LocatingSlice,
 };
@@ -30,12 +30,11 @@ impl ParseError {
         initial: &'i str,
         mut input: LocatingSlice<&'i str>,
         start: <LocatingSlice<&'i str> as Stream>::Checkpoint,
-        error: ErrMode<ContextError<StrContext>>,
+        error: ContextError<StrContext>,
     ) -> Self {
         let offset = input.offset_from(&start);
         input.reset(&start);
         let line_start = compute_line_number(initial, input.location());
-        let error = error.into_inner().expect("partial input can't be used");
         // Assume the error span is only for the first `char`.
         // When we'll implement
         let end = (offset + 1..)

--- a/core/src/parse/expr.rs
+++ b/core/src/parse/expr.rs
@@ -6,7 +6,7 @@ use winnow::{
         alt, delimited, dispatch, opt, peek, permutation, preceded, separated_foldl1, terminated,
         trace,
     },
-    error::{ContextError, FromExternalError, ParseError, ParserError},
+    error::{FromExternalError, ParserError},
     stream::{AsChar, Stream, StreamIsPartial},
     token::{any, one_of},
     PResult, Parser,
@@ -14,7 +14,7 @@ use winnow::{
 
 use crate::syntax::{expr, pretty_decimal};
 
-use super::{character::paren, primitive};
+use super::{adaptor::ParseOptions, character::paren, error, primitive};
 
 /// Parses value expression.
 pub fn value_expr<'i, I, E>(input: &mut I) -> PResult<expr::ValueExpr<'i>, E>
@@ -34,10 +34,12 @@ where
 }
 
 impl<'i> TryFrom<&'i str> for expr::ValueExpr<'i> {
-    type Error = ParseError<&'i str, ContextError>;
+    type Error = error::ParseError;
 
     fn try_from(value: &'i str) -> Result<Self, Self::Error> {
-        value_expr.parse(value)
+        ParseOptions::default()
+            .parse_single(value_expr, value)
+            .map(|x| x.1)
     }
 }
 
@@ -153,10 +155,12 @@ where
 }
 
 impl<'i> TryFrom<&'i str> for expr::Amount<'i> {
-    type Error = ParseError<&'i str, ContextError>;
+    type Error = error::ParseError;
 
     fn try_from(value: &'i str) -> Result<Self, Self::Error> {
-        unary_amount.parse(value)
+        ParseOptions::default()
+            .parse_single(unary_amount, value)
+            .map(|x| x.1)
     }
 }
 

--- a/core/src/parse/price.rs
+++ b/core/src/parse/price.rs
@@ -11,10 +11,23 @@ use winnow::{
 
 use crate::syntax;
 
-use super::{expr, primitive};
+use super::{
+    adaptor::{ParseOptions, ParsedContext},
+    character,
+    error::ParseError,
+    expr, primitive,
+};
+
+/// Parses a price DB content.
+pub fn parse_price_db<'i>(
+    options: &ParseOptions,
+    input: &'i str,
+) -> impl Iterator<Item = Result<(ParsedContext<'i>, syntax::PriceDBEntry<'i>), ParseError>> + 'i {
+    options.parse_repeated(price_db_entry, character::newlines, input)
+}
 
 /// Parses a price DB entry line.
-pub fn price_db_entry<'i, I>(input: &mut I) -> PResult<syntax::PriceDBEntry<'i>>
+fn price_db_entry<'i, I>(input: &mut I) -> PResult<syntax::PriceDBEntry<'i>>
 where
     I: Stream<Token = char, Slice = &'i str>
         + StreamIsPartial


### PR DESCRIPTION
Winnow error holds `'i` lifetime, often not good for `Error::source` which requires `'static`.
Changed to use our self defined `ParseError`.