### PR TITLE
Pick date-range bench windows from each dataset's date span

### DIFF
--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -159,22 +159,24 @@ fn query_balance(c: &mut Criterion) {
         let mut ledger = report::process(&mut ctx, input.new_loader(), &opts)
             .expect("report::process must succeed");
 
-        let query = report::query::BalanceQuery {
-            date_range: report::query::DateRange {
-                start: Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
-                end: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
-            },
-            conversion: None,
-        };
-        group.bench_with_input(
-            BenchmarkId::new("date-range", params),
-            &params,
-            |b, _params| {
+        for (label, (start, end)) in [
+            ("date-range-first10", params.date_range_first()),
+            ("date-range-middle20", params.date_range_middle()),
+            ("date-range-last30", params.date_range_last()),
+        ] {
+            let query = report::query::BalanceQuery {
+                date_range: report::query::DateRange {
+                    start: Some(start),
+                    end: Some(end),
+                },
+                conversion: None,
+            };
+            group.bench_with_input(BenchmarkId::new(label, params), &params, |b, _params| {
                 b.iter_with_large_drop(|| {
                     black_box(ledger.balance(&ctx, &query).unwrap());
                 })
-            },
-        );
+            });
+        }
     }
 
     for params in InputParams::params_from_env() {
@@ -330,7 +332,8 @@ fn query_register_entries(c: &mut Criterion) {
         );
     }
 
-    // date-range — one-year window, no account filter, no conversion
+    // date-range — three windows (first 10%, middle 20%, last 30% of the
+    // dataset's date span), no account filter, no conversion
     for params in InputParams::params_from_env() {
         let input = FakeFileSink::new_example(Path::new("report_bench"), params).unwrap();
         let arena = Bump::new();
@@ -339,17 +342,19 @@ fn query_register_entries(c: &mut Criterion) {
         let mut ledger = report::process(&mut ctx, input.new_loader(), &opts)
             .expect("report::process must succeed");
 
-        let query = report::query::RegisterQuery {
-            date_range: report::query::DateRange {
-                start: Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
-                end: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
-            },
-            ..Default::default()
-        };
-        group.bench_with_input(
-            BenchmarkId::new("date-range", params),
-            &params,
-            |b, _params| {
+        for (label, (start, end)) in [
+            ("date-range-first10", params.date_range_first()),
+            ("date-range-middle20", params.date_range_middle()),
+            ("date-range-last30", params.date_range_last()),
+        ] {
+            let query = report::query::RegisterQuery {
+                date_range: report::query::DateRange {
+                    start: Some(start),
+                    end: Some(end),
+                },
+                ..Default::default()
+            };
+            group.bench_with_input(BenchmarkId::new(label, params), &params, |b, _params| {
                 b.iter_with_large_drop(|| {
                     let mut entries = ledger.register_entries(&ctx, &query).unwrap();
                     let mut count = 0u64;
@@ -361,8 +366,8 @@ fn query_register_entries(c: &mut Criterion) {
                     }
                     black_box(count)
                 })
-            },
-        );
+            });
+        }
     }
 
     // conversion-historical — no pricedb, historical conversion to CHF

--- a/core/benches/testing/mod.rs
+++ b/core/benches/testing/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use okane_core::load;
 
-use chrono::{Datelike, NaiveDate, Weekday};
+use chrono::{Datelike, Days, NaiveDate, Weekday};
 use pretty_decimal::PrettyDecimal;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -156,6 +156,36 @@ impl InputParams {
 
     fn years(&self) -> impl Iterator<Item = Year> {
         (YEAR_BEGIN..YEAR_BEGIN + self.num_years).map(Year)
+    }
+
+    /// Returns a `[start, end)` date window covering `length_pct` percent of
+    /// the dataset's date span, starting `start_pct` percent in from the
+    /// beginning. The dataset spans `[YEAR_BEGIN-01-01, (YEAR_BEGIN+num_years)-01-01)`.
+    fn date_window(&self, start_pct: u32, length_pct: u32) -> (NaiveDate, NaiveDate) {
+        debug_assert!(start_pct + length_pct <= 100);
+        let begin = NaiveDate::from_ymd_opt(YEAR_BEGIN, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(YEAR_BEGIN + self.num_years, 1, 1).unwrap();
+        let total_days = (end - begin).num_days() as u64;
+        let start_offset = total_days * start_pct as u64 / 100;
+        let end_offset = total_days * (start_pct + length_pct) as u64 / 100;
+        let start = begin.checked_add_days(Days::new(start_offset)).unwrap();
+        let stop = begin.checked_add_days(Days::new(end_offset)).unwrap();
+        (start, stop)
+    }
+
+    /// First 10% of the dataset's date span.
+    pub fn date_range_first(&self) -> (NaiveDate, NaiveDate) {
+        self.date_window(0, 10)
+    }
+
+    /// Middle 20% of the dataset's date span (40%..60%).
+    pub fn date_range_middle(&self) -> (NaiveDate, NaiveDate) {
+        self.date_window(40, 20)
+    }
+
+    /// Last 30% of the dataset's date span.
+    pub fn date_range_last(&self) -> (NaiveDate, NaiveDate) {
+        self.date_window(70, 30)
     }
 }
 


### PR DESCRIPTION
## Summary

- `balance/date-range` and `register/date-range` hardcoded `2024-01-01 .. 2025-01-01`. For `small_5y10a200t` (data spans 2015-2019) this window misses every transaction; for `middle_10y16a500t` (data spans 2015-2024) it barely intersects. The benches were measuring iterator dispatch on empty results, not the date-range path itself — flagged in [#428](https://github.com/xkikeg/okane/pull/428) review.
- Add `InputParams::date_range_first` / `date_range_middle` / `date_range_last`, which derive `[start, end)` windows from each dataset's actual span (`YEAR_BEGIN` .. `YEAR_BEGIN + num_years`).
- Each `date-range` bench becomes three variants: `date-range-first10` (first 10%), `date-range-middle20` (middle 20%), `date-range-last30` (last 30%). Every variant matches real data across all configured `InputParams`.

## Result on `small_5y10a200t` (`register` query, sample-size 10)

| bench | time |
|---|---|
| `register/date-range-first10` | 83.0 µs |
| `register/date-range-middle20` | 117.5 µs |
| `register/date-range-last30` | 176.0 µs |

Times now scale with window size, confirming real rows are being matched and the dispatch-only artifact is gone.

## Test plan

- [x] `cargo check --benches -p okane-core`
- [x] `cargo clippy --benches -p okane-core` — clean
- [x] `cargo bench -p okane-core --bench report_bench -- --list` — confirms the new IDs (`date-range-first10` / `-middle20` / `-last30`) replace the old `date-range` IDs for both `query::balance` and `query::register`.
- [x] Smoke ran `query::register/date-range-*/small_5y10a200t` end-to-end and observed non-trivial, size-proportional timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)