### PR TITLE
Add explicit lifetime in the type path, and use consistent lifetime.

### DIFF
--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -317,7 +317,7 @@ where
     }
 }
 
-fn amount_with_sign(amount: &OwnedAmount, sign: Decimal) -> BorrowedAmount {
+fn amount_with_sign(amount: &'_ OwnedAmount, sign: Decimal) -> BorrowedAmount<'_> {
     let mut ret = amount.into_borrowed();
     ret.value.set_sign_positive(sign.is_sign_positive());
     ret
@@ -364,7 +364,7 @@ mod tests {
         );
     }
 
-    fn syntax_amount(value: PrettyDecimal, commodity: &str) -> syntax::expr::ValueExpr {
+    fn syntax_amount(value: PrettyDecimal, commodity: &'_ str) -> syntax::expr::ValueExpr<'_> {
         syntax::expr::Amount {
             value,
             commodity: commodity.into(),

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -85,7 +85,7 @@ mod tests {
 
     use syntax::plain::LedgerEntry;
 
-    fn parse_ledger_into(input: &str) -> Vec<(ParsedContext, LedgerEntry)> {
+    fn parse_ledger_into(input: &'_ str) -> Vec<(ParsedContext<'_>, LedgerEntry<'_>)> {
         let r: Result<Vec<(ParsedContext, LedgerEntry)>, ParseError> =
             parse_ledger(&ParseOptions::default(), input).collect();
         match r {

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -539,7 +539,7 @@ mod tests {
         syntax::tracked::TrackedSpan,
     };
 
-    fn parse_transaction(input: &str) -> syntax::tracked::Transaction {
+    fn parse_transaction(input: &'_ str) -> syntax::tracked::Transaction<'_> {
         let (_, ret) = expect_parse_ok(parse::transaction::transaction, input);
         ret
     }


### PR DESCRIPTION
Followed warning message.