### PR TITLE
refact: Renamed UpToDate conversion strategy field to today.

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -475,7 +475,7 @@ impl EvalOptions {
         let strategy = if self.historical {
             query::ConversionStrategy::Historical
         } else {
-            query::ConversionStrategy::UpToDate { now: self.today }
+            query::ConversionStrategy::UpToDate { today: self.today }
         };
         Ok(Some(query::Conversion { strategy, target }))
     }

--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -190,7 +190,7 @@ fn query_balance(c: &mut Criterion) {
             date_range: report::query::DateRange::default(),
             conversion: Some(report::query::Conversion {
                 strategy: report::query::ConversionStrategy::UpToDate {
-                    now: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
+                    today: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
                 },
                 target: usd,
             }),


### PR DESCRIPTION
It's not `now` (timestamp), but `today` (just a yyyy/mm/dd tuple).