### PR TITLE
feat: Add commodity matcher

### DIFF
--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -95,13 +95,14 @@ fn extract_transaction(
     let rate = resolver
         .extract(FieldKey::Rate, r)?
         .map_or_else(|| Ok(None), |s| str_to_comma_decimal(&s))?;
-    // TODO: remove this temporary record.
-    let tmp_record = record::Record {
+    // this temporary record exists to handle the error on wrong template outside the extractor.
+    let record = record::Record {
         payee: &original_payee,
         category: category.as_deref(),
+        commodity: &commodity.clone(),
         secondary_commodity: secondary_commodity.as_deref(),
     };
-    let fragment = extractor.extract(&tmp_record);
+    let fragment = extractor.extract(&record);
     let payee = fragment.payee.unwrap_or(&original_payee);
     let fragment = extract::Fragment {
         payee: Some(payee),

--- a/cli/src/import/csv/record.rs
+++ b/cli/src/import/csv/record.rs
@@ -5,6 +5,7 @@ use crate::import::extract::{self, StrField};
 pub struct Record<'a> {
     pub payee: &'a str,
     pub category: Option<&'a str>,
+    pub commodity: &'a str,
     pub secondary_commodity: Option<&'a str>,
 }
 
@@ -24,6 +25,7 @@ impl extract::EntityFormat for CsvFormat {
         match field {
             StrField::Payee => true,
             StrField::Category => true,
+            StrField::Commodity => true,
             StrField::SecondaryCommodity => true,
             StrField::Camt(_) => false,
         }
@@ -35,6 +37,7 @@ impl<'a> extract::Entity<'a> for &'a Record<'a> {
         match field {
             StrField::Payee => Some(self.payee),
             StrField::Category => self.category,
+            StrField::Commodity => Some(self.commodity),
             StrField::SecondaryCommodity => self.secondary_commodity,
             StrField::Camt(_) => None,
         }

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -83,6 +83,7 @@ pub trait Entity<'a>: Copy {
 pub enum StrField {
     Payee,
     Category,
+    Commodity,
     SecondaryCommodity,
     /// Camt specific field.
     /// With this approach other format (CSV) can avoid skipping all camt arm one by one.

--- a/cli/src/import/iso_camt053.rs
+++ b/cli/src/import/iso_camt053.rs
@@ -192,8 +192,10 @@ impl extract::EntityFormat for CamtFormat {
     fn has_str_field(&self, field: StrField) -> bool {
         match field {
             StrField::Camt(_) => true,
+            StrField::Payee => false,
+            StrField::Category => false,
+            StrField::Commodity => true,
             StrField::SecondaryCommodity => true,
-            _ => false,
         }
     }
 }
@@ -243,12 +245,13 @@ impl<'a> extract::Entity<'a> for CamtEntity<'a> {
                     .and_then(|t| t.additional_info.as_ref())
                     .map(|ai| ai.as_str()),
             },
+            StrField::Commodity => Some(entry.amount.currency.as_str()),
             StrField::SecondaryCommodity => transaction
                 .as_ref()
                 .and_then(|x| x.amount_details.as_ref())
                 .and_then(|x| x.transaction.as_ref())
                 .map(|x| x.amount.currency.as_str()),
-            _ => None,
+            StrField::Payee | StrField::Category => None,
         }
     }
 }


### PR DESCRIPTION
Now matcher can filter entity with secondary_commodity. Why not (primary) commodity?