### PR TITLE
Use resolver v3 so cargo install respects workspace MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ members = [
 ]
 
 # for workspace, we need to specify resolver explicitly.
-resolver = "2"
+# resolver = "3" enables MSRV-aware version selection, so `cargo install`
+# (which re-resolves and ignores Cargo.lock) does not pick transitive deps
+# requiring a newer rustc than our `rust-version`.
+resolver = "3"
 
 [workspace.package]
 version = "0.19.0"


### PR DESCRIPTION
## Summary
- `cargo install --path cli/` failed on rustc 1.95.0 because it re-resolves dependencies (ignoring `Cargo.lock`) and pulled in `maybe-dangling 0.1.3`, which requires rustc 1.96.0.
- `cargo build` / `cargo build --release` were unaffected since they honor `Cargo.lock` (where `maybe-dangling` is pinned to `0.1.2`).
- Switching the workspace to `resolver = "3"` turns on MSRV-aware version selection, so the resolver skips transitive deps that exceed `rust-version` (currently `1.88.0`). MSRV is unchanged and no `cargo update` is needed.

## Test plan
- [x] `cargo install --path cli/ --force` succeeds on rustc 1.95.0
- [x] `cargo check` succeeds
- [x] `cargo check --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)