### PR TITLE
Reorganize ui module: report/ sub-module and shared table.rs

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -150,11 +150,11 @@ impl ImportCmd {
         // accounts are already sorted.
         // Render every transaction up front: review items need the previews,
         // and any conversion error surfaces here, before entering raw mode.
-        let items: Vec<ui::ReviewItem> = txns
+        let items: Vec<ui::import::ReviewItem> = txns
             .iter()
             .map(|txn| {
                 let preview = header.render_transaction(txn)?;
-                Ok(ui::ReviewItem::new(
+                Ok(ui::import::ReviewItem::new(
                     txn.review_kind(),
                     preview,
                     txn.date(),
@@ -163,19 +163,19 @@ impl ImportCmd {
                 ))
             })
             .collect::<Result<_, import::ImportError>>()?;
-        let mut app = ui::ReviewApp::new(
+        let mut app = ui::import::ReviewApp::new(
             self.source.display().to_string(),
             output_path.display().to_string(),
             items,
             accounts,
         );
         let outcome =
-            ui::run_review(&mut app, &header, &mut txns).context("failed to run review TUI")?;
+            ui::import::run_review(&mut app, &header, &mut txns).context("failed to run review TUI")?;
         match outcome {
-            ui::SessionOutcome::Abort => {
+            ui::import::SessionOutcome::Abort => {
                 eprintln!("import aborted; nothing written");
             }
-            ui::SessionOutcome::Write => {
+            ui::import::SessionOutcome::Write => {
                 let rendered: Vec<String> = txns
                     .iter()
                     .map(|txn| header.render_transaction(txn))
@@ -438,18 +438,18 @@ impl UiCmd {
             date_range,
         };
         let balance = ledger.balance(&ctx, &balance_query)?.into_owned();
-        let rows: Vec<ui::BalanceRow> = balance
+        let rows: Vec<ui::report::BalanceRow> = balance
             .into_vec()
             .into_iter()
-            .map(|(account, amount)| ui::BalanceRow { account, amount })
+            .map(|(account, amount)| ui::report::BalanceRow { account, amount })
             .collect();
         // Reused for every register drill-down during the session.
-        let register_template = ui::RegisterQueryTemplate {
+        let register_template = ui::report::RegisterQueryTemplate {
             conversion,
             date_range,
         };
-        let app = ui::App::new(self.source.display().to_string(), rows, register_template);
-        ui::run_ui(app, &mut ledger, &ctx).context("failed to run TUI")?;
+        let app = ui::report::App::new(self.source.display().to_string(), rows, register_template);
+        ui::report::run_ui(app, &mut ledger, &ctx).context("failed to run TUI")?;
         Ok(())
     }
 }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,44 +1,6 @@
 //! Terminal UI for okane — entry point and shared types.
-//!
-//! Architecture (Elm-style; see
-//! <https://ratatui.rs/concepts/application-patterns/the-elm-architecture/>):
-//! - [`App`] holds all state and exposes [`App::update`] for transitions.
-//! - [`event`] translates `KeyEvent`s to [`app::Message`]s and runs the loop.
-//! - [`render`] is a pure view over `App`.
-//!
-//! See [`run_ui`] for the public entry point. The session presents a balance
-//! table; pressing Enter drills into a register view for the selected
-//! account, and q/Esc returns. A quit confirmation popup guards exits from
-//! the balance screen; Ctrl-C bypasses it.
 
-mod app;
-mod event;
-mod render;
-mod import;
-
-pub use app::{App, BalanceRow, RegisterQueryTemplate};
-pub use import::{ReviewApp, ReviewItem, SessionOutcome, run_review};
-
-use okane_core::report::ReportContext;
-use okane_core::report::query::Ledger;
-
-/// Runs the TUI session with the prepared [`App`].
-///
-/// Sets up the terminal (raw mode, alternate screen), installs a panic hook
-/// that restores the terminal before propagating, runs the event loop, and
-/// tears down the terminal on exit (normal or error).
-///
-/// `ledger` is borrowed mutably so the register view can be computed on
-/// demand. `ctx` is borrowed for the lifetime of the session so amount
-/// values can be formatted lazily under the same `ReportContext` that
-/// produced them.
-pub fn run_ui<'ctx>(
-    mut app: App<'ctx>,
-    ledger: &mut Ledger<'ctx>,
-    ctx: &ReportContext<'ctx>,
-) -> anyhow::Result<()> {
-    let mut terminal = ratatui::init();
-    let result = event::run(&mut terminal, &mut app, ledger, ctx);
-    ratatui::restore();
-    result
-}
+mod keys;
+mod table;
+pub mod report;
+pub mod import;

--- a/cli/src/ui/import/app.rs
+++ b/cli/src/ui/import/app.rs
@@ -9,7 +9,7 @@
 use chrono::NaiveDate;
 
 use crate::import::single_entry::ReviewKind;
-use crate::ui::app::TableNav;
+use crate::ui::table::TableNav;
 
 /// Decision state of one reviewed transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cli/src/ui/import/event.rs
+++ b/cli/src/ui/import/event.rs
@@ -9,11 +9,12 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use okane_core::syntax::ClearState;
 use ratatui::DefaultTerminal;
 
 use crate::import::{ImportHeader, single_entry};
+use crate::ui::keys::is_ctrl;
 
 use super::app::{Command, Message, ReviewApp, SessionOutcome};
 use super::render;
@@ -50,7 +51,7 @@ pub fn key_to_message(app: &ReviewApp, key: KeyEvent) -> Option<Message> {
     if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
         return None;
     }
-    let ctrl = (key.modifiers & !KeyModifiers::SHIFT) == KeyModifiers::CONTROL;
+    let ctrl = is_ctrl(key.modifiers);
 
     // Ctrl-C always aborts — even through an open overlay or prompt.
     if ctrl && matches!(key.code, KeyCode::Char('c')) {
@@ -149,6 +150,7 @@ mod tests {
     use super::*;
 
     use chrono::NaiveDate;
+    use crossterm::event::KeyModifiers;
     use pretty_assertions::assert_eq;
 
     use crate::import::single_entry::ReviewKind;

--- a/cli/src/ui/keys.rs
+++ b/cli/src/ui/keys.rs
@@ -1,0 +1,43 @@
+//! Module providing small utilities related to key events.
+
+use crossterm::event::KeyModifiers;
+
+/// Returns true when `modifiers` is Ctrl, ignoring Shift.
+///
+/// Shift is excluded so that Ctrl+Shift+letter sequences (common on some
+/// keyboard layouts and terminal emulators) still register as Ctrl combos.
+/// Other modifiers (Alt, Super, …) prevent a match so that e.g. AltGr
+/// sequences on European layouts are not mis-classified as Ctrl.
+pub fn is_ctrl(modifiers: KeyModifiers) -> bool {
+    (modifiers & !KeyModifiers::SHIFT) == KeyModifiers::CONTROL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_modifiers_is_not_ctrl() {
+        assert!(!is_ctrl(KeyModifiers::NONE));
+    }
+
+    #[test]
+    fn shift_alone_is_not_ctrl() {
+        assert!(!is_ctrl(KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn ctrl_alone_is_ctrl() {
+        assert!(is_ctrl(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn shift_ctrl_is_ctrl() {
+        assert!(is_ctrl(KeyModifiers::CONTROL | KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn ctrl_alt_is_not_ctrl() {
+        assert!(!is_ctrl(KeyModifiers::CONTROL | KeyModifiers::ALT));
+    }
+}

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -1,0 +1,39 @@
+//! Report TUI session — balance and register viewer.
+//!
+//! Architecture (Elm-style; see
+//! <https://ratatui.rs/concepts/application-patterns/the-elm-architecture/>):
+//! - [`app::App`] holds all state and exposes [`app::App::update`] for transitions.
+//! - [`event`] translates `KeyEvent`s to messages and runs the loop.
+//! - [`render`] is a pure view over `App`.
+//!
+//! See [`run_ui`] for the public entry point.
+
+mod app;
+mod event;
+mod render;
+
+pub use app::{App, BalanceRow, RegisterQueryTemplate};
+
+use okane_core::report::ReportContext;
+use okane_core::report::query::Ledger;
+
+/// Runs the TUI session with the prepared [`App`].
+///
+/// Sets up the terminal (raw mode, alternate screen), installs a panic hook
+/// that restores the terminal before propagating, runs the event loop, and
+/// tears down the terminal on exit (normal or error).
+///
+/// `ledger` is borrowed mutably so the register view can be computed on
+/// demand. `ctx` is borrowed for the lifetime of the session so amount
+/// values can be formatted lazily under the same `ReportContext` that
+/// produced them.
+pub fn run_ui<'ctx>(
+    mut app: App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> anyhow::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = event::run(&mut terminal, &mut app, ledger, ctx);
+    ratatui::restore();
+    result
+}

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -8,8 +8,9 @@
 use chrono::NaiveDate;
 use okane_core::report::query::{Conversion, DateRange};
 use okane_core::report::{Account, Amount};
-use ratatui::widgets::TableState;
 use regex::RegexBuilder;
+
+use crate::ui::table::TableNav;
 
 /// One row of the balance table.
 ///
@@ -54,76 +55,6 @@ impl RegisterRow<'_> {
 fn amount_line_count(amount: &Amount<'_>) -> u16 {
     let n = amount.iter().count();
     n.max(1).min(u16::MAX as usize) as u16
-}
-
-/// Pure scroll/selection state for a table.
-///
-/// Lives separately from row data so the navigation math can be tested
-/// without constructing a `'ctx`-bound `App` or a real `ReportContext`.
-#[derive(Debug, Default)]
-pub struct TableNav {
-    pub table_state: TableState,
-    pub row_count: usize,
-    /// Last known viewport height for the table body. Updated each frame and
-    /// used to size page-up/page-down jumps.
-    pub viewport_height: u16,
-}
-
-impl TableNav {
-    pub fn new(row_count: usize) -> Self {
-        let mut table_state = TableState::default();
-        if row_count > 0 {
-            table_state.select(Some(0));
-        }
-        Self {
-            table_state,
-            row_count,
-            viewport_height: 0,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.row_count == 0
-    }
-
-    fn last_index(&self) -> Option<usize> {
-        self.row_count.checked_sub(1)
-    }
-
-    /// Moves the selection by `delta` rows, clamping to the row range.
-    pub fn move_selection(&mut self, delta: isize) {
-        let Some(last) = self.last_index() else {
-            return;
-        };
-        let current = self.table_state.selected().unwrap_or(0) as isize;
-        let next = (current + delta).clamp(0, last as isize);
-        self.table_state.select(Some(next as usize));
-    }
-
-    /// Page size — at least 1 row, falls back to a sensible default if the
-    /// viewport height has not been observed yet.
-    pub fn page_size(&self) -> usize {
-        self.viewport_height.max(1) as usize
-    }
-
-    pub fn select_first(&mut self) {
-        if !self.is_empty() {
-            self.table_state.select(Some(0));
-        }
-    }
-
-    pub fn select_last(&mut self) {
-        if let Some(last) = self.last_index() {
-            self.table_state.select(Some(last));
-        }
-    }
-
-    /// Selects an explicit row index, ignored when out of range.
-    pub fn select(&mut self, index: usize) {
-        if index < self.row_count {
-            self.table_state.select(Some(index));
-        }
-    }
 }
 
 /// Query parameters reused for every register lookup during the session
@@ -642,6 +573,8 @@ impl<'ctx> App<'ctx> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::collections::HashMap;
     use std::path::PathBuf;
 
@@ -651,7 +584,7 @@ mod tests {
     use okane_core::{load, report};
     use rust_decimal_macros::dec;
 
-    use super::*;
+    use crate::ui::table::TableNav;
 
     fn nav(n: usize) -> TableNav {
         TableNav::new(n)

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -11,11 +11,13 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use lender::FallibleLender;
 use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
 use okane_core::report::{Account, ReportContext};
 use ratatui::DefaultTerminal;
+
+use crate::ui::keys::is_ctrl;
 
 use super::app::{
     App, Command, Message, Overlay, RegisterQueryTemplate, RegisterRow, Screen, SearchDirection,
@@ -53,7 +55,7 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
     if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
         return None;
     }
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let ctrl = is_ctrl(key.modifiers);
 
     // Ctrl-C always quits — even through an open overlay.
     if ctrl && matches!(key.code, KeyCode::Char('c')) {
@@ -194,14 +196,18 @@ fn load_register<'ctx>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use crate::ui::app::{RegisterView, Search, SearchIntent, SearchMatch, TableNav};
     use bumpalo::Bump;
+    use crossterm::event::KeyModifiers;
     use okane_core::{load, report};
 
-    use super::*;
+    use crate::ui::table::TableNav;
+
+    use super::super::app::{RegisterView, Search, SearchIntent, SearchMatch};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -17,6 +17,7 @@ use super::app::{
     App, BalanceRow, Overlay, RegisterRow, RegisterView, Screen, Search, SearchDirection,
     SearchMatch, SearchMode, SearchPhase,
 };
+use crate::ui::table::TableNav;
 
 const FOOTER_HINT_BALANCE: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · / search · C-s isearch · q quit ";
 const FOOTER_HINT_REGISTER: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · q/Esc back ";
@@ -81,7 +82,7 @@ fn draw_balance_body<'ctx>(
     frame: &mut Frame,
     area: Rect,
     rows: &[BalanceRow<'ctx>],
-    nav: &mut super::app::TableNav,
+    nav: &mut TableNav,
     matches: Option<&SearchMatch>,
     ctx: &ReportContext<'ctx>,
 ) {

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -1,0 +1,71 @@
+use ratatui::widgets::TableState;
+
+/// Pure scroll/selection state for a table.
+///
+/// Lives separately from row data so the navigation math can be tested
+/// without constructing a `'ctx`-bound `App` or a real `ReportContext`.
+#[derive(Debug, Default)]
+pub struct TableNav {
+    pub table_state: TableState,
+    pub row_count: usize,
+    /// Last known viewport height for the table body. Updated each frame and
+    /// used to size page-up/page-down jumps.
+    pub viewport_height: u16,
+}
+
+impl TableNav {
+    pub fn new(row_count: usize) -> Self {
+        let mut table_state = TableState::default();
+        if row_count > 0 {
+            table_state.select(Some(0));
+        }
+        Self {
+            table_state,
+            row_count,
+            viewport_height: 0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.row_count == 0
+    }
+
+    fn last_index(&self) -> Option<usize> {
+        self.row_count.checked_sub(1)
+    }
+
+    /// Moves the selection by `delta` rows, clamping to the row range.
+    pub fn move_selection(&mut self, delta: isize) {
+        let Some(last) = self.last_index() else {
+            return;
+        };
+        let current = self.table_state.selected().unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, last as isize);
+        self.table_state.select(Some(next as usize));
+    }
+
+    /// Page size — at least 1 row, falls back to a sensible default if the
+    /// viewport height has not been observed yet.
+    pub fn page_size(&self) -> usize {
+        self.viewport_height.max(1) as usize
+    }
+
+    pub fn select_first(&mut self) {
+        if !self.is_empty() {
+            self.table_state.select(Some(0));
+        }
+    }
+
+    pub fn select_last(&mut self) {
+        if let Some(last) = self.last_index() {
+            self.table_state.select(Some(last));
+        }
+    }
+
+    /// Selects an explicit row index, ignored when out of range.
+    pub fn select(&mut self, index: usize) {
+        if index < self.row_count {
+            self.table_state.select(Some(index));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Move `ui/{app,event,render}.rs` into `ui/report/` to mirror the existing `ui/import/` layout — each TUI session type now lives in its own sub-module
- Extract `TableNav` into `ui/table.rs` so both `report/` and `import/` can share it without a cross-module path
- Expose `report` and `import` as `pub mod` in `ui.rs`, removing the flat `pub use` re-exports; callers now use `ui::report::*` and `ui::import::*` directly

## Test plan

- [x] `cargo check -p okane`
- [x] `cargo test -p okane` — all 240 tests pass
- [x] `cargo clippy -p okane`

🤖 Generated with [Claude Code](https://claude.com/claude-code)