### PR TITLE
Pre-allocate bumpalo arena for sort-date-warm case.

### DIFF
--- a/core/benches/report_bench.rs
+++ b/core/benches/report_bench.rs
@@ -5,7 +5,7 @@ use bumpalo::Bump;
 use chrono::NaiveDate;
 use criterion::measurement::Measurement as _;
 use criterion::{
-    criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkId, Criterion,
+    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
 use lender::FallibleLender;
 use log::LevelFilter;
@@ -484,7 +484,9 @@ fn query_register_entries(c: &mut Criterion) {
     // This measures the marginal cost of the cached path vs `sort-original`.
     for params in InputParams::params_from_env() {
         let input = FakeFileSink::new_example(Path::new("report_bench"), params).unwrap();
-        let arena = Bump::new();
+        // given the test is very sensitive to memory allocation,
+        // I'll go with pre-allocating 32 MiB.
+        let arena = Bump::with_capacity(1 << 25);
         let mut ctx = report::ReportContext::new(&arena);
         let opts = report::ProcessOptions::default();
         let mut ledger = report::process(&mut ctx, input.new_loader(), &opts)


### PR DESCRIPTION
Essentially this is a benchmark spanning across all the transactions, so memory locality matters, quite a lot. Pre-allocating 32 MiB would help reducing the noise.