### PR TITLE
refact: Reordered Amount / SingleAmount / PostingAmount from_value(s)? args.

### DIFF
--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -494,7 +494,7 @@ impl<'a> PostingAmount<'a> {
             None => (self.amount.value, self.amount.commodity),
             Some(rate) => (self.amount.value * rate.value, rate.commodity),
         };
-        report::SingleAmount::from_value(v, ctx.commodity_store_mut().ensure(c))
+        report::SingleAmount::from_value(ctx.commodity_store_mut().ensure(c), v)
     }
 
     /// Gets the syntax version of posting.

--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -157,13 +157,13 @@ mod tests {
         let updated = balance
             .add_posting_amount(
                 ctx.accounts.ensure("Expenses"),
-                PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+                PostingAmount::from_value(ctx.commodities.ensure("JPY"), dec!(1000)),
             )
             .clone();
 
         assert_eq!(
             updated,
-            Amount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
+            Amount::from_value(ctx.commodities.ensure("JPY"), dec!(1000))
         );
         assert_eq!(
             balance.get(&ctx.accounts.ensure("Expenses")),
@@ -173,7 +173,7 @@ mod tests {
         let updated = balance
             .add_posting_amount(
                 ctx.accounts.ensure("Expenses"),
-                PostingAmount::from_value(dec!(-1000), ctx.commodities.ensure("JPY")),
+                PostingAmount::from_value(ctx.commodities.ensure("JPY"), dec!(-1000)),
             )
             .clone();
 
@@ -193,15 +193,15 @@ mod tests {
         let expenses = ctx.accounts.ensure("Expenses");
         let jpy = ctx.commodities.insert("JPY").unwrap();
         let prev = balance
-            .set_partial(&ctx, expenses, PostingAmount::from_value(dec!(1000), jpy))
+            .set_partial(&ctx, expenses, PostingAmount::from_value(jpy, dec!(1000)))
             .unwrap();
 
         // Note it won't be PostingAmount::zero(),
         // as set_partial is called with commodity amount.
-        assert_eq!(prev, PostingAmount::from_value(dec!(0), jpy));
+        assert_eq!(prev, PostingAmount::from_value(jpy, dec!(0)));
         assert_eq!(
             balance.get(&expenses),
-            Some(&Amount::from_value(dec!(1000), jpy))
+            Some(&Amount::from_value(jpy, dec!(1000)))
         );
     }
 
@@ -210,28 +210,22 @@ mod tests {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
         let mut balance = Balance::default();
+        let jpy = ctx.commodities.ensure("JPY");
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            PostingAmount::from_value(jpy, dec!(1000)),
         );
 
         let expenses = ctx.accounts.ensure("Expenses");
-        let jpy = ctx.commodities.ensure("JPY");
 
         let prev = balance
-            .set_partial(&ctx, expenses, PostingAmount::from_value(dec!(-1000), jpy))
+            .set_partial(&ctx, expenses, PostingAmount::from_value(jpy, dec!(-1000)))
             .unwrap();
 
-        assert_eq!(
-            prev,
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
-        );
+        assert_eq!(prev, PostingAmount::from_value(jpy, dec!(1000)));
         assert_eq!(
             balance.get(&ctx.accounts.ensure("Expenses")),
-            Some(&Amount::from_value(
-                dec!(-1000),
-                ctx.commodities.ensure("JPY")
-            ))
+            Some(&Amount::from_value(jpy, dec!(-1000)))
         );
     }
 
@@ -240,32 +234,27 @@ mod tests {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
         let mut balance = Balance::default();
+        let jpy = ctx.commodities.ensure("JPY");
+        let chf = ctx.commodities.ensure("CHF");
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            PostingAmount::from_value(jpy, dec!(1000)),
         );
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF")),
+            PostingAmount::from_value(chf, dec!(200)),
         );
 
         let expenses = ctx.accounts.ensure("Expenses");
-        let chf = ctx.commodities.ensure("CHF");
 
         let prev = balance
-            .set_partial(&ctx, expenses, PostingAmount::from_value(dec!(100), chf))
+            .set_partial(&ctx, expenses, PostingAmount::from_value(chf, dec!(100)))
             .unwrap();
 
-        assert_eq!(
-            prev,
-            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF"))
-        );
+        assert_eq!(prev, PostingAmount::from_value(chf, dec!(200)));
         assert_eq!(
             balance.get(&ctx.accounts.ensure("Expenses")),
-            Some(&Amount::from_values([
-                (dec!(1000), ctx.commodities.ensure("JPY")),
-                (dec!(100), ctx.commodities.ensure("CHF")),
-            ]))
+            Some(&Amount::from_values([(jpy, dec!(1000)), (chf, dec!(100)),]))
         );
     }
 
