### PR TITLE
Added `template: true` to allow declaring a config just a template.

### DIFF
--- a/testdata/import/test_config.yml
+++ b/testdata/import/test_config.yml
@@ -10,6 +10,7 @@ output:
     #   default:
     #     significant_digits: 5
     #     scale: 3 # which do we want?
+template: true
 ---
 path: index_amount.csv
 encoding: UTF-8


### PR DESCRIPTION
If user adds catch-all blanket config, it's problematic as all files would have essentially matched config and led some error missing fields.
To avoid that, introduced `template` field so to declare a config isn't a leaf config, and thus needs to be merged later.

Some alternative considered:

1. Considered `leaf: true`, but `template` must be rare and explicit.
1. Considered not allowing template back to leaf. This might be indeed good as we're currently ordering the config merge order depending on the matched path length and the last one must be non-template, others must be template.
However, eventually I might introduce more complicated (like mixin). (Of course, mixin can be `mixin: true` instead of template...)

This fixes #323.