### PR TITLE
Pre-allocate Bump arena for sort-date-cold benchmark.

### DIFF
--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -449,7 +449,10 @@ fn query_register_entries(c: &mut Criterion) {
                     let walltime = WallTime;
                     let mut total = walltime.zero();
                     for _ in 0..iters {
-                        let arena = Bump::new();
+                        // given the test is very sensitive to memory allocation,
+                        // I'll go with pre-allocating 32 MiB.
+                        let arena = Bump::with_capacity(1 << 25);
+
                         let mut ctx = report::ReportContext::new(&arena);
                         let opts = report::ProcessOptions::default();
                         let mut ledger = report::process(&mut ctx, input.new_loader(), &opts)


### PR DESCRIPTION
In CI the particular benchmark (`query::register/sort-date-cold/*`) is quite flaky.
I might see antagonist jobs effect, so maybe we can make it stable with `Bump::with_capacity`. In real usage, user can also pass pre-allocated arena to avoid extensive allocations.