### PR TITLE
Recover logging on unspecified account import

### DIFF
--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -167,6 +167,9 @@ impl<'a> Fragment<'a> {
                 "unknown payee"
             }
         };
+        if self.account.is_none() {
+            log::warn!("account not set @ {}", position());
+        }
         let mut txn = single_entry::Txn::new(date, payee, amount);
         txn.code_option(self.code.map(|x| x.into()))
             .dest_account_option(self.account);


### PR DESCRIPTION
The log was accidentally removed in:
https://github.com/xkikeg/okane/pull/292
https://github.com/xkikeg/okane/commit/1d7100fded5c43dc7a274249fbb960895f1a6bd9