### PR TITLE
Add register drill-down and quit confirmation to `okane ui`

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -326,22 +326,25 @@ impl UiCmd {
             load::new_loader(self.source.clone()),
             &self.eval_options.to_process_options(),
         )?;
-        let query = query::BalanceQuery {
-            conversion: self.eval_options.to_conversion(&ctx)?,
-            date_range: self.eval_options.to_date_range()?,
+        let conversion = self.eval_options.to_conversion(&ctx)?;
+        let date_range = self.eval_options.to_date_range()?;
+        let balance_query = query::BalanceQuery {
+            conversion,
+            date_range,
         };
-        let balance = ledger.balance(&ctx, &query)?.into_owned();
+        let balance = ledger.balance(&ctx, &balance_query)?.into_owned();
         let rows: Vec<ui::BalanceRow> = balance
             .into_vec()
             .into_iter()
             .map(|(account, amount)| ui::BalanceRow { account, amount })
             .collect();
-        // `ledger` is intentionally kept alive for the full UI session so
-        // future iterations (register drill-down, recomputation under
-        // different conversions, etc.) can reuse it without re-parsing.
-        let app = ui::App::new(self.source.display().to_string(), rows);
-        ui::run_ui(app, &ctx).context("failed to run TUI")?;
-        drop(ledger);
+        // Reused for every register drill-down during the session.
+        let register_template = ui::RegisterQueryTemplate {
+            conversion,
+            date_range,
+        };
+        let app = ui::App::new(self.source.display().to_string(), rows, register_template);
+        ui::run_ui(app, &mut ledger, &ctx).context("failed to run TUI")?;
         Ok(())
     }
 }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,17 +1,24 @@
 //! Terminal UI for okane — entry point and shared types.
 //!
-//! See [`run_ui`] for the public entry point. The first iteration renders the
-//! same content as `okane balance` as a single scrollable table.
+//! Architecture (Elm-style; see
+//! <https://ratatui.rs/concepts/application-patterns/the-elm-architecture/>):
+//! - [`App`] holds all state and exposes [`App::update`] for transitions.
+//! - [`event`] translates `KeyEvent`s to [`app::Message`]s and runs the loop.
+//! - [`render`] is a pure view over `App`.
+//!
+//! See [`run_ui`] for the public entry point. The session presents a balance
+//! table; pressing Enter drills into a register view for the selected
+//! account, and q/Esc returns. A quit confirmation popup guards exits from
+//! the balance screen; Ctrl-C bypasses it.
 
 mod app;
 mod event;
 mod render;
 
-pub use app::{App, BalanceRow};
-
-use std::io;
+pub use app::{App, BalanceRow, RegisterQueryTemplate};
 
 use okane_core::report::ReportContext;
+use okane_core::report::query::Ledger;
 
 /// Runs the TUI session with the prepared [`App`].
 ///
@@ -19,11 +26,17 @@ use okane_core::report::ReportContext;
 /// that restores the terminal before propagating, runs the event loop, and
 /// tears down the terminal on exit (normal or error).
 ///
-/// `ctx` is borrowed for the lifetime of the session so amount values can be
-/// formatted lazily under the same `ReportContext` that produced them.
-pub fn run_ui<'ctx>(mut app: App<'ctx>, ctx: &ReportContext<'ctx>) -> io::Result<()> {
+/// `ledger` is borrowed mutably so the register view can be computed on
+/// demand. `ctx` is borrowed for the lifetime of the session so amount
+/// values can be formatted lazily under the same `ReportContext` that
+/// produced them.
+pub fn run_ui<'ctx>(
+    mut app: App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
-    let result = event::run(&mut terminal, &mut app, ctx);
+    let result = event::run(&mut terminal, &mut app, ledger, ctx);
     ratatui::restore();
     result
 }

--- a/cli/src/ui/app.rs
+++ b/cli/src/ui/app.rs
@@ -1,5 +1,12 @@
 //! UI application state.
+//!
+//! Follows The Elm Architecture: state lives in [`App`], all transitions go
+//! through [`App::update`] driven by a [`Message`]. Key handling in
+//! [`super::event`] translates raw `KeyEvent`s into messages based on the
+//! currently active screen and overlay.
 
+use chrono::NaiveDate;
+use okane_core::report::query::{Conversion, DateRange};
 use okane_core::report::{Account, Amount};
 use ratatui::widgets::TableState;
 
@@ -23,16 +30,32 @@ impl BalanceRow<'_> {
     }
 }
 
-/// Number of lines an [`Amount`] would render as in the balance table.
+/// One row of the register table.
 ///
-/// Exposed at module level so it can be tested without constructing an
-/// `Account<'ctx>`, which has no public constructor outside `okane_core`.
+/// The account is implied by the active [`RegisterView`] (exact-match
+/// filter), so it is not duplicated per row.
+#[derive(Debug, Clone)]
+pub struct RegisterRow<'ctx> {
+    pub date: NaiveDate,
+    pub payee: String,
+    pub amount: Amount<'ctx>,
+    pub total: Amount<'ctx>,
+}
+
+impl RegisterRow<'_> {
+    /// Number of rendered lines this row occupies (>= 1).
+    pub fn line_count(&self) -> u16 {
+        amount_line_count(&self.amount).max(amount_line_count(&self.total))
+    }
+}
+
+/// Number of lines an [`Amount`] would render as in a table.
 fn amount_line_count(amount: &Amount<'_>) -> u16 {
     let n = amount.iter().count();
     n.max(1).min(u16::MAX as usize) as u16
 }
 
