### PR TITLE
Canonicalize Windows path on import matching to ensure import works.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "shlex",
+ "soft-canonicalize",
  "strum",
  "thiserror",
  "winnow",
@@ -1669,6 +1670,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "soft-canonicalize"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d773c1dc6044d8c2065e16808d6aed9d840c172a8b6c3295658be1138b3b53b"
+dependencies = [
+ "dunce",
+]
 
 [[package]]
 name = "strsim"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,6 +35,7 @@ serde_yaml = "0.9.34"
 strum.workspace = true
 thiserror.workspace = true
 winnow.workspace = true
+soft-canonicalize = { version = "0.4.5", features = [ "dunce" ] }
 
 [dev-dependencies]
 okane-golden = { version = "0.1.0", path = "../golden" }


### PR DESCRIPTION
We use `PathBufExt::from_slash` for the `entry.path` to use back-slash for separator. However, user given path might use slash and passed to `select()`. thus we have to unify both path to use system separator with `soft_canonicalize`. (Note `fs::canonicalize` is safe to use, but chose to use soft_canonicalize for unit tests.)