### PR TITLE
Handle account alias properly in accounts command.

### DIFF
--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -7,18 +7,19 @@ mod context;
 mod error;
 mod eval;
 mod price_db;
+mod process;
 pub mod query;
 mod transaction;
 
 use std::borrow::Borrow;
 
 pub use balance::Balance;
-pub use book_keeping::{ProcessOptions, process};
 pub use commodity::{Commodity, CommodityStore, CommodityTag, OwnedCommodity};
 pub use context::{Account, ReportContext};
 pub use error::ReportError;
 pub use eval::{Amount, SingleAmount};
 pub use price_db::LoadError;
+pub use process::{process, ProcessOptions};
 pub use transaction::{Posting, Transaction};
 
 use crate::{load, syntax::plain::LedgerEntry};
@@ -26,20 +27,80 @@ use crate::{load, syntax::plain::LedgerEntry};
 /// Returns all accounts for the given LedgerEntry.
 /// WARNING: interface are subject to change.
 pub fn accounts<'ctx, L, F>(
-    ctx: &'ctx mut context::ReportContext,
+    ctx: &'_ mut context::ReportContext<'ctx>,
     loader: L,
-) -> Result<Vec<Account<'ctx>>, load::LoadError>
+) -> Result<Vec<Account<'ctx>>, ReportError>
 where
     L: Borrow<load::Loader<F>>,
     F: load::FileSystem,
 {
-    loader.borrow().load(|_path, _ctx, entry| {
-        if let LedgerEntry::Txn(txn) = entry {
-            for posting in &txn.posts {
-                ctx.accounts.ensure(&posting.account);
+    loader.borrow().load(|path, pctx, entry| {
+        match entry {
+            LedgerEntry::Account(account) => {
+                process::process_account(ctx, account).map_err(|berr| {
+                    ReportError::BookKeep(
+                        berr,
+                        error::ErrorContext::new(
+                            loader.borrow().error_style().clone(),
+                            path.to_owned(),
+                            pctx,
+                        ),
+                    )
+                })?
             }
+            LedgerEntry::Txn(txn) => {
+                for posting in &txn.posts {
+                    ctx.accounts.ensure(&posting.account);
+                }
+            }
+            _ => (),
         }
-        Ok::<(), load::LoadError>(())
+        Ok::<(), ReportError>(())
     })?;
     Ok(ctx.all_accounts())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bumpalo::Bump;
+    use indoc::indoc;
+    use maplit::hashmap;
+    use pretty_assertions::assert_eq;
+
+    use crate::{load, report};
+
+    #[test]
+    fn accounts_gives_all_accounts() {
+        let fake = hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                account Expenses:Food
+                   alias Expenses:Bar
+
+                account Expenses:Bar
+                   alias Expenses:Baz
+
+                2026/01/01 drink
+                   Expenses:Baz     1,000 JPY
+                   Assets:Bank:X
+            "}.as_bytes().to_vec(),
+        };
+        let loader = load::Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            load::FakeFileSystem::from(fake),
+        );
+        let arena = Bump::new();
+        let mut ctx = report::ReportContext::new(&arena);
+
+        let got = report::accounts(&mut ctx, &loader).unwrap();
+
+        assert_eq!(
+            vec![
+                ctx.account("Assets:Bank:X").unwrap(),
+                ctx.account("Expenses:Food").unwrap()
+            ],
+            got,
+        );
+    }
 }

--- a/core/src/report/book_keeping.rs
+++ b/core/src/report/book_keeping.rs
@@ -1,17 +1,14 @@
 //! Contains book keeping logics to process the input stream,
 //! and convert them into a processed Transactions.
 
-use std::{borrow::Borrow, path::PathBuf};
-
 use annotate_snippets::{Annotation, AnnotationKind};
-use bumpalo::Bump;
 use bumpalo::collections as bcc;
+use bumpalo::Bump;
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
 
 use crate::parse::ParsedSpan;
 use crate::{
-    load,
     report::eval::EvalError,
     syntax::{
         self,
@@ -23,10 +20,8 @@ use crate::{
 use super::{
     balance::{Balance, BalanceError},
     context::ReportContext,
-    error::{self, ReportError},
     eval::{Amount, Evaluable, OwnedEvalError, PostingAmount, SingleAmount},
     price_db::{PriceEvent, PriceRepositoryBuilder, PriceSource},
-    query::Ledger,
     transaction::{Posting, Transaction},
 };
 
@@ -77,11 +72,9 @@ impl BookKeepError {
         text: &str,
     ) -> Vec<Annotation<'arena>> {
         match self {
-            BookKeepError::EvalFailure(err, pos) => vec![
-                AnnotationKind::Primary
-                    .span(parsed_span.resolve(pos))
-                    .label(bumpalo::format!(in &bump, "{}", err).into_bump_str()),
-            ],
+            BookKeepError::EvalFailure(err, pos) => vec![AnnotationKind::Primary
+                .span(parsed_span.resolve(pos))
+                .label(bumpalo::format!(in &bump, "{}", err).into_bump_str())],
             BookKeepError::BalanceFailure {
                 source: err,
                 account,
@@ -121,16 +114,12 @@ impl BookKeepError {
                         .label(msg.into_bump_str()),
                 ]
             }
-            BookKeepError::ZeroAmountWithExchange(exchange) => vec![
-                AnnotationKind::Primary
-                    .span(parsed_span.resolve(exchange))
-                    .label("absolute zero posting should not have exchange"),
-            ],
-            BookKeepError::ZeroExchangeRate(exchange) => vec![
-                AnnotationKind::Primary
-                    .span(parsed_span.resolve(exchange))
-                    .label("exchange with zero amount"),
-            ],
+            BookKeepError::ZeroAmountWithExchange(exchange) => vec![AnnotationKind::Primary
+                .span(parsed_span.resolve(exchange))
+                .label("absolute zero posting should not have exchange")],
+            BookKeepError::ZeroExchangeRate(exchange) => vec![AnnotationKind::Primary
+                .span(parsed_span.resolve(exchange))
+                .label("exchange with zero amount")],
             BookKeepError::ExchangeWithAmountCommodity {
                 posting_amount,
                 exchange,
@@ -146,129 +135,16 @@ impl BookKeepError {
                 // TODO: Add more detailed error into this.
                 // Also, put these logic into BookKeepError.
                 // https://github.com/xkikeg/okane/issues/189
-                vec![
-                    AnnotationKind::Primary
-                        .span(0..text.len())
-                        .label("error occured"),
-                ]
+                vec![AnnotationKind::Primary
+                    .span(0..text.len())
+                    .label("error occured")]
             }
         }
     }
 }
 
-/// Options to control process behavior.
-#[derive(Debug, Default)]
-// TODO: non_exhaustive
-pub struct ProcessOptions {
-    /// Path to the price DB file.
-    pub price_db_path: Option<PathBuf>,
-}
-
-/// Takes the loader, and gives back the all read transactions.
-/// Also returns the computed balance, as a side-artifact.
-/// Usually this needs to be reordered, so just returning a `Vec`.
-pub fn process<'ctx, L, F>(
-    ctx: &mut ReportContext<'ctx>,
-    loader: L,
-    options: &ProcessOptions,
-) -> Result<Ledger<'ctx>, ReportError>
-where
-    L: Borrow<load::Loader<F>>,
-    F: load::FileSystem,
-{
-    let mut accum = ProcessAccumulator::new();
-    loader.borrow().load(|path, pctx, entry| {
-        accum.process(ctx, entry).map_err(|berr| {
-            ReportError::BookKeep(
-                berr,
-                error::ErrorContext::new(
-                    loader.borrow().error_style().clone(),
-                    path.to_owned(),
-                    pctx,
-                ),
-            )
-        })
-    })?;
-    if let Some(price_db_path) = options.price_db_path.as_deref() {
-        accum
-            .price_repos
-            .load_price_db(ctx, loader.borrow().filesystem(), price_db_path)?;
-    }
-    Ok(Ledger {
-        arena: ctx.arena,
-        transactions: accum.txns,
-        date_sorted_txns: None,
-        raw_balance: accum.balance,
-        price_repos: accum.price_repos.build(),
-    })
-}
-
-struct ProcessAccumulator<'ctx> {
-    balance: Balance<'ctx>,
-    txns: Vec<Transaction<'ctx>>,
-    price_repos: PriceRepositoryBuilder<'ctx>,
-}
-
-impl<'ctx> ProcessAccumulator<'ctx> {
-    fn new() -> Self {
-        Self {
-            balance: Balance::default(),
-            txns: Vec::new(),
-            price_repos: PriceRepositoryBuilder::default(),
-        }
-    }
-
-    fn process(
-        &mut self,
-        ctx: &mut ReportContext<'ctx>,
-        entry: &syntax::tracked::LedgerEntry,
-    ) -> Result<(), BookKeepError> {
-        match entry {
-            syntax::LedgerEntry::Txn(txn) => {
-                self.txns.push(add_transaction(
-                    ctx,
-                    &mut self.price_repos,
-                    &mut self.balance,
-                    txn,
-                )?);
-                Ok(())
-            }
-            syntax::LedgerEntry::Account(account) => {
-                let canonical = ctx.accounts.ensure(&account.name);
-                for ad in &account.details {
-                    if let syntax::AccountDetail::Alias(alias) = ad {
-                        ctx.accounts
-                            .insert_alias(alias, canonical)
-                            .map_err(|_| BookKeepError::InvalidAccountAlias(alias.to_string()))?;
-                    }
-                }
-                Ok(())
-            }
-            syntax::LedgerEntry::Commodity(commodity) => {
-                let canonical = ctx.commodities.ensure(&commodity.name);
-                for cd in &commodity.details {
-                    match cd {
-                        syntax::CommodityDetail::Alias(alias) => {
-                            ctx.commodities
-                                .insert_alias(alias, canonical)
-                                .map_err(|_| {
-                                    BookKeepError::InvalidCommodityAlias(alias.to_string())
-                                })?;
-                        }
-                        syntax::CommodityDetail::Format(format_amount) => {
-                            ctx.commodities.set_format(canonical, format_amount.value);
-                        }
-                        _ => {}
-                    }
-                }
-                Ok(())
-            }
-            _ => Ok(()),
-        }
-    }
-}
 /// Adds a syntax transaction, and converts it into a processed Transaction.
-fn add_transaction<'ctx>(
+pub fn add_transaction<'ctx>(
     ctx: &mut ReportContext<'ctx>,
     price_repos: &mut PriceRepositoryBuilder<'ctx>,
     bal: &mut Balance<'ctx>,

--- a/core/src/report/process.rs
+++ b/core/src/report/process.rs
@@ -1,0 +1,132 @@
+use std::borrow::Borrow;
+use std::path::PathBuf;
+
+use crate::{load, syntax};
+
+use super::balance::Balance;
+use super::book_keeping::{self, BookKeepError};
+use super::context::ReportContext;
+use super::error::{self, ReportError};
+use super::price_db::PriceRepositoryBuilder;
+use super::query::Ledger;
+use super::transaction::Transaction;
+
+/// Options to control process behavior.
+#[derive(Debug, Default)]
+// TODO: non_exhaustive
+pub struct ProcessOptions {
+    /// Path to the price DB file.
+    pub price_db_path: Option<PathBuf>,
+}
+
+/// Takes the loader, and gives back the all read transactions.
+/// Also returns the computed balance, as a side-artifact.
+/// Usually this needs to be reordered, so just returning a `Vec`.
+pub fn process<'ctx, L, F>(
+    ctx: &mut ReportContext<'ctx>,
+    loader: L,
+    options: &ProcessOptions,
+) -> Result<Ledger<'ctx>, ReportError>
+where
+    L: Borrow<load::Loader<F>>,
+    F: load::FileSystem,
+{
+    let mut accum = ProcessAccumulator::new();
+    loader.borrow().load(|path, pctx, entry| {
+        accum.process(ctx, entry).map_err(|berr| {
+            ReportError::BookKeep(
+                berr,
+                error::ErrorContext::new(
+                    loader.borrow().error_style().clone(),
+                    path.to_owned(),
+                    pctx,
+                ),
+            )
+        })
+    })?;
+    if let Some(price_db_path) = options.price_db_path.as_deref() {
+        accum
+            .price_repos
+            .load_price_db(ctx, loader.borrow().filesystem(), price_db_path)?;
+    }
+    Ok(Ledger {
+        arena: ctx.arena,
+        transactions: accum.txns,
+        date_sorted_txns: None,
+        raw_balance: accum.balance,
+        price_repos: accum.price_repos.build(),
+    })
+}
+
+struct ProcessAccumulator<'ctx> {
+    balance: Balance<'ctx>,
+    txns: Vec<Transaction<'ctx>>,
+    price_repos: PriceRepositoryBuilder<'ctx>,
+}
+
+impl<'ctx> ProcessAccumulator<'ctx> {
+    fn new() -> Self {
+        Self {
+            balance: Balance::default(),
+            txns: Vec::new(),
+            price_repos: PriceRepositoryBuilder::default(),
+        }
+    }
+
+    fn process(
+        &mut self,
+        ctx: &mut ReportContext<'ctx>,
+        entry: &syntax::tracked::LedgerEntry,
+    ) -> Result<(), BookKeepError> {
+        match entry {
+            syntax::LedgerEntry::Txn(txn) => {
+                self.txns.push(book_keeping::add_transaction(
+                    ctx,
+                    &mut self.price_repos,
+                    &mut self.balance,
+                    txn,
+                )?);
+                Ok(())
+            }
+            syntax::LedgerEntry::Account(account) => process_account(ctx, account),
+            syntax::LedgerEntry::Commodity(commodity) => process_commodity(ctx, commodity),
+            _ => Ok(()),
+        }
+    }
+}
+
+pub fn process_account<'ctx>(
+    ctx: &mut ReportContext<'ctx>,
+    account: &syntax::AccountDeclaration<'_>,
+) -> Result<(), BookKeepError> {
+    let canonical = ctx.accounts.ensure(&account.name);
+    for ad in &account.details {
+        if let syntax::AccountDetail::Alias(alias) = ad {
+            ctx.accounts
+                .insert_alias(alias, canonical)
+                .map_err(|_| BookKeepError::InvalidAccountAlias(alias.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+fn process_commodity<'ctx>(
+    ctx: &mut ReportContext<'ctx>,
+    commodity: &syntax::CommodityDeclaration<'_>,
+) -> Result<(), BookKeepError> {
+    let canonical = ctx.commodities.ensure(&commodity.name);
+    for cd in &commodity.details {
+        match cd {
+            syntax::CommodityDetail::Alias(alias) => {
+                ctx.commodities
+                    .insert_alias(alias, canonical)
+                    .map_err(|_| BookKeepError::InvalidCommodityAlias(alias.to_string()))?;
+            }
+            syntax::CommodityDetail::Format(format_amount) => {
+                ctx.commodities.set_format(canonical, format_amount.value);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This also comes with refactoring splitting
book keep details (add_transaction) and process overall, so that we can reuse it from accounts.