-/// Pure scroll/selection state for the balance table.
+/// Pure scroll/selection state for a table.
 ///
 /// Lives separately from row data so the navigation math can be tested
 /// without constructing a `'ctx`-bound `App` or a real `ReportContext`.
@@ -43,7 +66,6 @@ pub struct TableNav {
     /// Last known viewport height for the table body. Updated each frame and
     /// used to size page-up/page-down jumps.
     pub viewport_height: u16,
-    pub should_quit: bool,
 }
 
 impl TableNav {
@@ -56,7 +78,6 @@ impl TableNav {
             table_state,
             row_count,
             viewport_height: 0,
-            should_quit: false,
         }
     }
 
@@ -95,28 +116,184 @@ impl TableNav {
             self.table_state.select(Some(last));
         }
     }
+}
 
-    pub fn quit(&mut self) {
-        self.should_quit = true;
+/// Query parameters reused for every register lookup during the session
+/// (built once from the CLI's `EvalOptions`).
+#[derive(Debug, Clone, Copy)]
+pub struct RegisterQueryTemplate<'ctx> {
+    pub conversion: Option<Conversion<'ctx>>,
+    pub date_range: DateRange,
+}
+
+/// State for the register drill-down screen.
+#[derive(Debug)]
+pub struct RegisterView<'ctx> {
+    pub account: String,
+    pub rows: Vec<RegisterRow<'ctx>>,
+    pub nav: TableNav,
+}
+
+impl<'ctx> RegisterView<'ctx> {
+    pub fn new(account: String, rows: Vec<RegisterRow<'ctx>>) -> Self {
+        let mut nav = TableNav::new(rows.len());
+        // Most recent entry is the most useful starting point.
+        nav.select_last();
+        Self { account, rows, nav }
     }
+}
+
+/// Top-level screen the user is currently looking at.
+#[derive(Debug)]
+pub enum Screen<'ctx> {
+    Balance,
+    Register(RegisterView<'ctx>),
+}
+
+/// Modal overlay drawn on top of the current screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Overlay {
+    /// "Quit? y/n" prompt shown when leaving the balance screen.
+    QuitConfirm,
+}
+
+/// Messages that drive state transitions (Elm-style).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Message {
+    MoveUp,
+    MoveDown,
+    PageUp,
+    PageDown,
+    SelectFirst,
+    SelectLast,
+    /// User asked to drill into the selected balance row.
+    OpenRegister,
+    /// Leave the register view and go back to balance.
+    LeaveRegister,
+    /// User asked to quit from balance — show the confirmation overlay.
+    RequestQuit,
+    /// Confirm quit from the overlay.
+    ConfirmQuit,
+    /// Dismiss the current overlay.
+    DismissOverlay,
+    /// Unconditional quit (Ctrl-C).
+    QuitImmediate,
+}
+
+/// Effect requested by [`App::update`] that requires resources the pure
+/// state machine does not own (here: `&mut Ledger` to compute a register).
+#[derive(Debug, Clone)]
+pub enum Command {
+    LoadRegister { account: String },
 }
 
 /// Application state for the TUI session.
 #[derive(Debug)]
 pub struct App<'ctx> {
     pub source_display: String,
