### PR TITLE
Do not increase Cargo.toml version requirements for minor upgrades.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
This can be done by lock file upgrade unless there is a vulnerability.