### PR TITLE
Allow specifying file_type in the config.

### DIFF
--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -10,7 +10,7 @@ pub use commodity::{
     AccountCommoditySpec, CommodityConversionSpec, ConversionAmountMode, ConversionRateMode,
     HiddenFee, HiddenFeeCondition, HiddenFeeRate,
 };
-pub use format::{FieldKey, FieldPos, FormatSpec, RowOrder, SkipSpec, TemplateField};
+pub use format::{FieldKey, FieldPos, FileType, FormatSpec, RowOrder, SkipSpec, TemplateField};
 pub use output::{
     CommodityFormatStyle, OutputCommodityDetailsSpec, OutputCommoditySpec, OutputSpec,
 };

--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -273,6 +273,7 @@ mod tests {
             "",
             &config::Config {
                 format: config::FormatSpec {
+                    file_type: None,
                     date: "%Y/%m/%d".to_string(),
                     fields: hashmap! {
                         FieldKey::Date => FieldPos::Index(OneBasedU32::from_one_based(1).unwrap()),

--- a/testdata/import/test_config.yml
+++ b/testdata/import/test_config.yml
@@ -250,6 +250,8 @@ rewrite:
 ---
 path: iso_camt.xml
 account: Assets:Okane Bank
+format:
+  file_type: ISO_CAMT053
 rewrite:
   - matcher:
       payee: "Herr.*Frau.*"
@@ -268,6 +270,8 @@ encoding: UTF-8
 account: Liabilities:Okane Card
 account_type: liability
 operator: Okane Card (fee)
+format:
+  file_type: VISECA
 commodity:
   primary: CHF
   hidden_fee:


### PR DESCRIPTION
Implements and closes https://github.com/xkikeg/okane/issues/319.

Precisely, this PR **forces** to set file_type for ISO Camt053 and Viseca format as well.