-    pub rows: Vec<BalanceRow<'ctx>>,
-    pub nav: TableNav,
+    pub balance_rows: Vec<BalanceRow<'ctx>>,
+    pub balance_nav: TableNav,
+    pub screen: Screen<'ctx>,
+    pub overlay: Option<Overlay>,
+    pub register_template: RegisterQueryTemplate<'ctx>,
+    pub should_quit: bool,
 }
 
 impl<'ctx> App<'ctx> {
-    pub fn new(source_display: String, rows: Vec<BalanceRow<'ctx>>) -> Self {
-        let nav = TableNav::new(rows.len());
+    pub fn new(
+        source_display: String,
+        balance_rows: Vec<BalanceRow<'ctx>>,
+        register_template: RegisterQueryTemplate<'ctx>,
+    ) -> Self {
+        let balance_nav = TableNav::new(balance_rows.len());
         Self {
             source_display,
-            rows,
-            nav,
+            balance_rows,
+            balance_nav,
+            screen: Screen::Balance,
+            overlay: None,
+            register_template,
+            should_quit: false,
         }
+    }
+
+    /// The currently-selected balance account, if any.
+    pub fn selected_balance_account(&self) -> Option<&str> {
+        let idx = self.balance_nav.table_state.selected()?;
+        self.balance_rows.get(idx).map(|r| r.account.as_str())
+    }
+
+    /// Mutable handle to whichever nav drives the currently visible table.
+    fn active_nav_mut(&mut self) -> &mut TableNav {
+        match &mut self.screen {
+            Screen::Balance => &mut self.balance_nav,
+            Screen::Register(view) => &mut view.nav,
+        }
+    }
+
+    /// Applies a message; optionally returns a [`Command`] for the event
+    /// loop to execute (the only impure step in this flow).
+    pub fn update(&mut self, msg: Message) -> Option<Command> {
+        // QuitImmediate is honored regardless of overlay/screen.
+        if matches!(msg, Message::QuitImmediate) {
+            self.should_quit = true;
+            return None;
+        }
+
+        if self.overlay.is_some() {
+            match msg {
+                Message::ConfirmQuit => self.should_quit = true,
+                Message::DismissOverlay => self.overlay = None,
+                // Ignore other input while a modal is up.
+                _ => {}
+            }
+            return None;
+        }
+
+        match msg {
+            Message::MoveUp => self.active_nav_mut().move_selection(-1),
+            Message::MoveDown => self.active_nav_mut().move_selection(1),
+            Message::PageUp => {
+                let nav = self.active_nav_mut();
+                let delta = -(nav.page_size() as isize);
+                nav.move_selection(delta);
+            }
+            Message::PageDown => {
+                let nav = self.active_nav_mut();
+                let delta = nav.page_size() as isize;
+                nav.move_selection(delta);
+            }
+            Message::SelectFirst => self.active_nav_mut().select_first(),
+            Message::SelectLast => self.active_nav_mut().select_last(),
+            Message::OpenRegister => {
+                if matches!(self.screen, Screen::Balance)
+                    && let Some(account) = self.selected_balance_account()
+                {
+                    return Some(Command::LoadRegister {
+                        account: account.to_owned(),
+                    });
+                }
+            }
+            Message::LeaveRegister => {
+                if matches!(self.screen, Screen::Register(_)) {
+                    self.screen = Screen::Balance;
+                }
+            }
+            Message::RequestQuit => {
+                if matches!(self.screen, Screen::Balance) {
+                    self.overlay = Some(Overlay::QuitConfirm);
+                }
+            }
+            // Already handled above.
+            Message::QuitImmediate | Message::ConfirmQuit | Message::DismissOverlay => {}
+        }
+        None
+    }
+
+    /// Called by the event loop once a [`Command::LoadRegister`] has been
+    /// fulfilled.
+    pub fn show_register(&mut self, account: String, rows: Vec<RegisterRow<'ctx>>) {
+        self.screen = Screen::Register(RegisterView::new(account, rows));
     }
 }
 
@@ -130,6 +307,21 @@ mod tests {
 
     fn nav(n: usize) -> TableNav {
         TableNav::new(n)
+    }
+
+    fn template<'ctx>() -> RegisterQueryTemplate<'ctx> {
+        RegisterQueryTemplate {
+            conversion: None,
+            date_range: DateRange::default(),
+        }
+    }
+
+    /// Build an `App` with no balance rows — sufficient for testing the
+    /// pure state machine. (Constructing a `BalanceRow` requires an
+    /// `Account<'ctx>`, whose interner has no public constructor outside
+    /// `okane_core`, so we side-step it.)
+    fn app_no_rows<'ctx>() -> App<'ctx> {
+        App::new("test".to_owned(), Vec::new(), template())
     }
 
     #[test]
@@ -204,5 +396,84 @@ mod tests {
         let mut n = nav(10);
         n.viewport_height = 20;
         assert_eq!(n.page_size(), 20);
+    }
+
+    #[test]
+    fn request_quit_on_balance_opens_overlay() {
+        let mut app = app_no_rows();
+        assert!(app.update(Message::RequestQuit).is_none());
+        assert_eq!(app.overlay, Some(Overlay::QuitConfirm));
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn dismiss_overlay_keeps_session_alive() {
+        let mut app = app_no_rows();
+        app.update(Message::RequestQuit);
+        app.update(Message::DismissOverlay);
+        assert_eq!(app.overlay, None);
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn confirm_quit_from_overlay_quits() {
+        let mut app = app_no_rows();
+        app.update(Message::RequestQuit);
+        app.update(Message::ConfirmQuit);
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn quit_immediate_quits_from_any_state() {
+        let mut app = app_no_rows();
+        app.update(Message::RequestQuit);
+        assert_eq!(app.overlay, Some(Overlay::QuitConfirm));
+        app.update(Message::QuitImmediate);
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn open_register_with_no_selection_is_noop() {
+        let mut app = app_no_rows();
+        assert!(app.update(Message::OpenRegister).is_none());
+        assert!(matches!(app.screen, Screen::Balance));
+    }
+
+    #[test]
+    fn nav_messages_ignored_while_overlay_visible() {
+        let mut app = app_no_rows();
+        // Pretend there are rows to move through by poking the nav directly.
+        app.balance_nav = TableNav::new(3);
+        app.update(Message::RequestQuit);
+        app.update(Message::MoveDown);
+        assert_eq!(app.balance_nav.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn leave_register_returns_to_balance() {
+        let mut app = app_no_rows();
+        // Bypass show_register's RegisterView::new — it just needs *some*
+        // register screen state to flip the enum variant.
+        app.screen = Screen::Register(RegisterView {
+            account: "Assets:Cash".to_owned(),
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        app.update(Message::LeaveRegister);
+        assert!(matches!(app.screen, Screen::Balance));
+    }
+
+    #[test]
+    fn request_quit_from_register_does_not_open_overlay() {
+        let mut app = app_no_rows();
+        app.screen = Screen::Register(RegisterView {
+            account: "Assets:Cash".to_owned(),
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        assert!(app.update(Message::RequestQuit).is_none());
+        // From register, q/Esc leaves to balance (mapped at the event layer)
+        // rather than opening the quit overlay.
+        assert_eq!(app.overlay, None);
     }
 }

--- a/cli/src/ui/event.rs
+++ b/cli/src/ui/event.rs
@@ -1,13 +1,25 @@
 //! Event loop and keyboard handling for the TUI.
+//!
+//! Architecture follows The Elm Architecture (see
+//! <https://ratatui.rs/concepts/application-patterns/the-elm-architecture/>):
+//! key events are translated into [`Message`]s by [`key_to_message`] (a pure
+//! function that consults the current screen/overlay), [`App::update`] applies
+//! them, and any returned [`Command`] is fulfilled here — the single place
+//! that owns the mutable resources (the `Ledger`) the pure state machine
+//! cannot touch.
 
-use std::io;
 use std::time::Duration;
 
+use anyhow::Context;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use lender::FallibleLender;
 use okane_core::report::ReportContext;
+use okane_core::report::query::{Ledger, RegisterQuery};
 use ratatui::DefaultTerminal;
 
-use super::app::{App, TableNav};
+use super::app::{
+    App, Command, Message, Overlay, RegisterQueryTemplate, RegisterRow, Screen,
+};
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);
@@ -16,60 +28,125 @@ const POLL_TIMEOUT: Duration = Duration::from_millis(250);
 pub fn run<'ctx>(
     terminal: &mut DefaultTerminal,
     app: &mut App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
     ctx: &ReportContext<'ctx>,
-) -> io::Result<()> {
-    while !app.nav.should_quit {
+) -> anyhow::Result<()> {
+    while !app.should_quit {
         terminal.draw(|frame| render::draw(frame, app, ctx))?;
         if event::poll(POLL_TIMEOUT)?
             && let Event::Key(key) = event::read()?
+            && let Some(msg) = key_to_message(app, key)
+            && let Some(cmd) = app.update(msg)
         {
-            handle_key_event(&mut app.nav, key);
+            fulfill(app, ledger, ctx, cmd)?;
         }
     }
     Ok(())
 }
 
-/// Applies a key event to the navigation state.
-///
-/// Pure: only mutates `nav`, no IO. Used by the event loop and by unit tests
-/// to drive synthetic input without a real terminal or a `'ctx`-bound `App`.
-pub fn handle_key_event(nav: &mut TableNav, key: KeyEvent) {
-    // crossterm on Windows emits both Press and Release events; act on Press
+/// Pure: translate a raw `KeyEvent` into a [`Message`] given the current
+/// screen and overlay. Returns `None` when the key is unmapped.
+pub fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
+    // crossterm on Windows emits both Press and Release; act on Press
     // (and `Repeat`, treated like Press) to avoid double handling.
     if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
-        return;
+        return None;
     }
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-    match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => nav.quit(),
-        KeyCode::Char('c') if ctrl => nav.quit(),
-        KeyCode::Up | KeyCode::Char('k') => nav.move_selection(-1),
-        KeyCode::Down | KeyCode::Char('j') => nav.move_selection(1),
-        KeyCode::PageUp => {
-            let delta = -(nav.page_size() as isize);
-            nav.move_selection(delta);
-        }
-        KeyCode::Char('b') if ctrl => {
-            let delta = -(nav.page_size() as isize);
-            nav.move_selection(delta);
-        }
-        KeyCode::PageDown => {
-            let delta = nav.page_size() as isize;
-            nav.move_selection(delta);
-        }
-        KeyCode::Char('f') if ctrl => {
-            let delta = nav.page_size() as isize;
-            nav.move_selection(delta);
-        }
-        KeyCode::Home | KeyCode::Char('g') => nav.select_first(),
-        KeyCode::End | KeyCode::Char('G') => nav.select_last(),
-        _ => {}
+
+    // Ctrl-C always quits — even through an open overlay.
+    if ctrl && matches!(key.code, KeyCode::Char('c')) {
+        return Some(Message::QuitImmediate);
     }
+
+    if app.overlay == Some(Overlay::QuitConfirm) {
+        return match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                Some(Message::ConfirmQuit)
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Char('q') => {
+                Some(Message::DismissOverlay)
+            }
+            _ => None,
+        };
+    }
+
+    // Common navigation keys, regardless of screen.
+    let nav = match key.code {
+        KeyCode::Up | KeyCode::Char('k') => Some(Message::MoveUp),
+        KeyCode::Down | KeyCode::Char('j') => Some(Message::MoveDown),
+        KeyCode::PageUp => Some(Message::PageUp),
+        KeyCode::Char('b') if ctrl => Some(Message::PageUp),
+        KeyCode::PageDown => Some(Message::PageDown),
+        KeyCode::Char('f') if ctrl => Some(Message::PageDown),
+        KeyCode::Home | KeyCode::Char('g') => Some(Message::SelectFirst),
+        KeyCode::End | KeyCode::Char('G') => Some(Message::SelectLast),
+        _ => None,
+    };
+    if nav.is_some() {
+        return nav;
+    }
+
+    // Screen-specific keys.
+    match (&app.screen, key.code) {
+        (Screen::Balance, KeyCode::Enter) => Some(Message::OpenRegister),
+        (Screen::Balance, KeyCode::Char('q') | KeyCode::Esc) => Some(Message::RequestQuit),
+        (Screen::Register(_), KeyCode::Char('q') | KeyCode::Esc) => {
+            Some(Message::LeaveRegister)
+        }
+        _ => None,
+    }
+}
+
+/// Executes a [`Command`] returned from [`App::update`]. The only impure
+/// step in the loop — it owns the `&mut Ledger` the pure state machine
+/// cannot touch.
+fn fulfill<'ctx>(
+    app: &mut App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+    cmd: Command,
+) -> anyhow::Result<()> {
+    match cmd {
+        Command::LoadRegister { account } => {
+            let rows = load_register(ledger, ctx, &app.register_template, &account)
+                .with_context(|| format!("failed to load register for {account}"))?;
+            app.show_register(account, rows);
+            Ok(())
+        }
+    }
+}
+
+/// Collects the register rows for `account` into owned [`RegisterRow`]s so
+/// they can be displayed without keeping the `FallibleLender` alive.
+fn load_register<'ctx>(
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+    template: &RegisterQueryTemplate<'ctx>,
+    account: &str,
+) -> anyhow::Result<Vec<RegisterRow<'ctx>>> {
+    let query = RegisterQuery {
+        account: Some(account.to_owned()),
+        date_range: template.date_range,
+        conversion: template.conversion,
+    };
+    let mut entries = ledger.register_entries(ctx, &query)?;
+    let mut rows = Vec::new();
+    while let Some(entry) = entries.next()? {
+        rows.push(RegisterRow {
+            date: entry.date,
+            payee: entry.payee.to_owned(),
+            amount: entry.amount.clone(),
+            total: entry.total.clone(),
+        });
+    }
+    Ok(rows)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::app::{RegisterView, TableNav};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -79,79 +156,140 @@ mod tests {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
     }
 
-    #[test]
-    fn arrow_keys_move_selection() {
-        let mut nav = TableNav::new(5);
-        handle_key_event(&mut nav, key(KeyCode::Down));
-        assert_eq!(nav.table_state.selected(), Some(1));
-        handle_key_event(&mut nav, key(KeyCode::Down));
-        assert_eq!(nav.table_state.selected(), Some(2));
-        handle_key_event(&mut nav, key(KeyCode::Up));
-        assert_eq!(nav.table_state.selected(), Some(1));
+    fn app<'ctx>() -> App<'ctx> {
+        App::new(
+            "test".to_owned(),
+            Vec::new(),
+            RegisterQueryTemplate {
+                conversion: None,
+                date_range: Default::default(),
+            },
+        )
     }
 
     #[test]
-    fn vim_keys_move_selection() {
-        let mut nav = TableNav::new(5);
-        handle_key_event(&mut nav, key(KeyCode::Char('j')));
-        assert_eq!(nav.table_state.selected(), Some(1));
-        handle_key_event(&mut nav, key(KeyCode::Char('k')));
-        assert_eq!(nav.table_state.selected(), Some(0));
+    fn balance_arrow_keys_map_to_nav() {
+        let app = app();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Down)),
+            Some(Message::MoveDown)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('k'))),
+            Some(Message::MoveUp)
+        );
     }
 
     #[test]
-    fn page_keys_use_viewport_height() {
-        let mut nav = TableNav::new(50);
-        nav.viewport_height = 10;
-        handle_key_event(&mut nav, key(KeyCode::PageDown));
-        assert_eq!(nav.table_state.selected(), Some(10));
-        handle_key_event(&mut nav, ctrl_key('f'));
-        assert_eq!(nav.table_state.selected(), Some(20));
-        handle_key_event(&mut nav, key(KeyCode::PageUp));
-        assert_eq!(nav.table_state.selected(), Some(10));
-        handle_key_event(&mut nav, ctrl_key('b'));
-        assert_eq!(nav.table_state.selected(), Some(0));
+    fn balance_enter_opens_register() {
+        let app = app();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Enter)),
+            Some(Message::OpenRegister)
+        );
     }
 
     #[test]
-    fn home_and_end_jump_to_bounds() {
-        let mut nav = TableNav::new(10);
-        handle_key_event(&mut nav, key(KeyCode::Char('G')));
-        assert_eq!(nav.table_state.selected(), Some(9));
-        handle_key_event(&mut nav, key(KeyCode::Char('g')));
-        assert_eq!(nav.table_state.selected(), Some(0));
-        handle_key_event(&mut nav, key(KeyCode::End));
-        assert_eq!(nav.table_state.selected(), Some(9));
-        handle_key_event(&mut nav, key(KeyCode::Home));
-        assert_eq!(nav.table_state.selected(), Some(0));
+    fn balance_q_requests_quit_confirmation() {
+        let app = app();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('q'))),
+            Some(Message::RequestQuit)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Esc)),
+            Some(Message::RequestQuit)
+        );
     }
 
     #[test]