@@ -293,9 +282,10 @@ mod tests {
         let arena = Bump::new();
         let mut ctx = ReportContext::new(&arena);
         let mut balance = Balance::default();
+        let jpy = ctx.commodities.ensure("JPY");
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            PostingAmount::from_value(jpy, dec!(1000)),
         );
 
         let expenses = ctx.accounts.ensure("Expenses");
@@ -304,10 +294,7 @@ mod tests {
             .set_partial(&ctx, expenses, PostingAmount::zero())
             .unwrap();
 
-        assert_eq!(
-            prev,
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY"))
-        );
+        assert_eq!(prev, PostingAmount::from_value(jpy, dec!(1000)));
         assert_eq!(
             balance.get(&ctx.accounts.ensure("Expenses")),
             Some(&Amount::zero())
@@ -321,11 +308,11 @@ mod tests {
         let mut balance = Balance::default();
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(1000), ctx.commodities.ensure("JPY")),
+            PostingAmount::from_value(ctx.commodities.ensure("JPY"), dec!(1000)),
         );
         balance.add_posting_amount(
             ctx.accounts.ensure("Expenses"),
-            PostingAmount::from_value(dec!(200), ctx.commodities.ensure("CHF")),
+            PostingAmount::from_value(ctx.commodities.ensure("CHF"), dec!(200)),
         );
 
         let expenses = ctx.accounts.ensure("Expenses");

--- a/core/src/report/eval/posting_amount.rs
+++ b/core/src/report/eval/posting_amount.rs
@@ -89,10 +89,10 @@ impl<'ctx> PostingAmount<'ctx> {
 
     /// Constructs an instance with single commodity.
     pub(crate) fn from_value(
-        value: rust_decimal::Decimal,
         commodity: crate::report::commodity::CommodityTag<'ctx>,
+        value: rust_decimal::Decimal,
     ) -> Self {
-        PostingAmount::Single(SingleAmount::from_value(value, commodity))
+        PostingAmount::Single(SingleAmount::from_value(commodity, value))
     }
 }
 
@@ -116,8 +116,8 @@ mod tests {
         assert_eq!(PostingAmount::Zero, -PostingAmount::zero());
 
         assert_eq!(
-            PostingAmount::from_value(dec!(5), jpy),
-            -PostingAmount::from_value(dec!(-5), jpy),
+            PostingAmount::from_value(jpy, dec!(5)),
+            -PostingAmount::from_value(jpy, dec!(-5)),
         );
     }
 
@@ -129,16 +129,16 @@ mod tests {
         let jpy = ctx.commodities.insert("JPY").unwrap();
 
         assert_eq!(
-            PostingAmount::from_value(dec!(5), jpy),
-            PostingAmount::from_value(dec!(5), jpy)
+            PostingAmount::from_value(jpy, dec!(5)),
+            PostingAmount::from_value(jpy, dec!(5))
                 .check_add(PostingAmount::zero())
                 .unwrap(),
         );
 
         assert_eq!(
-            PostingAmount::from_value(dec!(5), jpy),
+            PostingAmount::from_value(jpy, dec!(5)),
             PostingAmount::zero()
-                .check_add(PostingAmount::from_value(dec!(5), jpy))
+                .check_add(PostingAmount::from_value(jpy, dec!(5)))
                 .unwrap(),
         );
     }
@@ -155,7 +155,7 @@ mod tests {
             "1.23 JPY",
             format!(
                 "{}",
-                PostingAmount::from_value(dec!(1.23), jpy).as_display(&ctx)
+                PostingAmount::from_value(jpy, dec!(1.23)).as_display(&ctx)
             )
         );
     }

