### PR TITLE
TUI: add Ctrl-n/Ctrl-p navigation

### DIFF
--- a/cli/src/ui/event.rs
+++ b/cli/src/ui/event.rs
@@ -74,7 +74,9 @@ pub fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
     // Common navigation keys, regardless of screen.
     let nav = match key.code {
         KeyCode::Up | KeyCode::Char('k') => Some(Message::MoveUp),
+        KeyCode::Char('p') if ctrl => Some(Message::MoveUp),
         KeyCode::Down | KeyCode::Char('j') => Some(Message::MoveDown),
+        KeyCode::Char('n') if ctrl => Some(Message::MoveDown),
         KeyCode::PageUp => Some(Message::PageUp),
         KeyCode::Char('b') if ctrl => Some(Message::PageUp),
         KeyCode::PageDown => Some(Message::PageDown),
@@ -204,6 +206,13 @@ mod tests {
             key_to_message(&app, key(KeyCode::Char('k'))),
             Some(Message::MoveUp)
         );
+    }
+
+    #[test]
+    fn ctrl_n_and_p_navigate_like_j_k() {
+        let app = app();
+        assert_eq!(key_to_message(&app, ctrl_key('n')), Some(Message::MoveDown));
+        assert_eq!(key_to_message(&app, ctrl_key('p')), Some(Message::MoveUp));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bind `Ctrl-n` / `Ctrl-p` as aliases for `j` / `k` (move selection down / up) in
the TUI balance and register views, matching common readline / Emacs-style
navigation.

## Details

- Added to the shared navigation key block in `key_to_message`, so they work on
  every screen just like the arrow keys and `j`/`k`.

## Test plan

- `cargo test -p okane` (new `ctrl_n_and_p_navigate_like_j_k` unit test).
- `cargo clippy -p okane` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)