-    fn quit_keys_set_should_quit() {
-        for code in [KeyCode::Char('q'), KeyCode::Esc] {
-            let mut nav = TableNav::new(3);
-            handle_key_event(&mut nav, key(code));
-            assert!(nav.should_quit, "quit key {code:?} did not quit");
-        }
-        let mut nav = TableNav::new(3);
-        handle_key_event(&mut nav, ctrl_key('c'));
-        assert!(nav.should_quit, "Ctrl-C did not quit");
+    fn register_q_leaves_register() {
+        let mut app = app();
+        app.screen = Screen::Register(RegisterView {
+            account: "A".into(),
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('q'))),
+            Some(Message::LeaveRegister)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Esc)),
+            Some(Message::LeaveRegister)
+        );
     }
 
     #[test]
-    fn unmapped_key_is_noop() {
-        let mut nav = TableNav::new(3);
-        handle_key_event(&mut nav, key(KeyCode::Char('x')));
-        assert_eq!(nav.table_state.selected(), Some(0));
-        assert!(!nav.should_quit);
+    fn register_enter_is_unmapped() {
+        let mut app = app();
+        app.screen = Screen::Register(RegisterView {
+            account: "A".into(),
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        assert_eq!(key_to_message(&app, key(KeyCode::Enter)), None);
+    }
+
+    #[test]
+    fn ctrl_c_always_quits() {
+        let mut app = app();
+        assert_eq!(
+            key_to_message(&app, ctrl_key('c')),
+            Some(Message::QuitImmediate)
+        );
+        app.overlay = Some(Overlay::QuitConfirm);
+        assert_eq!(
+            key_to_message(&app, ctrl_key('c')),
+            Some(Message::QuitImmediate)
+        );
+        app.overlay = None;
+        app.screen = Screen::Register(RegisterView {
+            account: "A".into(),
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        assert_eq!(
+            key_to_message(&app, ctrl_key('c')),
+            Some(Message::QuitImmediate)
+        );
+    }
+
+    #[test]
+    fn overlay_y_confirms_n_dismisses() {
+        let mut app = app();
+        app.overlay = Some(Overlay::QuitConfirm);
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('y'))),
+            Some(Message::ConfirmQuit)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('Y'))),
+            Some(Message::ConfirmQuit)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Enter)),
+            Some(Message::ConfirmQuit)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('n'))),
+            Some(Message::DismissOverlay)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Esc)),
+            Some(Message::DismissOverlay)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('q'))),
+            Some(Message::DismissOverlay)
+        );
     }
 
     #[test]
     fn key_release_is_ignored() {
-        let mut nav = TableNav::new(5);
+        let app = app();
         let release =
             KeyEvent::new_with_kind(KeyCode::Down, KeyModifiers::NONE, KeyEventKind::Release);
-        handle_key_event(&mut nav, release);
-        assert_eq!(nav.table_state.selected(), Some(0));
+        assert_eq!(key_to_message(&app, release), None);
     }
 }