--- a/core/src/report/eval/single_amount.rs
+++ b/core/src/report/eval/single_amount.rs
@@ -12,8 +12,8 @@ use super::error::EvalError;
 /// Amount with only one commodity.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct SingleAmount<'ctx> {
-    pub(crate) value: Decimal,
     pub(crate) commodity: CommodityTag<'ctx>,
+    pub(crate) value: Decimal,
 }
 
 impl Neg for SingleAmount<'_> {
@@ -41,7 +41,7 @@ impl Mul<Decimal> for SingleAmount<'_> {
 impl<'ctx> SingleAmount<'ctx> {
     /// Constructs an instance with single commodity.
     #[inline]
-    pub fn from_value(value: Decimal, commodity: CommodityTag<'ctx>) -> Self {
+    pub fn from_value(commodity: CommodityTag<'ctx>, value: Decimal) -> Self {
         Self { value, commodity }
     }
 
@@ -151,8 +151,8 @@ mod tests {
         let jpy = ctx.commodities.insert("JPY").unwrap();
 
         assert_eq!(
-            SingleAmount::from_value(dec!(-5), jpy),
-            -SingleAmount::from_value(dec!(5), jpy)
+            SingleAmount::from_value(jpy, dec!(-5)),
+            -SingleAmount::from_value(jpy, dec!(5))
         );
     }
 
@@ -166,8 +166,8 @@ mod tests {
 
         assert_eq!(
             Err(EvalError::UnmatchingCommodities(jpy, chf)),
-            SingleAmount::from_value(dec!(10), jpy)
-                .check_add(SingleAmount::from_value(dec!(20), chf))
+            SingleAmount::from_value(jpy, dec!(10))
+                .check_add(SingleAmount::from_value(chf, dec!(20)))
         );
     }
 
@@ -179,9 +179,9 @@ mod tests {
         let jpy = ctx.commodities.insert("JPY").unwrap();
 
         assert_eq!(
-            SingleAmount::from_value(dec!(-10), jpy),
-            SingleAmount::from_value(dec!(10), jpy)
-                .check_add(SingleAmount::from_value(dec!(-20), jpy))
+            SingleAmount::from_value(jpy, dec!(-10)),
+            SingleAmount::from_value(jpy, dec!(10))
+                .check_add(SingleAmount::from_value(jpy, dec!(-20)))
                 .unwrap()
         );
     }
@@ -196,8 +196,8 @@ mod tests {
 
         assert_eq!(
             Err(EvalError::UnmatchingCommodities(jpy, chf)),
-            SingleAmount::from_value(dec!(10), jpy)
-                .check_sub(SingleAmount::from_value(dec!(0), chf))
+            SingleAmount::from_value(jpy, dec!(10))
+                .check_sub(SingleAmount::from_value(chf, dec!(0)))
         );
     }
 
@@ -209,9 +209,9 @@ mod tests {
         let jpy = ctx.commodities.insert("JPY").unwrap();
 
         assert_eq!(
-            SingleAmount::from_value(dec!(5), jpy),
-            SingleAmount::from_value(dec!(10), jpy)
-                .check_sub(SingleAmount::from_value(dec!(5), jpy))
+            SingleAmount::from_value(jpy, dec!(5)),
+            SingleAmount::from_value(jpy, dec!(10))
+                .check_sub(SingleAmount::from_value(jpy, dec!(5)))
                 .unwrap()
         );
     }
@@ -225,7 +225,7 @@ mod tests {
 
         assert_eq!(
             "1.20 USD".to_string(),
-            SingleAmount::from_value(dec!(1.20), usd)
+            SingleAmount::from_value(usd, dec!(1.20))
                 .as_display(&ctx)
                 .to_string()
         );
@@ -248,29 +248,29 @@ mod tests {
 
         // as-is
         assert_eq!(
-            SingleAmount::from_value(dec!(812), jpy),
-            SingleAmount::from_value(dec!(812), jpy).round(&ctx),
+            SingleAmount::from_value(jpy, dec!(812)),
+            SingleAmount::from_value(jpy, dec!(812)).round(&ctx),
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(-100.00), eur),
-            SingleAmount::from_value(dec!(-100.0), eur).round(&ctx),
+            SingleAmount::from_value(eur, dec!(-100.00)),
+            SingleAmount::from_value(eur, dec!(-100.0)).round(&ctx),
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(6.660), chf),
-            SingleAmount::from_value(dec!(6.66), chf).round(&ctx),
+            SingleAmount::from_value(chf, dec!(6.660)),
+            SingleAmount::from_value(chf, dec!(6.66)).round(&ctx),
         );
 
         assert_eq!(
-            SingleAmount::from_value(dec!(812), jpy),
-            SingleAmount::from_value(dec!(812.5), jpy).round(&ctx),
+            SingleAmount::from_value(jpy, dec!(812)),
+            SingleAmount::from_value(jpy, dec!(812.5)).round(&ctx),
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(-100.02), eur),
-            SingleAmount::from_value(dec!(-100.015), eur).round(&ctx),
+            SingleAmount::from_value(eur, dec!(-100.02)),
+            SingleAmount::from_value(eur, dec!(-100.015)).round(&ctx),
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(6.666), chf),
-            SingleAmount::from_value(dec!(6.6665), chf).round(&ctx),
+            SingleAmount::from_value(chf, dec!(6.666)),
+            SingleAmount::from_value(chf, dec!(6.6665)).round(&ctx),
         );
     }
 
