### PR TITLE
refact: Use String instead of &'static str for ImportError::InvalidConfig.

### DIFF
--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -117,18 +117,20 @@ pub struct Config {
 impl TryFrom<ConfigFragment> for Config {
     type Error = ImportError;
     fn try_from(value: ConfigFragment) -> Result<Self, Self::Error> {
-        let encoding = value
-            .encoding
-            .ok_or(ImportError::InvalidConfig("no encoding specified"))?;
-        let account = value
-            .account
-            .ok_or(ImportError::InvalidConfig("no account specified"))?;
-        let account_type = value
-            .account_type
-            .ok_or(ImportError::InvalidConfig("no account_type specified"))?;
+        let encoding = value.encoding.ok_or(ImportError::InvalidConfig(
+            "no encoding specified".to_string(),
+        ))?;
+        let account = value.account.ok_or(ImportError::InvalidConfig(
+            "no account specified".to_string(),
+        ))?;
+        let account_type = value.account_type.ok_or(ImportError::InvalidConfig(
+            "no account_type specified".to_string(),
+        ))?;
         let commodity = value
             .commodity
-            .ok_or(ImportError::InvalidConfig("no commodity specified"))?
+            .ok_or(ImportError::InvalidConfig(
+                "no commodity specified".to_string(),
+            ))?
             .into();
         let format = value.format.unwrap_or_default();
         let output = value.output.unwrap_or_default();

--- a/cli/src/import/csv/field.rs
+++ b/cli/src/import/csv/field.rs
@@ -149,11 +149,15 @@ impl FieldResolver {
         let date = ki
             .get(&config::FieldKey::Date)
             .cloned()
-            .ok_or(ImportError::InvalidConfig("no Date field specified"))?;
+            .ok_or(ImportError::InvalidConfig(
+                "no Date field specified".to_string(),
+            ))?;
         let payee = ki
             .get(&config::FieldKey::Payee)
             .cloned()
-            .ok_or(ImportError::InvalidConfig("no Payee field specified"))?;
+            .ok_or(ImportError::InvalidConfig(
+                "no Payee field specified".to_string(),
+            ))?;
         let amount = ki.get(&config::FieldKey::Amount).cloned();
         let credit = ki.get(&config::FieldKey::Credit).cloned();
         let debit = ki.get(&config::FieldKey::Debit).cloned();
@@ -166,7 +170,7 @@ impl FieldResolver {
                     debit: d,
                 })
                 .ok_or(ImportError::InvalidConfig(
-                    "either amount or credit/debit pair should be set",
+                    "either amount or credit/debit pair should be set".to_string(),
                 )),
         }?;
         Ok(FieldResolver {

--- a/cli/src/import/error.rs
+++ b/cli/src/import/error.rs
@@ -15,10 +15,10 @@ pub enum ImportError {
     YAML(#[from] serde_yaml::Error),
     #[error("failed to parse VISECA file: {0}")]
     Viseca(String),
-    #[error("invalid flag {0}")]
+    #[error("invalid flag: {0}")]
     InvalidFlag(&'static str),
-    #[error("invalid config {0}")]
-    InvalidConfig(&'static str),
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
     #[error("invalid datetime")]
     InvalidDatetime(#[from] chrono::ParseError),
     #[error("invalid decimal")]

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -309,7 +309,7 @@ impl MatchAndExpr {
         let matchers = matchers?;
         if matchers.is_empty() {
             Err(ImportError::InvalidConfig(
-                "empty field matcher is not allowed",
+                "empty field matcher is not allowed".to_string(),
             ))
         } else {
             Ok(MatchAndExpr(matchers))

--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -287,7 +287,7 @@ impl Txn {
                 .as_ref()
                 .map(|o| Cow::Borrowed(o.as_str()))
                 .ok_or(ImportError::InvalidConfig(
-                    "config should have operator to have charge",
+                    "config should have operator to have charge".to_string(),
                 ))
         };
         let post_cleared = self.clear_state.unwrap_or(match &self.dest_account {


### PR DESCRIPTION
This is more flexible, and nobody cares about the regression for just one String allocation on error path.

Eventually I'd make ImportError into simple struct with kind, message and cause.