--- a/cli/src/ui/render.rs
+++ b/cli/src/ui/render.rs
@@ -1,48 +1,83 @@
 //! Pure rendering functions for the TUI.
+//!
+//! The popup pattern follows
+//! <https://ratatui.rs/recipes/layout/center-a-widget/>:
+//! render a `Clear` widget over a centered rect, then render the popup
+//! contents on top.
 
-use okane_core::report::ReportContext;
+use okane_core::report::{Amount, ReportContext};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table};
 use unicode_width::UnicodeWidthStr;
 
-use super::app::{App, BalanceRow};
+use super::app::{App, BalanceRow, Overlay, RegisterRow, RegisterView, Screen};
 
-const FOOTER_HINT: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · q quit ";
+const FOOTER_HINT_BALANCE: &str =
+    " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · q quit ";
+const FOOTER_HINT_REGISTER: &str =
+    " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · q/Esc back ";
 
 /// Renders a frame for the given app state.
 pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
     let area = frame.area();
     let layout = Layout::vertical([
         Constraint::Length(1), // title bar
-        Constraint::Min(1),    // table body
+        Constraint::Min(1),    // body
         Constraint::Length(1), // footer hint
     ])
     .split(area);
 
     draw_title(frame, layout[0], app);
-    draw_body(frame, layout[1], app, ctx);
-    draw_footer(frame, layout[2]);
+    match &mut app.screen {
+        Screen::Balance => {
+            draw_balance_body(
+                frame,
+                layout[1],
+                &app.balance_rows,
+                &mut app.balance_nav,
+                ctx,
+            );
+            draw_footer(frame, layout[2], FOOTER_HINT_BALANCE);
+        }
+        Screen::Register(view) => {
+            draw_register_body(frame, layout[1], view, ctx);
+            draw_footer(frame, layout[2], FOOTER_HINT_REGISTER);
+        }
+    }
+
+    if app.overlay == Some(Overlay::QuitConfirm) {
+        draw_quit_confirm(frame, area);
+    }
 }
 
 fn draw_title(frame: &mut Frame, area: Rect, app: &App<'_>) {
-    let title = format!(" okane ui — {} ", app.source_display);
+    let title = match &app.screen {
+        Screen::Balance => format!(" okane ui — {} ", app.source_display),
+        Screen::Register(view) => format!(
+            " okane ui — {} — register: {} ",
+            app.source_display, view.account
+        ),
+    };
     let paragraph =
         Paragraph::new(Line::from(title)).style(Style::default().add_modifier(Modifier::BOLD));
     frame.render_widget(paragraph, area);
 }
 
