### PR TITLE
Refactoring: simpler ImportError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,9 +1267,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "one-based"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38cbb1b90ade2dc7429ca739c18668080d494d460dee533cd777b8166f8eb9e"
+checksum = "23420c0b26e8bdcdc4f30be84af23819213c9a4c5262b27b6dd8c567765b7433"
 dependencies = [
  "serde",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,7 @@ encoding_rs_io = "0.1.7"
 env_logger.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-one-based = { version = "0.4.0", features = ["serde"] }
+one-based = { version = "1.0.0", features = ["serde"] }
 path-slash = "0.2.1"
 pretty_decimal.workspace = true
 quick-xml = { version = "0.38", features = [ "serialize" ] }

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -13,7 +13,7 @@ use okane_core::{load, report};
 
 use crate::build::CLAP_LONG_VERSION;
 use crate::format;
-use crate::import::{self, ImportError};
+use crate::import;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -29,6 +29,8 @@ pub enum Error {
     Report(#[from] report::ReportError),
     #[error("failed to query")]
     Query(#[from] query::QueryError),
+    #[error("{0}")]
+    Other(String),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -408,10 +410,10 @@ impl EvalOptions {
 
     // TODO: Use anyhow::Error.
     // https://github.com/xkikeg/okane/issues/310
-    fn to_date_range(&self) -> Result<query::DateRange, ImportError> {
+    fn to_date_range(&self) -> Result<query::DateRange, Error> {
         let end = if self.current {
             let tomorrow = self.today.succ_opt().ok_or_else(|| {
-                ImportError::Other(format!("cannot compute one day after today {}", self.today))
+                Error::Other(format!("cannot compute one day after today {}", self.today))
             })?;
             Some(tomorrow)
         } else {

--- a/cli/src/import/config/commodity.rs
+++ b/cli/src/import/config/commodity.rs
@@ -11,7 +11,7 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::import::amount::OwnedAmount;
 
-use super::merge::{merge_non_empty, Merge};
+use super::merge::{Merge, merge_non_empty};
 
 /// CommodityConfig contains either primary commodity string, or more complex CommoditySpec.
 #[derive(Debug, PartialEq, Eq, Serialize, Clone)]

--- a/cli/src/import/config/format.rs
+++ b/cli/src/import/config/format.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use one_based::OneBasedU32;
 use serde::{
-    de::{self, value::MapAccessDeserializer},
     Deserialize, Serialize,
+    de::{self, value::MapAccessDeserializer},
 };
 
-use super::merge::{merge_non_empty, Merge};
+use super::merge::{Merge, merge_non_empty};
 
 /// FormatSpec describes the several format used in import target.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -87,8 +87,9 @@ pub enum RowOrder {
 }
 
 /// Key represents the field abstracted way.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum FieldKey {
     /// Date of the transaction.
     Date,
@@ -245,7 +246,7 @@ mod tests {
     mod deserialize_field_pos {
         use super::*;
 
-        use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
+        use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
 
         #[test]
         fn positive_integer_succeeds() {

--- a/cli/src/import/config/merge.rs
+++ b/cli/src/import/config/merge.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map, HashMap},
+    collections::{HashMap, hash_map},
     hash::Hash,
 };
 
@@ -42,11 +42,7 @@ impl<K: Eq + Hash, T: Merge> Merge for HashMap<K, T> {
 /// so that to choose non-empty one.
 macro_rules! merge_non_empty {
     ($a:expr, $b:expr) => {
-        if !$b.is_empty() {
-            $b
-        } else {
-            $a
-        }
+        if !$b.is_empty() { $b } else { $a }
     };
 }
 

--- a/cli/src/import/error.rs
+++ b/cli/src/import/error.rs
@@ -1,36 +1,176 @@
-use csv::Error as CsvError;
-use regex::Error as RegexError;
+use std::error::Error;
+use std::fmt::Display;
 
-use super::template;
+/// Error kind of the [`ImportError`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ImportErrorKind {
+    /// Failed to read source file.
+    SourceFileReadFailed,
+    /// Failed to read config file.
+    ConfigFileReadFailed,
+    /// Source file format is unknown.
+    UnknownSourceFileFormat,
+    /// Source is invalid.
+    InvalidSource,
+    /// Config is invalid.
+    InvalidConfig,
+    /// Config entry isn't found.
+    ConfigNotFound,
+    /// Failed to emit output.
+    OutputFailed,
+    /// Unimplemented feature.
+    Unimplemented,
+    /// Internal failure, most likely a bug.
+    Internal,
+}
 
-#[derive(thiserror::Error, Debug)]
-pub enum ImportError {
-    #[error("failed to perform IO")]
-    IO(#[from] std::io::Error),
-    #[error("failed to parse CSV")]
-    Csv(#[from] CsvError),
-    #[error("failed to parse XML")]
-    Xml(#[from] quick_xml::DeError),
-    #[error("failed to parse YAML")]
-    Yaml(#[from] serde_yaml::Error),
-    #[error("failed to parse VISECA file: {0}")]
-    Viseca(String),
-    #[error("invalid config: {0}")]
-    InvalidConfig(String),
-    #[error("invalid datetime")]
-    InvalidDatetime(#[from] chrono::ParseError),
-    #[error("invalid decimal")]
-    InvalidDecimal(#[from] rust_decimal::Error),
-    #[error("invalid regex")]
-    InvalidRegex(#[from] RegexError),
-    #[error("failed to parse template")]
-    TemplateParseFailed(#[from] template::ParseError),
-    #[error("failed to render template")]
-    TemplateRenderFailed(#[from] template::RenderError),
-    #[error("other error: {0}")]
-    Other(String),
-    #[error("unimplemented: {0}")]
-    Unimplemented(&'static str),
-    #[error("unknown format")]
-    UnknownFormat,
+impl ImportErrorKind {
+    /// Returns `&str` for [`ImportErrorKind`].
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ImportErrorKind::SourceFileReadFailed => "failed to read source file",
+            ImportErrorKind::ConfigFileReadFailed => "failed to read config file",
+            ImportErrorKind::UnknownSourceFileFormat => "unknown source file format",
+            ImportErrorKind::InvalidSource => "invalid source",
+            ImportErrorKind::InvalidConfig => "invalid config",
+            ImportErrorKind::ConfigNotFound => "corresponding config not found",
+            ImportErrorKind::OutputFailed => "output failed",
+            ImportErrorKind::Unimplemented => "unimplemented",
+            ImportErrorKind::Internal => "internal error",
+        }
+    }
+}
+
+impl Display for ImportErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error to represent a failure in import.
+#[derive(Debug)]
+pub struct ImportError {
+    kind: ImportErrorKind,
+    message: String,
+    source: Option<Box<dyn Error>>,
+}
+
+impl ImportError {
+    /// Creates a new [`ImportError`].
+    pub fn new(kind: ImportErrorKind, message: String) -> Self {
+        Self {
+            kind,
+            message,
+            source: None,
+        }
+    }
+
+    /// Creates a new [`ImportError`] with source.
+    pub fn with_source<E: Error + 'static>(
+        kind: ImportErrorKind,
+        message: String,
+        source: E,
+    ) -> Self {
+        Self {
+            kind,
+            message,
+            source: Some(source.into()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn error_kind(&self) -> ImportErrorKind {
+        self.kind
+    }
+
+    #[cfg(test)]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.kind, self.message)
+    }
+}
+
+impl Error for ImportError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(Box::as_ref)
+    }
+}
+
+pub trait LazyMessage {
+    fn into(self) -> String;
+}
+
+impl<'a> LazyMessage for &'a str {
+    fn into(self) -> String {
+        self.to_string()
+    }
+}
+
+impl<F: FnOnce() -> String> LazyMessage for F {
+    fn into(self) -> String {
+        self()
+    }
+}
+
+mod private {
+    pub trait IntoImportErrSeal {}
+    pub trait AnnotateImportErrorSeal {}
+}
+
+/// Adds method [`into_import_err`] as a convenient method.
+pub trait IntoImportError<T>: private::IntoImportErrSeal {
+    fn into_import_err<M: LazyMessage>(
+        self,
+        kind: ImportErrorKind,
+        message: M,
+    ) -> Result<T, ImportError>;
+}
+
+impl<T, E> private::IntoImportErrSeal for Result<T, E> {}
+
+impl<T, E> IntoImportError<T> for Result<T, E>
+where
+    E: Error + 'static,
+{
+    fn into_import_err<M: LazyMessage>(
+        self,
+        kind: ImportErrorKind,
+        message: M,
+    ) -> Result<T, ImportError> {
+        self.map_err(|e| ImportError::with_source(kind, message.into(), e))
+    }
+}
+
+impl<T> private::IntoImportErrSeal for Option<T> {}
+
+impl<T> IntoImportError<T> for Option<T> {
+    fn into_import_err<M: LazyMessage>(
+        self,
+        kind: ImportErrorKind,
+        message: M,
+    ) -> Result<T, ImportError> {
+        self.ok_or_else(|| ImportError::new(kind, message.into()))
+    }
+}
+
+/// Allows annotating the given [`ImportError`].
+pub trait AnnotateImportError<T>: private::AnnotateImportErrorSeal {
+    fn annotate<F: FnOnce() -> Msg, Msg: Display>(self, prefix: F) -> Self;
+}
+
+impl<T> private::AnnotateImportErrorSeal for Result<T, ImportError> {}
+
+impl<T> AnnotateImportError<T> for Result<T, ImportError> {
+    fn annotate<F: FnOnce() -> Msg, Msg: Display>(self, prefix: F) -> Self {
+        self.map_err(|e| ImportError {
+            kind: e.kind,
+            message: format!("{}: {}", prefix(), e.message),
+            source: e.source,
+        })
+    }
 }

--- a/cli/src/import/extract.rs
+++ b/cli/src/import/extract.rs
@@ -8,7 +8,7 @@ use okane_core::syntax::ClearState;
 
 use super::amount::OwnedAmount;
 use super::config;
-use super::error::ImportError;
+use super::error::{ImportError, ImportErrorKind};
 use super::iso_camt053::xmlnode;
 use super::single_entry;
 
@@ -106,7 +106,8 @@ pub trait Entity<'a>: Copy {
 }
 
 /// String fields.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum StrField {
     Payee,
     Category,
@@ -308,7 +309,8 @@ impl MatchAndExpr {
             .collect();
         let matchers = matchers?;
         if matchers.is_empty() {
-            Err(ImportError::InvalidConfig(
+            Err(ImportError::new(
+                ImportErrorKind::InvalidConfig,
                 "empty field matcher is not allowed".to_string(),
             ))
         } else {

--- a/cli/src/import/extract/testing.rs
+++ b/cli/src/import/extract/testing.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{xmlnode, Entity, EntityFormat, StrField};
+use super::{Entity, EntityFormat, StrField, xmlnode};
 
 /// [`EntityFormat`] for unit tests.
 #[derive(Debug, Default)]

--- a/cli/src/import/iso_camt053/xmlnode.rs
+++ b/cli/src/import/iso_camt053/xmlnode.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, marker::PhantomData};
 
 use rust_decimal::Decimal;
 use serde::{
-    de::value::{CowStrDeserializer, MapAccessDeserializer},
     Deserialize, Serialize,
+    de::value::{CowStrDeserializer, MapAccessDeserializer},
 };
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/cli/src/import/viseca/format.rs
+++ b/cli/src/import/viseca/format.rs
@@ -9,6 +9,7 @@ use crate::import::{
 /// Entry represents one entry in Viseca PDF.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Entry {
+    /// Initial line number, 1-origin.
     pub line_count: usize,
     pub date: NaiveDate,
     pub effective_date: NaiveDate,


### PR DESCRIPTION
`ImportError` can be simpler and organized.

Related to #310 while the the task itself more focuses on the `cmd::Error`.