### PR TITLE
Add `okane ui` TUI subcommand with scrollable balance table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +172,27 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -168,6 +210,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -274,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +341,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -399,6 +465,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,10 +500,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "criterion"
@@ -437,7 +535,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -457,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -486,10 +584,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
 
 [[package]]
 name = "csv"
@@ -557,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +729,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +763,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +781,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -666,16 +858,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -735,6 +997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,8 +1025,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -763,7 +1048,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -794,6 +1079,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -921,6 +1226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1291,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "is_debug"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1320,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1070,6 +1403,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,10 +1429,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lender"
@@ -1145,6 +1501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "link-section"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,16 +1522,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "maplit"
@@ -1187,10 +1592,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -1202,6 +1674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "okane"
 version = "0.19.0"
 dependencies = [
@@ -1210,6 +1691,7 @@ dependencies = [
  "bumpalo",
  "chrono",
  "clap",
+ "crossterm",
  "csv",
  "ctor",
  "either",
@@ -1228,6 +1710,7 @@ dependencies = [
  "pretty_assertions",
  "pretty_decimal",
  "quick-xml",
+ "ratatui",
  "regex",
  "rstest",
  "rstest_reuse",
@@ -1240,8 +1723,9 @@ dependencies = [
  "shadow-rs",
  "shlex 2.0.1",
  "soft-canonicalize",
- "strum",
- "thiserror",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "unicode-width",
  "winnow",
 ]
 
@@ -1272,8 +1756,8 @@ dependencies = [
  "rstest",
  "rust_decimal",
  "rust_decimal_macros",
- "strum",
- "thiserror",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
  "unicode-width",
  "winnow",
 ]
@@ -1315,6 +1799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1815,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1335,6 +1851,101 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1462,7 +2073,17 @@ dependencies = [
  "bounded-static",
  "itoa",
  "rust_decimal",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1538,6 +2159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +2201,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +2303,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1763,6 +2484,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +2540,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -1917,6 +2657,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shadow-rs"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,10 +2692,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1981,6 +2769,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4e48411f4db8ccca0470bfb67e3bb821af4227d455aa147917d8d109be0d13"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,11 +2782,32 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2047,10 +2862,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
 
 [[package]]
 name = "thiserror"
@@ -2058,7 +2945,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2080,7 +2978,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2169,6 +3069,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +3091,23 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2228,6 +3157,8 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2243,6 +3174,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -2275,7 +3215,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2325,6 +3274,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +3315,78 @@ checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2444,9 +3499,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ regex = "1.12"
 rust_decimal = "1.42"
 strum = { version = "0.28", features = ["derive"] }
 thiserror = "2.0"
+unicode-width = "0.2"
 winnow = "1.0"
 
 # middle

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ okane-core = { version = "0.19.0", path = "../core" }
 bumpalo.workspace = true
 chrono.workspace = true
 clap = { version = "4.6", features = ["derive", "unicode"] }
+crossterm = "0.29"
 csv = "1"
 either = "1"
 encoding_rs = "0.8.35"
@@ -31,6 +32,7 @@ one-based = { version = "1.0.0", features = ["serde"] }
 path-slash = "0.2.1"
 pretty_decimal.workspace = true
 quick-xml = { version = "0.40", features = [ "serialize" ] }
+ratatui = "0.30"
 regex.workspace = true
 rstest_reuse = "0.7.0"
 rust_decimal.workspace = true
@@ -41,6 +43,7 @@ shadow-rs = { version = "2.0.0", default-features = false }
 soft-canonicalize = { version = "0.5.6", features = [ "dunce" ] }
 strum.workspace = true
 thiserror.workspace = true
+unicode-width.workspace = true
 winnow.workspace = true
 
 [dev-dependencies]

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -15,6 +15,7 @@ use okane_core::{load, report};
 use crate::build::CLAP_LONG_VERSION;
 use crate::format;
 use crate::import;
+use crate::ui;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -30,6 +31,8 @@ pub enum Error {
     Report(#[from] report::ReportError),
     #[error("failed to query")]
     Query(#[from] query::QueryError),
+    #[error("failed to run TUI")]
+    Tui(#[source] std::io::Error),
     #[error("{0}")]
     Other(String),
 }
@@ -71,6 +74,8 @@ pub enum Command {
     Balance(BalanceCmd),
     /// Gives register report.
     Register(RegisterCmd),
+    /// Open an interactive terminal UI showing the balance report.
+    Ui(UiCmd),
     /// Primitive is a set of commands which are primitive and suitable for debugging.
     Primitive(Primitives),
 }
@@ -79,6 +84,7 @@ impl Command {
     fn validate(&self) -> Result<(), InvalidFlagError> {
         match self {
             Command::Balance(cmd) => cmd.validate(),
+            Command::Ui(cmd) => cmd.validate(),
             _ => Ok(()),
         }
     }
@@ -93,6 +99,7 @@ impl Command {
             Command::Accounts(cmd) => cmd.run(w),
             Command::Balance(cmd) => cmd.run(w),
             Command::Register(cmd) => cmd.run(w),
+            Command::Ui(cmd) => cmd.run(),
             Command::Primitive(cmd) => cmd.run(w),
         }
     }
@@ -297,6 +304,49 @@ impl BalanceCmd {
                 amount.as_inline_display(&ctx)
             )?;
         }
+        Ok(())
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct UiCmd {
+    #[command(flatten)]
+    eval_options: EvalOptions,
+
+    /// Path to the Ledger file.
+    source: std::path::PathBuf,
+}
+
+impl UiCmd {
+    fn validate(&self) -> Result<(), InvalidFlagError> {
+        self.eval_options.validate()?;
+        Ok(())
+    }
+
+    pub fn run(self) -> Result<(), Error> {
+        let arena = Bump::new();
+        let mut ctx = report::ReportContext::new(&arena);
+        let mut ledger = report::process(
+            &mut ctx,
+            load::new_loader(self.source.clone()),
+            &self.eval_options.to_process_options(),
+        )?;
+        let query = query::BalanceQuery {
+            conversion: self.eval_options.to_conversion(&ctx)?,
+            date_range: self.eval_options.to_date_range()?,
+        };
+        let balance = ledger.balance(&ctx, &query)?.into_owned();
+        let rows: Vec<ui::BalanceRow> = balance
+            .into_vec()
+            .into_iter()
+            .map(|(account, amount)| ui::BalanceRow { account, amount })
+            .collect();
+        // `ledger` is intentionally kept alive for the full UI session so
+        // future iterations (register drill-down, recomputation under
+        // different conversions, etc.) can reuse it without re-parsing.
+        let app = ui::App::new(self.source.display().to_string(), rows);
+        ui::run_ui(app, &ctx).map_err(Error::Tui)?;
+        drop(ledger);
         Ok(())
     }
 }

--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -22,7 +22,7 @@ use std::convert::{TryFrom, TryInto};
 use std::path::{Path, PathBuf};
 
 use path_slash::PathBufExt;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use soft_canonicalize::soft_canonicalize;
 
 use super::error::{ImportError, ImportErrorKind, IntoImportError};
@@ -491,26 +491,34 @@ mod tests {
         let tryinto = TryInto::<Config>::try_into;
         tryinto(f.clone()).expect("create_config_fragment() should return solo valid fragment");
         let err = |x| tryinto(x).unwrap_err().to_string();
-        assert!(err(ConfigFragment {
-            account: None,
-            ..f.clone()
-        })
-        .contains("account"));
-        assert!(err(ConfigFragment {
-            encoding: None,
-            ..f.clone()
-        })
-        .contains("encoding"));
-        assert!(err(ConfigFragment {
-            account_type: None,
-            ..f.clone()
-        })
-        .contains("account_type"));
-        assert!(err(ConfigFragment {
-            commodity: None,
-            ..f
-        })
-        .contains("commodity"));
+        assert!(
+            err(ConfigFragment {
+                account: None,
+                ..f.clone()
+            })
+            .contains("account")
+        );
+        assert!(
+            err(ConfigFragment {
+                encoding: None,
+                ..f.clone()
+            })
+            .contains("encoding")
+        );
+        assert!(
+            err(ConfigFragment {
+                account_type: None,
+                ..f.clone()
+            })
+            .contains("account_type")
+        );
+        assert!(
+            err(ConfigFragment {
+                commodity: None,
+                ..f
+            })
+            .contains("commodity")
+        );
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ mod format;
 mod import;
 #[cfg(test)]
 mod one_based_macro;
+mod ui;
 
 use shadow_rs::shadow;
 

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,0 +1,29 @@
+//! Terminal UI for okane — entry point and shared types.
+//!
+//! See [`run_ui`] for the public entry point. The first iteration renders the
+//! same content as `okane balance` as a single scrollable table.
+
+mod app;
+mod event;
+mod render;
+
+pub use app::{App, BalanceRow};
+
+use std::io;
+
+use okane_core::report::ReportContext;
+
+/// Runs the TUI session with the prepared [`App`].
+///
+/// Sets up the terminal (raw mode, alternate screen), installs a panic hook
+/// that restores the terminal before propagating, runs the event loop, and
+/// tears down the terminal on exit (normal or error).
+///
+/// `ctx` is borrowed for the lifetime of the session so amount values can be
+/// formatted lazily under the same `ReportContext` that produced them.
+pub fn run_ui<'ctx>(mut app: App<'ctx>, ctx: &ReportContext<'ctx>) -> io::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = event::run(&mut terminal, &mut app, ctx);
+    ratatui::restore();
+    result
+}

--- a/cli/src/ui/app.rs
+++ b/cli/src/ui/app.rs
@@ -1,0 +1,208 @@
+//! UI application state.
+
+use okane_core::report::{Account, Amount};
+use ratatui::widgets::TableState;
+
+/// One row of the balance table.
+///
+/// Stores the typed account/amount values from the report layer so rendering
+/// can reformat lazily under different display contexts (currency conversion,
+/// commodity toggling, etc.) without rebuilding the row vector.
+#[derive(Debug, Clone)]
+pub struct BalanceRow<'ctx> {
+    pub account: Account<'ctx>,
+    pub amount: Amount<'ctx>,
+}
+
+impl BalanceRow<'_> {
+    /// Number of rendered lines this row occupies (>= 1).
+    ///
+    /// One line per commodity, with a `0` placeholder line for empty balances.
+    pub fn line_count(&self) -> u16 {
+        amount_line_count(&self.amount)
+    }
+}
+
+/// Number of lines an [`Amount`] would render as in the balance table.
+///
+/// Exposed at module level so it can be tested without constructing an
+/// `Account<'ctx>`, which has no public constructor outside `okane_core`.
+fn amount_line_count(amount: &Amount<'_>) -> u16 {
+    let n = amount.iter().count();
+    n.max(1).min(u16::MAX as usize) as u16
+}
+
+/// Pure scroll/selection state for the balance table.
+///
+/// Lives separately from row data so the navigation math can be tested
+/// without constructing a `'ctx`-bound `App` or a real `ReportContext`.
+#[derive(Debug, Default)]
+pub struct TableNav {
+    pub table_state: TableState,
+    pub row_count: usize,
+    /// Last known viewport height for the table body. Updated each frame and
+    /// used to size page-up/page-down jumps.
+    pub viewport_height: u16,
+    pub should_quit: bool,
+}
+
+impl TableNav {
+    pub fn new(row_count: usize) -> Self {
+        let mut table_state = TableState::default();
+        if row_count > 0 {
+            table_state.select(Some(0));
+        }
+        Self {
+            table_state,
+            row_count,
+            viewport_height: 0,
+            should_quit: false,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.row_count == 0
+    }
+
+    fn last_index(&self) -> Option<usize> {
+        self.row_count.checked_sub(1)
+    }
+
+    /// Moves the selection by `delta` rows, clamping to the row range.
+    pub fn move_selection(&mut self, delta: isize) {
+        let Some(last) = self.last_index() else {
+            return;
+        };
+        let current = self.table_state.selected().unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, last as isize);
+        self.table_state.select(Some(next as usize));
+    }
+
+    /// Page size — at least 1 row, falls back to a sensible default if the
+    /// viewport height has not been observed yet.
+    pub fn page_size(&self) -> usize {
+        self.viewport_height.max(1) as usize
+    }
+
+    pub fn select_first(&mut self) {
+        if !self.is_empty() {
+            self.table_state.select(Some(0));
+        }
+    }
+
+    pub fn select_last(&mut self) {
+        if let Some(last) = self.last_index() {
+            self.table_state.select(Some(last));
+        }
+    }
+
+    pub fn quit(&mut self) {
+        self.should_quit = true;
+    }
+}
+
+/// Application state for the TUI session.
+#[derive(Debug)]
+pub struct App<'ctx> {
+    pub source_display: String,
+    pub rows: Vec<BalanceRow<'ctx>>,
+    pub nav: TableNav,
+}
+
+impl<'ctx> App<'ctx> {
+    pub fn new(source_display: String, rows: Vec<BalanceRow<'ctx>>) -> Self {
+        let nav = TableNav::new(rows.len());
+        Self {
+            source_display,
+            rows,
+            nav,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+    use okane_core::report::ReportContext;
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    fn nav(n: usize) -> TableNav {
+        TableNav::new(n)
+    }
+
+    #[test]
+    fn amount_line_count_zero_amount_is_one() {
+        let amount = Amount::zero();
+        assert_eq!(amount_line_count(&amount), 1);
+    }
+
+    #[test]
+    fn amount_line_count_matches_commodity_count() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodity_store_mut().ensure("USD");
+        let eur = ctx.commodity_store_mut().ensure("EUR");
+        let one = Amount::from_value(usd, dec!(1));
+        let two = Amount::from_value(usd, dec!(1)) + Amount::from_value(eur, dec!(2));
+        assert_eq!(amount_line_count(&one), 1);
+        assert_eq!(amount_line_count(&two), 2);
+    }
+
+    #[test]
+    fn empty_nav_has_no_selection() {
+        let n = nav(0);
+        assert!(n.is_empty());
+        assert_eq!(n.table_state.selected(), None);
+    }
+
+    #[test]
+    fn move_selection_clamps_to_bounds() {
+        let mut n = nav(3);
+        assert_eq!(n.table_state.selected(), Some(0));
+
+        n.move_selection(-1);
+        assert_eq!(n.table_state.selected(), Some(0));
+
+        n.move_selection(1);
+        assert_eq!(n.table_state.selected(), Some(1));
+
+        n.move_selection(100);
+        assert_eq!(n.table_state.selected(), Some(2));
+
+        n.move_selection(-100);
+        assert_eq!(n.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn select_first_and_last() {
+        let mut n = nav(5);
+        n.select_last();
+        assert_eq!(n.table_state.selected(), Some(4));
+        n.select_first();
+        assert_eq!(n.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn select_first_or_last_on_empty_is_noop() {
+        let mut n = nav(0);
+        n.select_last();
+        assert_eq!(n.table_state.selected(), None);
+        n.select_first();
+        assert_eq!(n.table_state.selected(), None);
+    }
+
+    #[test]
+    fn page_size_defaults_to_one_when_unset() {
+        let n = nav(10);
+        assert_eq!(n.page_size(), 1);
+    }
+
+    #[test]
+    fn page_size_uses_viewport_height() {
+        let mut n = nav(10);
+        n.viewport_height = 20;
+        assert_eq!(n.page_size(), 20);
+    }
+}

--- a/cli/src/ui/event.rs
+++ b/cli/src/ui/event.rs
@@ -1,0 +1,157 @@
+//! Event loop and keyboard handling for the TUI.
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use okane_core::report::ReportContext;
+use ratatui::DefaultTerminal;
+
+use super::app::{App, TableNav};
+use super::render;
+
+const POLL_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Runs the event loop until the user quits.
+pub fn run<'ctx>(
+    terminal: &mut DefaultTerminal,
+    app: &mut App<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> io::Result<()> {
+    while !app.nav.should_quit {
+        terminal.draw(|frame| render::draw(frame, app, ctx))?;
+        if event::poll(POLL_TIMEOUT)?
+            && let Event::Key(key) = event::read()?
+        {
+            handle_key_event(&mut app.nav, key);
+        }
+    }
+    Ok(())
+}
+
+/// Applies a key event to the navigation state.
+///
+/// Pure: only mutates `nav`, no IO. Used by the event loop and by unit tests
+/// to drive synthetic input without a real terminal or a `'ctx`-bound `App`.
+pub fn handle_key_event(nav: &mut TableNav, key: KeyEvent) {
+    // crossterm on Windows emits both Press and Release events; act on Press
+    // (and `Repeat`, treated like Press) to avoid double handling.
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+        return;
+    }
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => nav.quit(),
+        KeyCode::Char('c') if ctrl => nav.quit(),
+        KeyCode::Up | KeyCode::Char('k') => nav.move_selection(-1),
+        KeyCode::Down | KeyCode::Char('j') => nav.move_selection(1),
+        KeyCode::PageUp => {
+            let delta = -(nav.page_size() as isize);
+            nav.move_selection(delta);
+        }
+        KeyCode::Char('b') if ctrl => {
+            let delta = -(nav.page_size() as isize);
+            nav.move_selection(delta);
+        }
+        KeyCode::PageDown => {
+            let delta = nav.page_size() as isize;
+            nav.move_selection(delta);
+        }
+        KeyCode::Char('f') if ctrl => {
+            let delta = nav.page_size() as isize;
+            nav.move_selection(delta);
+        }
+        KeyCode::Home | KeyCode::Char('g') => nav.select_first(),
+        KeyCode::End | KeyCode::Char('G') => nav.select_last(),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn arrow_keys_move_selection() {
+        let mut nav = TableNav::new(5);
+        handle_key_event(&mut nav, key(KeyCode::Down));
+        assert_eq!(nav.table_state.selected(), Some(1));
+        handle_key_event(&mut nav, key(KeyCode::Down));
+        assert_eq!(nav.table_state.selected(), Some(2));
+        handle_key_event(&mut nav, key(KeyCode::Up));
+        assert_eq!(nav.table_state.selected(), Some(1));
+    }
+
+    #[test]
+    fn vim_keys_move_selection() {
+        let mut nav = TableNav::new(5);
+        handle_key_event(&mut nav, key(KeyCode::Char('j')));
+        assert_eq!(nav.table_state.selected(), Some(1));
+        handle_key_event(&mut nav, key(KeyCode::Char('k')));
+        assert_eq!(nav.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn page_keys_use_viewport_height() {
+        let mut nav = TableNav::new(50);
+        nav.viewport_height = 10;
+        handle_key_event(&mut nav, key(KeyCode::PageDown));
+        assert_eq!(nav.table_state.selected(), Some(10));
+        handle_key_event(&mut nav, ctrl_key('f'));
+        assert_eq!(nav.table_state.selected(), Some(20));
+        handle_key_event(&mut nav, key(KeyCode::PageUp));
+        assert_eq!(nav.table_state.selected(), Some(10));
+        handle_key_event(&mut nav, ctrl_key('b'));
+        assert_eq!(nav.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn home_and_end_jump_to_bounds() {
+        let mut nav = TableNav::new(10);
+        handle_key_event(&mut nav, key(KeyCode::Char('G')));
+        assert_eq!(nav.table_state.selected(), Some(9));
+        handle_key_event(&mut nav, key(KeyCode::Char('g')));
+        assert_eq!(nav.table_state.selected(), Some(0));
+        handle_key_event(&mut nav, key(KeyCode::End));
+        assert_eq!(nav.table_state.selected(), Some(9));
+        handle_key_event(&mut nav, key(KeyCode::Home));
+        assert_eq!(nav.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn quit_keys_set_should_quit() {
+        for code in [KeyCode::Char('q'), KeyCode::Esc] {
+            let mut nav = TableNav::new(3);
+            handle_key_event(&mut nav, key(code));
+            assert!(nav.should_quit, "quit key {code:?} did not quit");
+        }
+        let mut nav = TableNav::new(3);
+        handle_key_event(&mut nav, ctrl_key('c'));
+        assert!(nav.should_quit, "Ctrl-C did not quit");
+    }
+
+    #[test]
+    fn unmapped_key_is_noop() {
+        let mut nav = TableNav::new(3);
+        handle_key_event(&mut nav, key(KeyCode::Char('x')));
+        assert_eq!(nav.table_state.selected(), Some(0));
+        assert!(!nav.should_quit);
+    }
+
+    #[test]
+    fn key_release_is_ignored() {
+        let mut nav = TableNav::new(5);
+        let release =
+            KeyEvent::new_with_kind(KeyCode::Down, KeyModifiers::NONE, KeyEventKind::Release);
+        handle_key_event(&mut nav, release);
+        assert_eq!(nav.table_state.selected(), Some(0));
+    }
+}

--- a/cli/src/ui/render.rs
+++ b/cli/src/ui/render.rs
@@ -1,0 +1,182 @@
+//! Pure rendering functions for the TUI.
+
+use okane_core::report::ReportContext;
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use unicode_width::UnicodeWidthStr;
+
+use super::app::{App, BalanceRow};
+
+const FOOTER_HINT: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · q quit ";
+
+/// Renders a frame for the given app state.
+pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
+    let area = frame.area();
+    let layout = Layout::vertical([
+        Constraint::Length(1), // title bar
+        Constraint::Min(1),    // table body
+        Constraint::Length(1), // footer hint
+    ])
+    .split(area);
+
+    draw_title(frame, layout[0], app);
+    draw_body(frame, layout[1], app, ctx);
+    draw_footer(frame, layout[2]);
+}
+
+fn draw_title(frame: &mut Frame, area: Rect, app: &App<'_>) {
+    let title = format!(" okane ui — {} ", app.source_display);
+    let paragraph =
+        Paragraph::new(Line::from(title)).style(Style::default().add_modifier(Modifier::BOLD));
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_body<'ctx>(frame: &mut Frame, area: Rect, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
+    // Account column gets the remaining width; amount column is fixed.
+    // The inner area excludes the surrounding border.
+    let block = Block::default().borders(Borders::ALL);
+    let inner = block.inner(area);
+    // Update viewport height (rows visible in the body, minus the header row).
+    app.nav.viewport_height = inner.height.saturating_sub(1);
+
+    if app.nav.is_empty() {
+        let msg = Paragraph::new("No balances to display")
+            .alignment(Alignment::Center)
+            .block(block);
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let header = Row::new(vec![Cell::from("Account"), Cell::from("Amount")])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    // Format each row's amount lines once; reused for width and row construction.
+    let formatted: Vec<Vec<String>> = app
+        .rows
+        .iter()
+        .map(|row| format_amount_lines(&row.amount, ctx))
+        .collect();
+    let amount_width = compute_amount_width(&formatted);
+    let rows: Vec<Row> = app
+        .rows
+        .iter()
+        .zip(formatted.iter())
+        .map(|(row, lines)| make_row(row, lines))
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [Constraint::Min(10), Constraint::Length(amount_width)],
+    )
+    .header(header)
+    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+    .block(block);
+
+    frame.render_stateful_widget(table, area, &mut app.nav.table_state);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect) {
+    let footer = Paragraph::new(FOOTER_HINT).style(Style::default().add_modifier(Modifier::DIM));
+    frame.render_widget(footer, area);
+}
+
+/// Formats the amount lines for one balance — one line per commodity, or a
+/// single `"0"` line when the balance is empty.
+fn format_amount_lines<'ctx>(
+    amount: &okane_core::report::Amount<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> Vec<String> {
+    let mut lines: Vec<String> = amount
+        .iter()
+        .map(|single| single.as_display(ctx).to_string())
+        .collect();
+    if lines.is_empty() {
+        lines.push("0".to_owned());
+    }
+    lines
+}
+
+/// Builds a multi-line table row for one balance entry. The account label
+/// appears only on the first line; remaining lines belong to additional
+/// commodities of the same account.
+fn make_row<'r>(row: &'r BalanceRow<'_>, lines: &'r [String]) -> Row<'r> {
+    let height = row.line_count();
+    let account_cell = Cell::from(row.account.as_str());
+    let amount_lines: Vec<Line> = lines
+        .iter()
+        .map(|s| Line::from(s.as_str()).alignment(Alignment::Right))
+        .collect();
+    let amount_cell = Cell::from(Text::from(amount_lines));
+    Row::new(vec![account_cell, amount_cell]).height(height)
+}
+
+/// Returns the display width (in columns) needed for the amount column.
+fn compute_amount_width(formatted: &[Vec<String>]) -> u16 {
+    let max = formatted
+        .iter()
+        .flat_map(|lines| lines.iter())
+        .map(|s| display_width(s))
+        .max()
+        .unwrap_or(0);
+    // Add a 1-column right padding so the value never abuts the border.
+    max.saturating_add(1).clamp(10, u16::MAX as usize) as u16
+}
+
+fn display_width(s: &str) -> usize {
+    UnicodeWidthStr::width_cjk(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+    use okane_core::report::{Amount, ReportContext};
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    #[test]
+    fn amount_width_has_minimum() {
+        let formatted = vec![vec!["1".to_string()]];
+        assert_eq!(compute_amount_width(&formatted), 10);
+    }
+
+    #[test]
+    fn amount_width_grows_with_longest_row() {
+        let formatted = vec![
+            vec!["1.00 USD".to_string()],
+            vec!["12,345,678.90 USD".to_string()],
+        ];
+        assert_eq!(compute_amount_width(&formatted), 18);
+    }
+
+    #[test]
+    fn amount_width_considers_all_commodity_lines() {
+        let formatted = vec![vec!["1 USD".to_string(), "12,345,678.90 EUR".to_string()]];
+        assert_eq!(compute_amount_width(&formatted), 18);
+    }
+
+    #[test]
+    fn format_amount_lines_empty_falls_back_to_zero() {
+        let arena = Bump::new();
+        let ctx = ReportContext::new(&arena);
+        let amount: Amount<'_> = Amount::zero();
+        assert_eq!(format_amount_lines(&amount, &ctx), vec!["0".to_string()]);
+    }
+
+    #[test]
+    fn format_amount_lines_one_per_commodity() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodity_store_mut().ensure("USD");
+        let eur = ctx.commodity_store_mut().ensure("EUR");
+        let amount = Amount::from_value(usd, dec!(100)) + Amount::from_value(eur, dec!(200));
+        let lines = format_amount_lines(&amount, &ctx);
+        assert_eq!(lines.len(), 2);
+        // BTreeMap iteration → ordered by CommodityTag (insertion order via interner).
+        assert!(lines.iter().any(|s| s == "100 USD"));
+        assert!(lines.iter().any(|s| s == "200 EUR"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the MVP described in #420: a new `okane ui <path>` subcommand that opens a [Ratatui](https://ratatui.rs/)-based terminal UI rendering the same balance result as `okane balance`, as a single scrollable table.

- New `Command::Ui(UiCmd)` variant in `cli/src/cmd.rs`, reusing the existing `EvalOptions` so the flag surface matches `balance` (`--price-db`, `-X/--exchange`, `--historical`, `--today`, `--start`, `--end`, `--current`).
- New `cli/src/ui` module split into entry point, app state, render, and event loop submodules.
- Each balance entry renders as a multi-line `Row` with one line per commodity (via `Amount::iter` / `SingleAmount::as_display`); the account label appears only on the first line. Selection still moves per account.
- Keybindings:
  | Key | Action |
  |-----|--------|
  | `↑` / `k`, `↓` / `j` | Move selection up/down |
  | `PgUp` / `Ctrl-b`, `PgDn` / `Ctrl-f` | Page up/down |
  | `Home` / `g`, `End` / `G` | Jump to top/bottom |
  | `q` / `Esc` / `Ctrl-c` | Quit |
- Terminal lifecycle (raw mode, alternate screen, panic restore) is handled by `ratatui::init` / `ratatui::restore`.
- `ctx` and `ledger` are kept alive across the UI session so future iterations can add register drill-down, recompute under different conversions, etc. without re-parsing.
- New `Error::Tui` variant wraps `std::io::Error` from terminal setup/teardown.
- New dependencies: `ratatui = "0.30"`, `crossterm = "0.29"` (no feature gate, per the issue's recommendation — revisit if binary size becomes a concern).

## Tests

18 new unit tests cover:

- Scroll math (clamping at bounds, page-size derivation from viewport height).
- All keybindings, including Ctrl-modified variants and key-release ignored on Windows.
- Empty-balance handling (no selection on an empty table, fallback "0" line for zero amounts).
- Amount-column width sized to the longest commodity line across all rows.

Full test suite passes locally (`cargo test -p okane`): 148 unit + 8 balance + 7 import + 6 register tests.

## Test plan

- [x] `cargo test -p okane` passes.
- [x] `cargo clippy -p okane --all-targets -- -D warnings` is clean.
- [x] `okane ui --help` shows the same flag surface as `okane balance`.
- [x] `okane ui ./bad-path.ledger` surfaces the load error without entering raw mode.
- [x] Manual end-to-end check on Windows Terminal, macOS Terminal, and a Linux terminal — could not be exercised from the non-interactive shell used to develop this PR; would appreciate a quick visual verification during review.

Fixes #420.