### PR TITLE
Don't fail on benchmark regression for continuous run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           auto-push: false
           alert-threshold: '200%'
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
           alert-comment-cc-users: '@xkikeg'
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Otherwise we won't track the main branch results.