### PR TITLE
Make AccountFilter public with Exact variant and typed Account interface

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -403,7 +403,12 @@ impl RegisterCmd {
             &self.eval_options.to_process_options(),
         )?;
         let query = query::RegisterQuery {
-            account: self.account.clone(),
+            account: self
+                .account
+                .as_deref()
+                .map_or(query::AccountFilter::Any, |s| {
+                    query::AccountFilter::from_pattern(&ctx, s)
+                }),
             date_range: self.eval_options.to_date_range()?,
             conversion: self.eval_options.to_conversion(&ctx)?,
             sort: self.sort.into(),

--- a/cli/src/ui/app.rs
+++ b/cli/src/ui/app.rs
@@ -129,13 +129,13 @@ pub struct RegisterQueryTemplate<'ctx> {
 /// State for the register drill-down screen.
 #[derive(Debug)]
 pub struct RegisterView<'ctx> {
-    pub account: String,
+    pub account: Account<'ctx>,
     pub rows: Vec<RegisterRow<'ctx>>,
     pub nav: TableNav,
 }
 
 impl<'ctx> RegisterView<'ctx> {
-    pub fn new(account: String, rows: Vec<RegisterRow<'ctx>>) -> Self {
+    pub fn new(account: Account<'ctx>, rows: Vec<RegisterRow<'ctx>>) -> Self {
         let mut nav = TableNav::new(rows.len());
         // Most recent entry is the most useful starting point.
         nav.select_last();
@@ -182,9 +182,9 @@ pub enum Message {
 
 /// Effect requested by [`App::update`] that requires resources the pure
 /// state machine does not own (here: `&mut Ledger` to compute a register).
-#[derive(Debug, Clone)]
-pub enum Command {
-    LoadRegister { account: String },
+#[derive(Debug, Clone, Copy)]
+pub enum Command<'ctx> {
+    LoadRegister { account: Account<'ctx> },
 }
 
 /// Application state for the TUI session.
@@ -218,9 +218,9 @@ impl<'ctx> App<'ctx> {
     }
 
     /// The currently-selected balance account, if any.
-    pub fn selected_balance_account(&self) -> Option<&str> {
+    pub fn selected_balance_account(&self) -> Option<Account<'ctx>> {
         let idx = self.balance_nav.table_state.selected()?;
-        self.balance_rows.get(idx).map(|r| r.account.as_str())
+        self.balance_rows.get(idx).map(|r| r.account)
     }
 
     /// Mutable handle to whichever nav drives the currently visible table.
@@ -233,7 +233,7 @@ impl<'ctx> App<'ctx> {
 
     /// Applies a message; optionally returns a [`Command`] for the event
     /// loop to execute (the only impure step in this flow).
-    pub fn update(&mut self, msg: Message) -> Option<Command> {
+    pub fn update(&mut self, msg: Message) -> Option<Command<'ctx>> {
         // QuitImmediate is honored regardless of overlay/screen.
         if matches!(msg, Message::QuitImmediate) {
             self.should_quit = true;
@@ -269,9 +269,7 @@ impl<'ctx> App<'ctx> {
                 if matches!(self.screen, Screen::Balance)
                     && let Some(account) = self.selected_balance_account()
                 {
-                    return Some(Command::LoadRegister {
-                        account: account.to_owned(),
-                    });
+                    return Some(Command::LoadRegister { account });
                 }
             }
             Message::LeaveRegister => {
@@ -292,14 +290,18 @@ impl<'ctx> App<'ctx> {
 
     /// Called by the event loop once a [`Command::LoadRegister`] has been
     /// fulfilled.
-    pub fn show_register(&mut self, account: String, rows: Vec<RegisterRow<'ctx>>) {
+    pub fn show_register(&mut self, account: Account<'ctx>, rows: Vec<RegisterRow<'ctx>>) {
         self.screen = Screen::Register(RegisterView::new(account, rows));
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
     use bumpalo::Bump;
+    use okane_core::{load, report};
     use okane_core::report::ReportContext;
     use rust_decimal_macros::dec;
 
@@ -322,6 +324,29 @@ mod tests {
     /// `okane_core`, so we side-step it.)
     fn app_no_rows<'ctx>() -> App<'ctx> {
         App::new("test".to_owned(), Vec::new(), template())
+    }
+
+    /// Process a trivial ledger and return the context + a resolved account.
+    fn make_account<'ctx>(
+        arena: &'ctx Bump,
+        account_name: &str,
+    ) -> (ReportContext<'ctx>, Account<'ctx>) {
+        let content = format!(
+            "2024/01/01 Init\n    {account_name}    100 USD\n    Equity\n"
+        );
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("test.ledger"),
+            content.into_bytes(),
+        );
+        let loader = load::Loader::new(
+            PathBuf::from("test.ledger"),
+            load::FakeFileSystem::from(map),
+        );
+        let mut ctx = ReportContext::new(arena);
+        let _ = report::process(&mut ctx, loader, &report::ProcessOptions::default()).unwrap();
+        let account = ctx.account(account_name).unwrap();
+        (ctx, account)
     }
 
     #[test]
@@ -451,11 +476,13 @@ mod tests {
 
     #[test]
     fn leave_register_returns_to_balance() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:Cash");
         let mut app = app_no_rows();
         // Bypass show_register's RegisterView::new — it just needs *some*
         // register screen state to flip the enum variant.
         app.screen = Screen::Register(RegisterView {
-            account: "Assets:Cash".to_owned(),
+            account,
             rows: Vec::new(),
             nav: TableNav::new(0),
         });
@@ -465,9 +492,11 @@ mod tests {
 
     #[test]
     fn request_quit_from_register_does_not_open_overlay() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:Cash");
         let mut app = app_no_rows();
         app.screen = Screen::Register(RegisterView {
-            account: "Assets:Cash".to_owned(),
+            account,
             rows: Vec::new(),
             nav: TableNav::new(0),
         });

--- a/cli/src/ui/event.rs
+++ b/cli/src/ui/event.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 use anyhow::Context;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use lender::FallibleLender;
-use okane_core::report::ReportContext;
-use okane_core::report::query::{Ledger, RegisterQuery, Sort};
+use okane_core::report::{Account, ReportContext};
+use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
 use ratatui::DefaultTerminal;
 
 use super::app::{
@@ -105,12 +105,12 @@ fn fulfill<'ctx>(
     app: &mut App<'ctx>,
     ledger: &mut Ledger<'ctx>,
     ctx: &ReportContext<'ctx>,
-    cmd: Command,
+    cmd: Command<'ctx>,
 ) -> anyhow::Result<()> {
     match cmd {
         Command::LoadRegister { account } => {
-            let rows = load_register(ledger, ctx, &app.register_template, &account)
-                .with_context(|| format!("failed to load register for {account}"))?;
+            let rows = load_register(ledger, ctx, &app.register_template, account)
+                .with_context(|| format!("failed to load register for {}", account.as_str()))?;
             app.show_register(account, rows);
             Ok(())
         }
@@ -123,10 +123,10 @@ fn load_register<'ctx>(
     ledger: &mut Ledger<'ctx>,
     ctx: &ReportContext<'ctx>,
     template: &RegisterQueryTemplate<'ctx>,
-    account: &str,
+    account: Account<'ctx>,
 ) -> anyhow::Result<Vec<RegisterRow<'ctx>>> {
     let query = RegisterQuery {
-        account: Some(account.to_owned()),
+        account: AccountFilter::single(account),
         date_range: template.date_range,
         conversion: template.conversion,
         sort: Sort::Date,
@@ -146,6 +146,12 @@ fn load_register<'ctx>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use bumpalo::Bump;
+    use okane_core::{load, report};
+
     use super::*;
     use crate::ui::app::{RegisterView, TableNav};
 
@@ -166,6 +172,25 @@ mod tests {
                 date_range: Default::default(),
             },
         )
+    }
+
+    /// Process a trivial ledger and return a resolved account.
+    fn make_account<'ctx>(
+        arena: &'ctx Bump,
+        account_name: &str,
+    ) -> (report::ReportContext<'ctx>, Account<'ctx>) {
+        let content = format!("2024/01/01 Init\n    {account_name}    1 USD\n    Equity\n");
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("test.ledger"), content.into_bytes());
+        let loader = load::Loader::new(
+            PathBuf::from("test.ledger"),
+            load::FakeFileSystem::from(map),
+        );
+        let mut ctx = report::ReportContext::new(arena);
+        let _ =
+            report::process(&mut ctx, loader, &report::ProcessOptions::default()).unwrap();
+        let account = ctx.account(account_name).unwrap();
+        (ctx, account)
     }
 
     #[test]
@@ -205,9 +230,11 @@ mod tests {
 
     #[test]
     fn register_q_leaves_register() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut app = app();
         app.screen = Screen::Register(RegisterView {
-            account: "A".into(),
+            account,
             rows: Vec::new(),
             nav: TableNav::new(0),
         });
@@ -223,9 +250,11 @@ mod tests {
 
     #[test]
     fn register_enter_is_unmapped() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut app = app();
         app.screen = Screen::Register(RegisterView {
-            account: "A".into(),
+            account,
             rows: Vec::new(),
             nav: TableNav::new(0),
         });
@@ -234,6 +263,8 @@ mod tests {
 
     #[test]
     fn ctrl_c_always_quits() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut app = app();
         assert_eq!(
             key_to_message(&app, ctrl_key('c')),
@@ -246,7 +277,7 @@ mod tests {
         );
         app.overlay = None;
         app.screen = Screen::Register(RegisterView {
-            account: "A".into(),
+            account,
             rows: Vec::new(),
             nav: TableNav::new(0),
         });

--- a/cli/src/ui/render.rs
+++ b/cli/src/ui/render.rs
@@ -58,7 +58,8 @@ fn draw_title(frame: &mut Frame, area: Rect, app: &App<'_>) {
         Screen::Balance => format!(" okane ui — {} ", app.source_display),
         Screen::Register(view) => format!(
             " okane ui — {} — register: {} ",
-            app.source_display, view.account
+            app.source_display,
+            view.account.as_str()
         ),
     };
     let paragraph =

--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -119,7 +119,10 @@ fn query_postings(c: &mut Criterion) {
     c.bench_function("query-posting-one-account", |b| {
         b.iter_with_large_drop(|| {
             let query = report::query::PostingQuery {
-                account: Some("Assets:Account02".to_string()),
+                account: report::query::AccountFilter::single(
+                    ctx.account("Assets:Account02")
+                        .expect("Assets:Account02 must exist in bench fixture"),
+                ),
             };
             black_box(ledger.postings(&ctx, &query));
         })
@@ -310,7 +313,10 @@ fn query_register_entries(c: &mut Criterion) {
             .expect("report::process must succeed");
 
         let query = report::query::RegisterQuery {
-            account: Some("Assets:Account02".to_string()),
+            account: report::query::AccountFilter::single(
+                ctx.account("Assets:Account02")
+                    .expect("Assets:Account02 must exist in bench fixture"),
+            ),
             ..Default::default()
         };
         group.bench_with_input(

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -59,11 +59,11 @@ pub enum QueryError {
 
 /// Query to list postings matching the criteria.
 // TODO: non_exhaustive
-#[derive(Debug)]
-pub struct PostingQuery {
+#[derive(Debug, Default)]
+pub struct PostingQuery<'ctx> {
     /// Select the specified account if specified.
     /// Note this will be changed to list of regex eventually.
-    pub account: Option<String>,
+    pub account: AccountFilter<'ctx>,
 }
 
 /// Specifies the iteration order of `register` rows.
@@ -82,7 +82,7 @@ pub enum Sort {
 pub struct RegisterQuery<'ctx> {
     /// Select the specified account if specified.
     /// Note this will be changed to a list of regex eventually.
-    pub account: Option<String>,
+    pub account: AccountFilter<'ctx>,
     /// Half-open date range to restrict transactions.
     pub date_range: DateRange,
     /// Optional currency conversion applied to every yielded amount and to the
@@ -236,18 +236,15 @@ impl<'ctx> Ledger<'ctx> {
     // https://github.com/xkikeg/okane/issues/313
     pub fn postings<'a>(
         &'a self,
-        ctx: &ReportContext<'ctx>,
-        query: &PostingQuery,
+        _ctx: &ReportContext<'ctx>,
+        query: &PostingQuery<'ctx>,
     ) -> Vec<&'a Posting<'ctx>> {
-        // compile them into compiled query.
-        let af = AccountFilter::new(ctx, query.account.as_deref());
-        let af = match af {
-            None => return Vec::new(),
-            Some(af) => af,
-        };
+        if query.account.is_exhaustive_empty() {
+            return Vec::new();
+        }
         self.transactions()
             .flat_map(|txn| &*txn.postings)
-            .filter(|x| af.is_match(&x.account))
+            .filter(|x| query.account.is_match(&x.account))
             .collect()
     }
 
@@ -280,32 +277,35 @@ impl<'ctx> Ledger<'ctx> {
                 }
             },
         };
-        // When the account filter excludes every known account, return an
-        // iterator that is already exhausted instead of scanning everything.
-        let account_filter = AccountFilter::new(ctx, query.account.as_deref());
-        let txns: TxnIter<'a, 'ctx> = match (account_filter.as_ref(), query.sort) {
-            (None, _) => TxnIter::linear(&[]),
-            (Some(_), Sort::Original) => TxnIter::linear(&self.transactions),
-            // Build (or reuse) the date-sorted clone cache. Bounds are
-            // applied via `date_range_iter` (binary-search lo, incremental
-            // `end` check), so the inner `date_range.contains` check below
-            // is a no-op on every txn yielded here — it's kept for the
-            // `Linear` arms above.
-            (Some(_), Sort::Date) => {
-                self.ensure_date_sorted_txns();
-                date_range_iter(
-                    self.date_sorted_txns
-                        .as_deref()
-                        .expect("just built by ensure_date_sorted_txns"),
-                    query.date_range,
-                )
+        let account_filter = query.account.clone();
+        // When the account filter can never match, return an iterator that is
+        // already exhausted instead of scanning everything.
+        let txns: TxnIter<'a, 'ctx> = if account_filter.is_exhaustive_empty() {
+            TxnIter::linear(&[])
+        } else {
+            match query.sort {
+                Sort::Original => TxnIter::linear(&self.transactions),
+                // Build (or reuse) the date-sorted clone cache. Bounds are
+                // applied via `date_range_iter` (binary-search lo, incremental
+                // `end` check), so the inner `date_range.contains` check below
+                // is a no-op on every txn yielded here — it's kept for the
+                // `Linear` arms above.
+                Sort::Date => {
+                    self.ensure_date_sorted_txns();
+                    date_range_iter(
+                        self.date_sorted_txns
+                            .as_deref()
+                            .expect("just built by ensure_date_sorted_txns"),
+                        query.date_range,
+                    )
+                }
             }
         };
         Ok(RegisterEntries {
             ctx,
             txns,
             current: [].iter(),
-            account_filter: account_filter.unwrap_or(AccountFilter::Any),
+            account_filter,
             date_range: query.date_range,
             conversion,
             price_repos: &mut self.price_repos,
@@ -599,31 +599,44 @@ fn compute_balance<'a, 'ctx>(
     Ok(bal)
 }
 
-enum AccountFilter<'ctx> {
+/// Describes which accounts to include in a query.
+#[derive(Debug, Clone, Default)]
+pub enum AccountFilter<'ctx> {
+    /// Match every account.
+    #[default]
     Any,
+    /// Match exactly one account (O(1) equality check).
+    Exact(Account<'ctx>),
+    /// Match any account in the set (intended for future multi-pattern / regex support).
     Set(HashSet<Account<'ctx>>),
 }
 
 impl<'ctx> AccountFilter<'ctx> {
-    /// Creates a new instance, unless there's no matching account.
-    fn new(ctx: &ReportContext<'ctx>, filter: Option<&str>) -> Option<Self> {
-        let filter = match filter {
-            None => return Some(AccountFilter::Any),
-            Some(filter) => filter,
-        };
-        let targets: HashSet<_> = ctx
-            .all_accounts_unsorted()
-            .filter(|x| x.as_str() == filter)
-            .collect();
-        if targets.is_empty() {
-            return None;
+    /// Returns a filter matching exactly one already-resolved account.
+    pub fn single(account: Account<'ctx>) -> Self {
+        AccountFilter::Exact(account)
+    }
+
+    /// Resolves a string pattern against the context's known accounts.
+    ///
+    /// Returns `AccountFilter::Exact` on a match, or an empty
+    /// `AccountFilter::Set` (matches nothing) when the pattern is unknown.
+    pub fn from_pattern(ctx: &ReportContext<'ctx>, pattern: &str) -> Self {
+        match ctx.account(pattern) {
+            Some(account) => AccountFilter::Exact(account),
+            None => AccountFilter::Set(HashSet::new()),
         }
-        Some(AccountFilter::Set(targets))
+    }
+
+    /// Returns `true` when the filter can never match any account.
+    fn is_exhaustive_empty(&self) -> bool {
+        matches!(self, AccountFilter::Set(s) if s.is_empty())
     }
 
     fn is_match(&self, account: &Account<'ctx>) -> bool {
         match self {
             AccountFilter::Any => true,
+            AccountFilter::Exact(target) => account == target,
             AccountFilter::Set(targets) => targets.contains(account),
         }
     }
@@ -1000,7 +1013,7 @@ mod tests {
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: Some("Assets:J 銀行".to_string()),
+                        account: AccountFilter::single(bank),
                         date_range: DateRange::default(),
                         conversion: None,
                         sort: Sort::Original,
@@ -1050,7 +1063,7 @@ mod tests {
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: None,
+                        account: AccountFilter::Any,
                         date_range: DateRange {
                             start: Some(NaiveDate::from_ymd_opt(2024, 1, 5).unwrap()),
                             end: Some(NaiveDate::from_ymd_opt(2024, 1, 9).unwrap()),
@@ -1095,7 +1108,7 @@ mod tests {
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: Some("Does:Not:Exist".to_string()),
+                        account: AccountFilter::from_pattern(&ctx, "Does:Not:Exist"),
                         date_range: DateRange::default(),
                         conversion: None,
                         sort: Sort::Original,
@@ -1123,7 +1136,7 @@ mod tests {
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: None,
+                        account: AccountFilter::Any,
                         date_range: DateRange {
                             start: Some(NaiveDate::from_ymd_opt(2024, 1, 5).unwrap()),
                             end: Some(NaiveDate::from_ymd_opt(2024, 1, 6).unwrap()),
@@ -1169,7 +1182,7 @@ mod tests {
             .register_entries(
                 &ctx,
                 &RegisterQuery {
-                    account: None,
+                    account: AccountFilter::Any,
                     date_range: DateRange::default(),
                     conversion: Some(Conversion {
                         strategy: ConversionStrategy::UpToDate {
@@ -1252,7 +1265,7 @@ mod tests {
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: Some("Assets:Bank".to_string()),
+                        account: AccountFilter::single(bank),
                         sort: Sort::Original,
                         ..Default::default()
                     },
@@ -1280,12 +1293,13 @@ mod tests {
         let mut ledger =
             report::process(&mut ctx, unordered_loader(), &report::ProcessOptions::default())
                 .unwrap();
+        let bank = ctx.account("Assets:Bank").unwrap();
         let rows = collect_register(
             ledger
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: Some("Assets:Bank".to_string()),
+                        account: AccountFilter::single(bank),
                         sort: Sort::Date,
                         ..Default::default()
                     },
@@ -1314,12 +1328,13 @@ mod tests {
             report::process(&mut ctx, unordered_loader(), &report::ProcessOptions::default())
                 .unwrap();
         let jpy = ctx.commodities.resolve("JPY").unwrap();
+        let bank = ctx.account("Assets:Bank").unwrap();
         let rows = collect_register(
             ledger
                 .register_entries(
                     &ctx,
                     &RegisterQuery {
-                        account: Some("Assets:Bank".to_string()),
+                        account: AccountFilter::single(bank),
                         sort: Sort::Date,
                         ..Default::default()
                     },


### PR DESCRIPTION
## Summary

- `AccountFilter<'ctx>` is now `pub` with a new `Exact(Account<'ctx>)` variant for O(1) single-account equality checks (previously all filtered accounts went through a `HashSet`).
- New constructors: `AccountFilter::single(account)` (→ `Exact`) and `AccountFilter::from_pattern(ctx, str)` which replaces the private `new()` — unknown patterns yield an empty `Set` (matches nothing) rather than `Option::None`.
- `RegisterQuery::account` and `PostingQuery::account` changed from `Option<String>` to `Option<AccountFilter<'ctx>>`, removing the implicit string-resolution buried inside `register_entries`/`postings`.
- `Account<'ctx>` is now threaded through the UI layer: `Command<'ctx>`, `App::show_register`, `RegisterView::account`, and `load_register` all use the typed account instead of `&str` / `String`. The CLI `register` subcommand resolves the user-supplied string via `AccountFilter::from_pattern` after processing.

## Test plan

- [ ] `cargo test` passes (all existing tests updated to use `AccountFilter::single` / `from_pattern`)
- [ ] `cargo clippy` clean
- [ ] `register_entries_unknown_account_is_empty` still passes (empty-Set path)
- [ ] Golden register tests unaffected (CLI behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)