### PR TITLE
Use dunce canonicalization instead of std::fs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +983,7 @@ dependencies = [
  "criterion",
  "ctor",
  "derive-where",
+ "dunce",
  "env_logger",
  "glob",
  "indoc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ bounded-static = { version = "0.8", default-features = false, features = ["deriv
 bumpalo.workspace = true
 chrono.workspace = true
 derive-where = "1.2"
+dunce = "1.0.5"
 glob = "0.3.2"
 itoa = "1"
 log.workspace = true

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -155,7 +155,7 @@ pub struct ProdFileSystem;
 
 impl FileSystem for ProdFileSystem {
     fn canonicalize_path<'a>(path: &'a Path) -> Cow<'a, Path> {
-        std::fs::canonicalize(path)
+        dunce::canonicalize(path)
             .map(|x| {
                 if x == path {
                     Cow::Borrowed(path)
@@ -300,20 +300,12 @@ mod tests {
             testdata_dir.display()
         );
         testdata_dir.push("testdata/load");
-        let root = testdata_dir
-            .join("recursive.ledger")
-            .canonicalize()
-            .unwrap();
-        let child1 = testdata_dir.join("child1.ledger").canonicalize().unwrap();
-        let child2 = testdata_dir
-            .join("sub/child2.ledger")
-            .canonicalize()
-            .unwrap();
-        let child3 = testdata_dir.join("child3.ledger").canonicalize().unwrap();
-        let child4 = testdata_dir
-            .join("sub/child4.ledger")
-            .canonicalize()
-            .unwrap();
+        testdata_dir = dunce::canonicalize(testdata_dir).unwrap();
+        let root = testdata_dir.join("recursive.ledger");
+        let child1 = testdata_dir.join("child1.ledger");
+        let child2 = testdata_dir.join("sub").join("child2.ledger");
+        let child3 = testdata_dir.join("child3.ledger");
+        let child4 = testdata_dir.join("sub").join("child4.ledger");
         let want = parse_static_ledger_entry(&[
             (
                 &root,


### PR DESCRIPTION
https://crates.io/crates/dunce allows to canonicalize Windows file path without using UNC path which is not popular.

This closes #266.