-fn draw_body<'ctx>(frame: &mut Frame, area: Rect, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
-    // Account column gets the remaining width; amount column is fixed.
-    // The inner area excludes the surrounding border.
+fn draw_balance_body<'ctx>(
+    frame: &mut Frame,
+    area: Rect,
+    rows: &[BalanceRow<'ctx>],
+    nav: &mut super::app::TableNav,
+    ctx: &ReportContext<'ctx>,
+) {
     let block = Block::default().borders(Borders::ALL);
     let inner = block.inner(area);
-    // Update viewport height (rows visible in the body, minus the header row).
-    app.nav.viewport_height = inner.height.saturating_sub(1);
+    nav.viewport_height = inner.height.saturating_sub(1);
 
-    if app.nav.is_empty() {
+    if rows.is_empty() {
         let msg = Paragraph::new("No balances to display")
             .alignment(Alignment::Center)
             .block(block);
@@ -53,42 +88,130 @@ fn draw_body<'ctx>(frame: &mut Frame, area: Rect, app: &mut App<'ctx>, ctx: &Rep
     let header = Row::new(vec![Cell::from("Account"), Cell::from("Amount")])
         .style(Style::default().add_modifier(Modifier::BOLD));
 
-    // Format each row's amount lines once; reused for width and row construction.
-    let formatted: Vec<Vec<String>> = app
-        .rows
+    let formatted: Vec<Vec<String>> = rows
         .iter()
         .map(|row| format_amount_lines(&row.amount, ctx))
         .collect();
     let amount_width = compute_amount_width(&formatted);
-    let rows: Vec<Row> = app
-        .rows
+    let table_rows: Vec<Row> = rows
         .iter()
         .zip(formatted.iter())
-        .map(|(row, lines)| make_row(row, lines))
+        .map(|(row, lines)| make_balance_row(row, lines))
         .collect();
 
     let table = Table::new(
-        rows,
+        table_rows,
         [Constraint::Min(10), Constraint::Length(amount_width)],
     )
     .header(header)
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .block(block);
 
-    frame.render_stateful_widget(table, area, &mut app.nav.table_state);
+    frame.render_stateful_widget(table, area, &mut nav.table_state);
 }
 
-fn draw_footer(frame: &mut Frame, area: Rect) {
-    let footer = Paragraph::new(FOOTER_HINT).style(Style::default().add_modifier(Modifier::DIM));
+fn draw_register_body<'ctx>(
+    frame: &mut Frame,
+    area: Rect,
+    view: &mut RegisterView<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) {
+    let block = Block::default().borders(Borders::ALL);
+    let inner = block.inner(area);
+    view.nav.viewport_height = inner.height.saturating_sub(1);
+
+    if view.rows.is_empty() {
+        let msg = Paragraph::new("No register entries to display")
+            .alignment(Alignment::Center)
+            .block(block);
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("Date"),
+        Cell::from("Payee"),
+        Cell::from("Amount"),
+        Cell::from("Total"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let amount_lines: Vec<Vec<String>> = view
+        .rows
+        .iter()
+        .map(|row| format_amount_lines(&row.amount, ctx))
+        .collect();
+    let total_lines: Vec<Vec<String>> = view
+        .rows
+        .iter()
+        .map(|row| format_amount_lines(&row.total, ctx))
+        .collect();
+    let amount_width = compute_amount_width(&amount_lines);
+    let total_width = compute_amount_width(&total_lines);
+
+    let table_rows: Vec<Row> = view
+        .rows
+        .iter()
+        .zip(amount_lines.iter())
+        .zip(total_lines.iter())
+        .map(|((row, amt), tot)| make_register_row(row, amt, tot))
+        .collect();
+
+    let table = Table::new(
+        table_rows,
+        [
+            Constraint::Length(10), // YYYY-MM-DD
+            Constraint::Min(10),    // payee, takes remaining
+            Constraint::Length(amount_width),
+            Constraint::Length(total_width),
+        ],
+    )
+    .header(header)
+    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+    .block(block);
+
+    frame.render_stateful_widget(table, area, &mut view.nav.table_state);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, hint: &str) {
+    let footer = Paragraph::new(hint).style(Style::default().add_modifier(Modifier::DIM));
     frame.render_widget(footer, area);
 }
 
-/// Formats the amount lines for one balance — one line per commodity, or a
-/// single `"0"` line when the balance is empty.
-fn format_amount_lines<'ctx>(
-    amount: &okane_core::report::Amount<'ctx>,
-    ctx: &ReportContext<'ctx>,
-) -> Vec<String> {
+/// Centered modal asking the user to confirm quitting.
+fn draw_quit_confirm(frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(area, 40, 5);
+    // Clear first so the popup paints over the table cleanly.
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Quit? ")
+        .style(Style::default().add_modifier(Modifier::BOLD));
+    let body = Paragraph::new(vec![
+        Line::from(""),
+        Line::from("Quit okane ui? (y/n)").alignment(Alignment::Center),
+    ])
+    .block(block);
+    frame.render_widget(body, popup);
+}
+
+/// Returns a sub-rect of `area` of the given size, centered.
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    Rect {
+        x,
+        y,
+        width,
+        height,
+    }
+}
+
+/// Formats the amount lines for one balance/register cell — one line per
+/// commodity, or a single `"0"` line when the balance is empty.
+fn format_amount_lines<'ctx>(amount: &Amount<'ctx>, ctx: &ReportContext<'ctx>) -> Vec<String> {
     let mut lines: Vec<String> = amount
         .iter()
         .map(|single| single.as_display(ctx).to_string())
@@ -99,21 +222,35 @@ fn format_amount_lines<'ctx>(
     lines
 }
 
-/// Builds a multi-line table row for one balance entry. The account label
-/// appears only on the first line; remaining lines belong to additional
-/// commodities of the same account.
-fn make_row<'r>(row: &'r BalanceRow<'_>, lines: &'r [String]) -> Row<'r> {
+fn make_balance_row<'r>(row: &'r BalanceRow<'_>, lines: &'r [String]) -> Row<'r> {
     let height = row.line_count();
     let account_cell = Cell::from(row.account.as_str());
