### PR TITLE
Fix: do not round on each posting

### DIFF
--- a/testdata/report/golden/multi_commodity.golden.balance.in_jpy_up_to_date.txt
+++ b/testdata/report/golden/multi_commodity.golden.balance.in_jpy_up_to_date.txt
@@ -1,10 +1,11 @@
-Assets:Banks:Swiss Bank: 7582520 JPY
+Assets:Banks:Swiss Bank: 7585703 JPY
 Assets:Banks:あおによし: 100000 JPY
 Assets:Brokers:US Broker: 7449124 JPY
 Assets:Wire:US Broker: 0
 Equity:Initial: -11472376 JPY
-Expenses:Cash: 86165 JPY
+Expenses:Cash: 81782 JPY
 Expenses:Comissions: 1729 JPY
+Expenses:Commissions: 1200 JPY
 Expenses:Tax:Income: 344660 JPY
 Income:Capital Gain: -62532 JPY
 Income:Salary: -1464805 JPY

--- a/testdata/report/golden/multi_commodity.golden.balance.in_usd_historical.txt
+++ b/testdata/report/golden/multi_commodity.golden.balance.in_usd_historical.txt
@@ -1,10 +1,11 @@
-Assets:Banks:Swiss Bank: 48343.14 USD
+Assets:Banks:Swiss Bank: 48363.50 USD
 Assets:Banks:あおによし: 639.67 USD
 Assets:Brokers:US Broker: 37650.00 USD
 Assets:Wire:US Broker: 0
 Equity:Initial: -73385.63 USD
-Expenses:Cash: 551.18 USD
+Expenses:Cash: 523.14 USD
 Expenses:Comissions: 11.06 USD
+Expenses:Commissions: 7.68 USD
 Expenses:Tax:Income: 2296.21 USD
 Income:Capital Gain: -400.00 USD
 Income:Salary: -9758.90 USD

--- a/testdata/report/multi_commodity.ledger
+++ b/testdata/report/multi_commodity.ledger
@@ -28,8 +28,12 @@ commodity USD
     Assets:Banks:Swiss Bank                -2,000.00 CHF
 
 2024/02/02 * convert to EUR
-    Expenses:Cash                             538.39 EUR @ 0.9287 CHF
-    Assets:Banks:Swiss Bank                  -500.00 CHF
+    ; this is 474.5657 CHF
+    Expenses:Cash                             511.00 EUR @ 0.9287 CHF
+    ; this is 6.96525 CHF
+    Expenses:Commissions                        7.50 EUR @ 0.9287 CHF
+    ; sum are 481.53095 CHF, ~ 481.53 CHF
+    Assets:Banks:Swiss Bank                  -481.53 CHF
 
 2024/02/05 * wire
     Assets:Wire:US Broker                   11481.06 USD @ 0.8710 CHF


### PR DESCRIPTION
If we have conversion at each posting, often we'll have remainder.
However, we should not round those at each posting. Why?
Assume the following situation.

```
   Expense        1 CHF @ 100.5 JPY
   Expense        1 CHF @ 100.5 JPY
   Asset       -201 JPY
```

This is totally legit, however, if you apply banker's round,
two expenses are evaluated as 100 JPY and there will be 1 JPY
unbalanced.