### PR TITLE
Move Account/AccountStore into report/account.rs

### DIFF
--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -1,6 +1,7 @@
 //! report module contains functions to evaluate and
 //! report various metrics out of the given Ledger file.
 
+mod account;
 mod balance;
 mod book_keeping;
 mod commodity;
@@ -14,9 +15,10 @@ mod transaction;
 
 use std::borrow::Borrow;
 
+pub use account::Account;
 pub use balance::Balance;
 pub use commodity::{Commodity, CommodityStore, CommodityTag, OwnedCommodity};
-pub use context::{Account, ReportContext};
+pub use context::ReportContext;
 pub use error::ReportError;
 pub use eval::{Amount, SingleAmount};
 pub use price_db::LoadError;

--- a/core/src/report/account.rs
+++ b/core/src/report/account.rs
@@ -1,0 +1,66 @@
+//! Defines account and its related types.
+
+use bumpalo::Bump;
+use bumpalo_intern::direct::{DirectInternStore, FromInterned, InternedStr, Iter, OccupiedError};
+
+/// Interned `&str` for accounts within the `'arena` bounded allocator lifetime.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct Account<'arena>(InternedStr<'arena>);
+
+impl<'arena> FromInterned<'arena> for Account<'arena> {
+    fn from_interned(v: InternedStr<'arena>) -> Self {
+        Self(v)
+    }
+
+    fn as_interned(&self) -> InternedStr<'arena> {
+        self.0
+    }
+}
+
+impl<'arena> Account<'arena> {
+    /// Returns the `&str`.
+    pub fn as_str(&self) -> &'arena str {
+        self.0.as_str()
+    }
+}
+
+/// Manages [`Account`] instances.
+pub struct AccountStore<'arena> {
+    intern: DirectInternStore<'arena, Account<'arena>>,
+}
+
+impl<'arena> AccountStore<'arena> {
+    /// Creates a new instance.
+    pub fn new(arena: &'arena Bump) -> Self {
+        Self {
+            intern: DirectInternStore::new(arena),
+        }
+    }
+
+    /// Returns the Account with the given `value`,
+    /// potentially resolving the alias.
+    /// If not available, registers the given `value` as the canonical.
+    pub fn ensure(&mut self, value: &str) -> Account<'arena> {
+        self.intern.ensure(value)
+    }
+
+    /// Returns the Account with the given `value` if and only if it's already registered.
+    pub fn resolve(&self, value: &str) -> Option<Account<'arena>> {
+        self.intern.resolve(value)
+    }
+
+    /// Inserts given `value` as always alias of `canonical`.
+    /// Returns error if given `value` is already registered as canonical.
+    pub fn insert_alias(
+        &mut self,
+        value: &str,
+        canonical: Account<'arena>,
+    ) -> Result<(), OccupiedError<'arena, Account<'arena>>> {
+        self.intern.insert_alias(value, canonical)
+    }
+
+    /// Returns the Iterator for all elements.
+    pub fn iter(&self) -> Iter<'arena, '_, Account<'arena>> {
+        self.intern.iter()
+    }
+}

--- a/core/src/report/balance.rs
+++ b/core/src/report/balance.rs
@@ -4,7 +4,7 @@ use crate::report::eval::EvalError;
 
 use super::{
     ReportContext,
-    context::Account,
+    account::Account,
     eval::{Amount, OwnedEvalError, PostingAmount},
 };
 

--- a/core/src/report/commodity.rs
+++ b/core/src/report/commodity.rs
@@ -7,7 +7,7 @@ use bumpalo::Bump;
 use bumpalo_intern::dense::{DenseInternStore, InternTag, Interned, Keyed, OccupiedError};
 use pretty_decimal::PrettyDecimal;
 
-/// `&str` for commodities, interned within the `'arena` bounded allocator lifetime.
+/// Interned `&str` for commodities within the `'arena` bounded allocator lifetime.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct Commodity<'arena>(&'arena str);
 
@@ -111,7 +111,7 @@ impl<'ctx> CommodityTag<'ctx> {
     }
 }
 
-/// Interner for [`Commodity`].
+/// Manages [`Commodity`] instances.
 pub struct CommodityStore<'arena> {
     intern: DenseInternStore<'arena, Commodity<'arena>>,
     formatting: CommodityMap<PrettyDecimal>,

--- a/core/src/report/context.rs
+++ b/core/src/report/context.rs
@@ -1,33 +1,10 @@
 use bumpalo::Bump;
-use bumpalo_intern::direct::{DirectInternStore, FromInterned, InternedStr, StoredValue};
+use bumpalo_intern::direct::StoredValue;
 
 use crate::report::commodity::CommodityTag;
 
+use super::account::{Account, AccountStore};
 use super::commodity::CommodityStore;
-
-/// `&str` for accounts, interned within the `'arena` bounded allocator lifetime.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Account<'arena>(InternedStr<'arena>);
-
-impl<'arena> FromInterned<'arena> for Account<'arena> {
-    fn from_interned(v: InternedStr<'arena>) -> Self {
-        Self(v)
-    }
-
-    fn as_interned(&self) -> InternedStr<'arena> {
-        self.0
-    }
-}
-
-impl<'arena> Account<'arena> {
-    /// Returns the `&str`.
-    pub fn as_str(&self) -> &'arena str {
-        self.0.as_str()
-    }
-}
-
-/// `Interner` for `Account`.
-pub(super) type AccountStore<'arena> = DirectInternStore<'arena, Account<'arena>>;
 
 /// Context object extensively used across Ledger file evaluation.
 pub struct ReportContext<'ctx> {

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -13,9 +13,10 @@ use crate::{
 };
 
 use super::{
+    account::Account,
     balance::Balance,
     commodity::OwnedCommodity,
-    context::{Account, ReportContext},
+    context::ReportContext,
     eval::{Amount, EvalError, Evaluable},
     price_db::{self, ConversionError, PriceRepository},
     transaction::{Posting, Transaction},

--- a/core/src/report/transaction.rs
+++ b/core/src/report/transaction.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 
 use super::{
-    context::Account,
+    account::Account,
     eval::{Amount, SingleAmount},
 };
 


### PR DESCRIPTION
## Summary
- Give `Account` its own module (`core/src/report/account.rs`), consistent with `Commodity` living in `commodity.rs`.
- Turn `AccountStore` from a bare `DirectInternStore` type alias into a wrapper struct (mirroring the existing `CommodityStore` pattern), so its implementation can change later without changing its type.
- Pure refactor: no behavior changes. Updated import paths in `balance.rs`, `transaction.rs`, `query.rs`, and re-exports in `report.rs` accordingly.

## Test plan
- [x] `cargo check -p okane-core`
- [x] `cargo test -p okane-core` (160 passed)
- [x] `cargo clippy -p okane-core --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)