-    let amount_lines: Vec<Line> = lines
-        .iter()
-        .map(|s| Line::from(s.as_str()).alignment(Alignment::Right))
-        .collect();
-    let amount_cell = Cell::from(Text::from(amount_lines));
+    let amount_cell = Cell::from(amount_text(lines));
     Row::new(vec![account_cell, amount_cell]).height(height)
 }
 
-/// Returns the display width (in columns) needed for the amount column.
+fn make_register_row<'r>(
+    row: &'r RegisterRow<'_>,
+    amount_lines: &'r [String],
+    total_lines: &'r [String],
+) -> Row<'r> {
+    let height = row.line_count();
+    let date_cell = Cell::from(row.date.to_string());
+    let payee_cell = Cell::from(row.payee.as_str());
+    let amount_cell = Cell::from(amount_text(amount_lines));
+    let total_cell = Cell::from(amount_text(total_lines));
+    Row::new(vec![date_cell, payee_cell, amount_cell, total_cell]).height(height)
+}
+
+fn amount_text<'a>(lines: &'a [String]) -> Text<'a> {
+    let lines: Vec<Line<'a>> = lines
+        .iter()
+        .map(|s| Line::from(s.as_str()).alignment(Alignment::Right))
+        .collect();
+    Text::from(lines)
+}
+
+/// Returns the display width (in columns) needed for an amount column.
 fn compute_amount_width(formatted: &[Vec<String>]) -> u16 {
     let max = formatted
         .iter()
@@ -175,8 +312,35 @@ mod tests {
         let amount = Amount::from_value(usd, dec!(100)) + Amount::from_value(eur, dec!(200));
         let lines = format_amount_lines(&amount, &ctx);
         assert_eq!(lines.len(), 2);
-        // BTreeMap iteration → ordered by CommodityTag (insertion order via interner).
         assert!(lines.iter().any(|s| s == "100 USD"));
         assert!(lines.iter().any(|s| s == "200 EUR"));
+    }
+
+    #[test]
+    fn centered_rect_sits_in_the_middle() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 30,
+        };
+        let r = centered_rect(area, 40, 6);
+        assert_eq!(r.width, 40);
+        assert_eq!(r.height, 6);
+        assert_eq!(r.x, 30);
+        assert_eq!(r.y, 12);
+    }
+
+    #[test]
+    fn centered_rect_clamps_to_area() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 4,
+        };
+        let r = centered_rect(area, 40, 6);
+        assert_eq!(r.width, 10);
+        assert_eq!(r.height, 4);
     }
 }


