### PR TITLE
ci: run the release binary build on every PR

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,79 @@
+name: Binary
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-binary:
+    name: Build binaries for ${{ matrix.target }}
+    strategy:
+      # no need to build everything as this is for CI
+      fail-fast: true
+      matrix:
+        include:
+          - build: linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: linux-aarch64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - build: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - build: macos-x86_64
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      # Cross-compilation helper for Linux
+      - name: Install packages (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+      - name: Set cross compile vars (Ubuntu)
+        if: ${{ matrix.build == 'linux-aarch64-musl' }}
+        run: |
+          # echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          # echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          rustup target add aarch64-unknown-linux-musl
+      - name: Build Binary
+        run: cargo build --release --target ${{ matrix.target }} --verbose
+      - name: Package Artifacts
+        shell: bash
+        run: |
+          staging="okane-${{ github.sha }}-${{ matrix.target }}"
+          outdir="target/${{ matrix.target }}/release"
+          mkdir "$staging"
+          cp README.md README.ja.md LICENSE CHANGELOG.md "$staging/"
+          if [[ "${{ matrix.os }}" =~ windows.* ]]; then
+            cp "$outdir/okane.exe" "$staging/"
+            cd "$staging"
+            7z a "../$staging.zip" .
+            echo "ASSET=$staging.zip" >> $GITHUB_ENV
+          else
+            cp "$outdir/okane" "$staging/"
+            tar czf "$staging.tar.gz" -C "$staging" .
+            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+          fi
+      - name: Upload to Action
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-${{ matrix.build }}
+          path: ${{ env.ASSET }}
+          if-no-files-found: error

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,23 @@
+# Runs the release build on every PR, so that a change breaking one of the
+# target builds or the license collection shows up before the tag is pushed,
+# not after.
+name: Binary
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-binary:
+    uses: ./.github/workflows/build-binary.yml
+    with:
+      version: ${{ github.sha }}
+      # One broken target is enough to fix; no need to burn the other runners.
+      fail-fast: true

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,106 @@
+# Builds the release archives, one per target, and uploads them as workflow
+# artifacts. Called both by the Release workflow, which turns the artifacts
+# into release assets, and by the Binary workflow, which only checks that the
+# build still works on every target before a tag is pushed.
+name: Build binary
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: >
+          Version part of the archive name, i.e. okane-<version>-<target>.
+          The release passes the tag, CI passes the commit SHA.
+        required: true
+        type: string
+      fail-fast:
+        description: >
+          Whether the first failing target cancels the remaining ones. CI does
+          not need every failure of the same breakage, a release does.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build for ${{ matrix.target }}
+    strategy:
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        include:
+          - build: linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - build: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - build: macos-x86_64
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1.94.1
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Install cargo-about
+        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+        with:
+          tool: cargo-about
+      - name: Install packages (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+      - name: Build Binary
+        run: cargo build --release --target ${{ matrix.target }} --verbose
+      - name: Collect dependency licenses
+        shell: bash
+        # The binary statically links its dependencies, so the archive has to
+        # carry their license texts. --target keeps the notice to the crates
+        # actually linked into this archive's binary.
+        run: |
+          cargo about generate --fail --locked \
+            --manifest-path cli/Cargo.toml \
+            --target ${{ matrix.target }} \
+            --output-file THIRD-PARTY-LICENSES.html \
+            about.hbs
+      - name: Package Artifacts
+        shell: bash
+        # The version reaches the script through the environment, so that a
+        # crafted tag name cannot inject shell code here.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          staging="okane-${VERSION}-${{ matrix.target }}"
+          outdir="target/${{ matrix.target }}/release"
+          mkdir "$staging"
+          cp README.md README.ja.md LICENSE CHANGELOG.md THIRD-PARTY-LICENSES.html "$staging/"
+          if [[ "${{ matrix.os }}" =~ windows.* ]]; then
+            cp "$outdir/okane.exe" "$staging/"
+            cd "$staging"
+            7z a "../$staging.zip" .
+            echo "ASSET=$staging.zip" >> $GITHUB_ENV
+          else
+            cp "$outdir/okane" "$staging/"
+            tar czf "$staging.tar.gz" -C "$staging" .
+            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+          fi
+      - name: Upload archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-${{ matrix.build }}
+          path: ${{ env.ASSET }}
+          if-no-files-found: error
+          # The release assets live on the release page, and the CI ones are
+          # only there to look at when a build misbehaves.
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,84 +5,35 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
 jobs:
   build-release:
-    name: Build for ${{ matrix.target }}
+    uses: ./.github/workflows/build-binary.yml
+    with:
+      version: ${{ github.ref_name }}
+      # A release wants to know about every broken target at once, not just the
+      # first one.
+      fail-fast: false
+
+  publish-release:
+    name: Publish the release assets
+    needs: build-release
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - build: linux-x86_64-musl
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          # Find time to fix cross-build
-          # - build: linux-aarch64-musl
-          #   os: ubuntu-latest
-          #   target: aarch64-unknown-linux-musl
-          - build: windows-x86_64
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - build: macos-x86_64
-            os: macos-latest
-            target: x86_64-apple-darwin
-          - build: macos-arm64
-            os: macos-latest
-            target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1.94.1
+      - name: Download the built archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - name: Install cargo-about
-        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
-        with:
-          tool: cargo-about
-      # Cross-compilation helper for Linux
-      - name: Install packages (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
-      - name: Build Binary
-        run: cargo build --release --target ${{ matrix.target }} --verbose
-      - name: Collect dependency licenses
-        shell: bash
-        # The binary statically links its dependencies, so the archive has to
-        # carry their license texts. --target keeps the notice to the crates
-        # actually linked into this archive's binary.
-        run: |
-          cargo about generate --fail --locked \
-            --manifest-path cli/Cargo.toml \
-            --target ${{ matrix.target }} \
-            --output-file THIRD-PARTY-LICENSES.html \
-            about.hbs
-      - name: Package Artifacts
-        shell: bash
-        run: |
-          staging="okane-${{ github.ref_name }}-${{ matrix.target }}"
-          outdir="target/${{ matrix.target }}/release"
-          mkdir "$staging"
-          cp README.md README.ja.md LICENSE CHANGELOG.md THIRD-PARTY-LICENSES.html "$staging/"
-          if [[ "${{ matrix.os }}" =~ windows.* ]]; then
-            cp "$outdir/okane.exe" "$staging/"
-            cd "$staging"
-            7z a "../$staging.zip" .
-            echo "ASSET=$staging.zip" >> $GITHUB_ENV
-          else
-            cp "$outdir/okane" "$staging/"
-            tar czf "$staging.tar.gz" -C "$staging" .
-            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
-          fi
+          pattern: binary-*
+          path: archives
       - name: Upload to Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          # One directory per matrix target, each holding a single archive.
           files: |
-            ${{ env.ASSET }}
+            archives/*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow was the only thing building the per-target archives, so a change breaking one of the target builds — or the `cargo about` license collection — only showed up after the tag had been pushed.

Move the build matrix into a reusable workflow, `.github/workflows/build-binary.yml`, and call it from both Release and a new Binary workflow running on push and pull_request against `main`. The two callers differ only in the version part of the archive name (the tag vs. the commit SHA) and in `fail-fast`: CI stops at the first broken target, a release wants to see all of them.

The build job no longer touches the release itself. It uploads every archive as a workflow artifact, and a separate `publish-release` job in Release — the only one holding `contents: write` — downloads them and attaches them to the release.

Two details worth a look:

* The actions are SHA-pinned with `# vX.Y.Z` comments, like the rest of the workflows, so dependabot keeps them current.
* The version reaches the packaging script through `env:` instead of being interpolated into the shell line, so a crafted tag name cannot inject there.

Checked locally with `actionlint`. The arm64 Linux target follows in a PR on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