@@ -282,32 +282,32 @@ mod tests {
         let jpy = ctx.commodities.insert("JPY").unwrap();
         let eur = ctx.commodities.insert("EUR").unwrap();
 
-        let positive = SingleAmount::from_value(dec!(1000), jpy);
+        let positive = SingleAmount::from_value(jpy, dec!(1000));
         assert_eq!(
-            SingleAmount::from_value(dec!(15), eur),
-            SingleAmount::from_value(dec!(15), eur).with_sign_of(positive)
+            SingleAmount::from_value(eur, dec!(15)),
+            SingleAmount::from_value(eur, dec!(15)).with_sign_of(positive)
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(0), eur),
-            SingleAmount::from_value(dec!(0), eur).with_sign_of(positive)
+            SingleAmount::from_value(eur, dec!(0)),
+            SingleAmount::from_value(eur, dec!(0)).with_sign_of(positive)
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(15), eur),
-            SingleAmount::from_value(dec!(-15), eur).with_sign_of(positive)
+            SingleAmount::from_value(eur, dec!(15)),
+            SingleAmount::from_value(eur, dec!(-15)).with_sign_of(positive)
         );
 
-        let negative = SingleAmount::from_value(dec!(-1000), jpy);
+        let negative = SingleAmount::from_value(jpy, dec!(-1000));
         assert_eq!(
-            SingleAmount::from_value(dec!(-15), eur),
-            SingleAmount::from_value(dec!(15), eur).with_sign_of(negative)
+            SingleAmount::from_value(eur, dec!(-15)),
+            SingleAmount::from_value(eur, dec!(15)).with_sign_of(negative)
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(0), eur),
-            SingleAmount::from_value(dec!(0), eur).with_sign_of(negative)
+            SingleAmount::from_value(eur, dec!(0)),
+            SingleAmount::from_value(eur, dec!(0)).with_sign_of(negative)
         );
         assert_eq!(
-            SingleAmount::from_value(dec!(-15), eur),
-            SingleAmount::from_value(dec!(-15), eur).with_sign_of(negative)
+            SingleAmount::from_value(eur, dec!(-15)),
+            SingleAmount::from_value(eur, dec!(-15)).with_sign_of(negative)
         );
     }
 }

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -384,38 +384,38 @@ mod tests {
         let want: Balance = [
             (
                 ctx.account("Assets:CH Bank").unwrap(),
-                Amount::from_value(dec!(1858.04), chf),
+                Amount::from_value(chf, dec!(1858.04)),
             ),
             (
                 ctx.account("Assets:Broker").unwrap(),
-                Amount::from_values([(dec!(4900.0000), okane), (dec!(12300), jpy)]),
+                Amount::from_values([(okane, dec!(4900.0000)), (jpy, dec!(12300))]),
             ),
             (
                 ctx.account("Assets:J 銀行").unwrap(),
-                Amount::from_value(dec!(980090), jpy),
+                Amount::from_value(jpy, dec!(980090)),
             ),
             (
                 ctx.account("Liabilities:EUR Card").unwrap(),
-                Amount::from_value(dec!(-300.00), eur),
+                Amount::from_value(eur, dec!(-300.00)),
             ),
             (
                 ctx.account("Income:Capital Gain").unwrap(),
-                Amount::from_value(dec!(-1540), jpy),
+                Amount::from_value(jpy, dec!(-1540)),
             ),
             (
                 ctx.account("Expenses:Food").unwrap(),
-                Amount::from_value(dec!(150.00), eur),
+                Amount::from_value(eur, dec!(150.00)),
             ),
             (
                 ctx.account("Expenses:Grocery").unwrap(),
-                Amount::from_value(dec!(100.00), chf),
+                Amount::from_value(chf, dec!(100.00)),
             ),
             (
                 ctx.account("Equity").unwrap(),
                 Amount::from_values([
-                    (dec!(-1_400_000), jpy),
-                    (dec!(-2000.00), chf),
-                    (dec!(300.00), eur),
+                    (jpy, dec!(-1_400_000)),
+                    (chf, dec!(-2000.00)),
+                    (eur, dec!(300.00)),
                 ]),
             ),
         ]
@@ -453,7 +453,7 @@ mod tests {
             (
                 ctx.account("Assets:CH Bank").unwrap(),
                 // 2000.00 * 168.24 - 141.96 * 171.50
-                Amount::from_value(dec!(312_134), jpy),
+                Amount::from_value(jpy, dec!(312_134)),
             ),
             (
                 ctx.account("Assets:Broker").unwrap(),
@@ -462,41 +462,41 @@ mod tests {
                 // -100 * 100 = -10_000
                 // -23 * 100 = -2_300
                 Amount::from_values([
-                    (dec!(400_000), jpy),
-                    (dec!(2_760), jpy),
-                    (dec!(-10_000), jpy),
-                    (dec!(-2_300), jpy),
-                    (dec!(12_300), jpy),
+                    (jpy, dec!(400_000)),
+                    (jpy, dec!(2_760)),
+                    (jpy, dec!(-10_000)),
+                    (jpy, dec!(-2_300)),
+                    (jpy, dec!(12_300)),
                 ]),
             ),
             (
                 ctx.account("Assets:J 銀行").unwrap(),
-                Amount::from_value(dec!(980090), jpy),
+                Amount::from_value(jpy, dec!(980090)),
             ),
             (
                 ctx.account("Liabilities:EUR Card").unwrap(),
-                Amount::from_value(dec!(-47_136), jpy),
+                Amount::from_value(jpy, dec!(-47_136)),
             ),
             (
                 ctx.account("Income:Capital Gain").unwrap(),
-                Amount::from_value(dec!(-1_540), jpy),
+                Amount::from_value(jpy, dec!(-1_540)),
             ),
             (
                 ctx.account("Expenses:Grocery").unwrap(),
-                Amount::from_value(dec!(17_150), jpy),
+                Amount::from_value(jpy, dec!(17_150)),
             ),
             (
                 ctx.account("Expenses:Food").unwrap(),
-                Amount::from_value(dec!(23_568), jpy),
+                Amount::from_value(jpy, dec!(23_568)),
             ),
             (
                 ctx.account("Equity").unwrap(),
                 Amount::from_values([
-                    (dec!(-1_400_000), jpy),
+                    (jpy, dec!(-1_400_000)),
                     // -2000 * 168.24, historical rate.
-                    (dec!(-336_480), jpy),
+                    (jpy, dec!(-336_480)),
                     // 300 * 157.12
-                    (dec!(47_136), jpy),
+                    (jpy, dec!(47_136)),
                 ]),
             ),
         ]
@@ -532,42 +532,42 @@ mod tests {
             (
                 ctx.account("Assets:CH Bank").unwrap(),
                 // 1858.04 * 171.50
-                Amount::from_value(dec!(318_654), jpy),
+                Amount::from_value(jpy, dec!(318_654)),
             ),
             (
                 ctx.account("Assets:Broker").unwrap(),
-                Amount::from_value(dec!(502_300), jpy),
+                Amount::from_value(jpy, dec!(502_300)),
             ),
             (
                 ctx.account("Assets:J 銀行").unwrap(),
-                Amount::from_value(dec!(980090), jpy),
+                Amount::from_value(jpy, dec!(980090)),
             ),
             (
                 ctx.account("Liabilities:EUR Card").unwrap(),
                 // -300 * 157.12, EUR/JPY rate won't use EUR/CHF CHF/JPY.
-                Amount::from_value(dec!(-47_136), jpy),
+                Amount::from_value(jpy, dec!(-47_136)),
             ),
             (
                 ctx.account("Income:Capital Gain").unwrap(),
-                Amount::from_value(dec!(-1540), jpy),
+                Amount::from_value(jpy, dec!(-1540)),
             ),
             (
                 ctx.account("Expenses:Food").unwrap(),
                 // 150.00 EUR * 157.12
-                Amount::from_value(dec!(23_568), jpy),
+                Amount::from_value(jpy, dec!(23_568)),
             ),
             (
                 ctx.account("Expenses:Grocery").unwrap(),
-                Amount::from_value(dec!(17_150), jpy),
+                Amount::from_value(jpy, dec!(17_150)),
             ),
             (
                 ctx.account("Equity").unwrap(),
                 Amount::from_values([
-                    (dec!(-1_400_000), jpy),
+                    (jpy, dec!(-1_400_000)),
                     // -2000 CHF * 171.50
-                    (dec!(-343_000), jpy),
+                    (jpy, dec!(-343_000)),
                     // 300 EUR * 157.12
-                    (dec!(47_136), jpy),
+                    (jpy, dec!(47_136)),
                 ]),
             ),
         ]
@@ -602,11 +602,11 @@ mod tests {
         let want: Balance = [
             (
                 ctx.account("Assets:J 銀行").unwrap(),
-                Amount::from_value(dec!(-17150), jpy),
+                Amount::from_value(jpy, dec!(-17150)),
             ),
             (
                 ctx.account("Expenses:Grocery").unwrap(),
-                Amount::from_value(dec!(100.00), chf),
+                Amount::from_value(chf, dec!(100.00)),
             ),
         ]
         .into_iter()
@@ -632,7 +632,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            Amount::from_value(dec!(1), ctx.commodities.resolve("JPY").unwrap()),
+            Amount::from_value(ctx.commodities.resolve("JPY").unwrap(), dec!(1)),
             evaluated
         );
     }


### PR DESCRIPTION
I found `Amount::into_values().into_iter()` gives the iterator of `(commodity, value)`, not the `(value, commodity)`.

Then, `from_values` should take the iterator in this order instead for make API symmetry.
For the alignment, `from_value` should also have the same order.