### PR DESCRIPTION
## Summary

- Press **Enter** on a balance row → opens a register table for that account.
- **q/Esc** on the register screen → returns to the balance screen with the same row selected.
- **q/Esc** on the balance screen → opens a centered confirmation popup (`Quit? y/n`).
- **Ctrl-C** quits immediately from any screen, bypassing confirmation.

## Architecture

The TUI is restructured around [The Elm Architecture](https://ratatui.rs/concepts/application-patterns/the-elm-architecture/):

- State lives in `App`, all transitions go through `App::update(Message) -> Option<Command>`.
- `key_to_message` is pure and screen-aware; `fulfill` is the only impure step and owns the `&mut Ledger` needed by `Command::LoadRegister`.
- Screens are an enum (`Balance` / `Register`); the quit popup is modeled as `Overlay::QuitConfirm` and rendered with the standard `Clear`-over-centered-rect pattern from the [popup recipe](https://ratatui.rs/recipes/layout/center-a-widget/).
- `should_quit` moved off `TableNav` (which is now pure scroll/selection) up to `App`.

Drill-down reuses the existing core `Ledger::register_entries` iterator (#314), filtered by the selected account name, with the same conversion / date range as the balance.

## Test plan

- [x] `cargo test -p okane` — 161 unit + integration tests pass
- [x] `cargo clippy -p okane --all-targets` — clean
- [ ] Manual: launch `okane ui <file>`, drill into an account with Enter, return with q
- [ ] Manual: press q on balance, verify popup; y quits, n/Esc/q dismisses
- [ ] Manual: Ctrl-C exits cleanly from balance, register, and from the open popup

## Follow-ups

- #424 — subaccount-aware filter for register drill-down (Enter on `Expenses` currently yields an empty register)
- #425 — Component-pattern refactor once `App` grows past a couple of screens
- #426 — shape of future `Command`s (recompute / export / pager)
- #427 — dedupe the table-viewport boilerplate when a third table screen appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)