### PR TITLE
[feat] Add reload feature to UI view.

### DIFF
--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -423,34 +423,19 @@ impl UiCmd {
     }
 
     pub fn run(self) -> anyhow::Result<()> {
-        let arena = Bump::new();
-        let mut ctx = report::ReportContext::new(&arena);
-        let mut ledger = report::process(
-            &mut ctx,
+        // All report data is built inside `run_ui`: its session loop resets
+        // the arena on reload (`r` / `F5`), which requires that nothing out
+        // here borrows it.
+        let reload = ui::report::ReloadContext::new(
             load::new_loader(self.source.clone()),
-            &self.eval_options.to_process_options(),
-        )?;
-        let conversion = self.eval_options.to_conversion(&ctx)?;
-        let date_range = self.eval_options.to_date_range()?;
-        let balance_query = query::BalanceQuery {
-            account: query::AccountFilter::All,
-            conversion,
-            date_range,
-        };
-        let balance = ledger.balance(&ctx, &balance_query)?.into_owned();
-        let rows: Vec<ui::report::BalanceRow> = balance
-            .into_vec()
-            .into_iter()
-            .map(|(account, amount)| ui::report::BalanceRow { account, amount })
-            .collect();
-        // Reused for every register drill-down during the session.
-        let register_template = ui::report::RegisterQueryTemplate {
-            conversion,
-            date_range,
-        };
-        let app = ui::report::App::new(self.source.display().to_string(), rows, register_template);
-        ui::report::run_ui(app, &mut ledger, &ctx).context("failed to run TUI")?;
-        Ok(())
+            load::new_loader(self.source.clone()),
+            self.eval_options.to_process_options(),
+            self.eval_options.to_conversion_spec(),
+            self.eval_options.to_date_range()?,
+        );
+        let mut arena = Bump::new();
+        ui::report::run_ui(&mut arena, self.source.display().to_string(), &reload)
+            .context("failed to run TUI")
     }
 }
 
@@ -633,6 +618,14 @@ impl EvalOptions {
         })
     }
 
+    fn conversion_strategy(&self) -> query::ConversionStrategy {
+        if self.historical {
+            query::ConversionStrategy::Historical
+        } else {
+            query::ConversionStrategy::UpToDate { today: self.today }
+        }
+    }
+
     fn to_conversion<'ctx>(
         &self,
         ctx: &report::ReportContext<'ctx>,
@@ -646,12 +639,19 @@ impl EvalOptions {
             .ok_or(query::QueryError::CommodityNotFound(
                 report::OwnedCommodity::from_string(ex.clone()),
             ))?;
-        let strategy = if self.historical {
-            query::ConversionStrategy::Historical
-        } else {
-            query::ConversionStrategy::UpToDate { today: self.today }
-        };
-        Ok(Some(query::Conversion { strategy, target }))
+        Ok(Some(query::Conversion {
+            strategy: self.conversion_strategy(),
+            target,
+        }))
+    }
+
+    /// Owned counterpart of [`Self::to_conversion`] for the UI session
+    /// loop, which re-resolves it against each session's fresh context.
+    fn to_conversion_spec(&self) -> Option<ui::report::ConversionSpec> {
+        self.exchange.as_ref().map(|ex| ui::report::ConversionSpec {
+            commodity: ex.clone(),
+            strategy: self.conversion_strategy(),
+        })
     }
 
     fn create_account_filter<'ctx>(

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -6,7 +6,12 @@
 //! - [`event`] translates `KeyEvent`s to messages and runs the loop.
 //! - [`render`] is a pure view over `App`.
 //!
-//! See [`run_ui`] for the public entry point.
+//! Reload (`r` / `F5`) is a *session* boundary: all report data — the
+//! [`ReportContext`] intern stores (accounts, commodities, aliases) and
+//! everything referencing the arena — is torn down, the arena is reset, and
+//! a fresh session is built from scratch, so stale interned entries never
+//! survive a reload. Only an owned [`app::UiSnapshot`] (selection, search,
+//! screen) crosses the boundary. See [`run_ui`] for the loop.
 
 mod app;
 mod event;
@@ -14,26 +19,510 @@ mod render;
 
 pub use app::{App, BalanceRow, RegisterQueryTemplate};
 
-use okane_core::report::ReportContext;
-use okane_core::report::query::Ledger;
+use bumpalo::Bump;
+use okane_core::load;
+use okane_core::report::query::{
+    AccountFilter, BalanceQuery, Conversion, ConversionStrategy, DateRange, Ledger, QueryError,
+};
+use okane_core::report::{self, OwnedCommodity, ProcessOptions, ReportContext};
+use ratatui::DefaultTerminal;
 
-/// Runs the TUI session with the prepared [`App`].
+use app::{ErrorPopup, Overlay, UiSnapshot};
+
+/// Everything needed to build (and rebuild) a session: the loaders re-read
+/// the source from disk on every `load` call, and the options carry the CLI
+/// configuration. Fully owned — no arena references — so it survives the
+/// arena resets between sessions.
+pub struct ReloadContext<F: load::FileSystem> {
+    /// Loader for the very first build. Keeps its (styled) renderer: a
+    /// startup error aborts before the terminal is set up and prints to the
+    /// normal terminal.
+    initial_loader: load::Loader<F>,
+    /// Loader for reload builds. The error renderer is forced to plain
+    /// because the rendered message is shown inside the TUI, where ANSI
+    /// escape sequences would garble the error modal.
+    reload_loader: load::Loader<F>,
+    process_options: ProcessOptions,
+    /// `--exchange` conversion as owned data, re-resolved against each
+    /// session's fresh [`ReportContext`].
+    conversion: Option<ConversionSpec>,
+    date_range: DateRange,
+}
+
+impl<F: load::FileSystem> ReloadContext<F> {
+    /// Wraps two loaders for the same source plus the query configuration.
+    pub fn new(
+        initial_loader: load::Loader<F>,
+        reload_loader: load::Loader<F>,
+        process_options: ProcessOptions,
+        conversion: Option<ConversionSpec>,
+        date_range: DateRange,
+    ) -> Self {
+        Self {
+            initial_loader,
+            reload_loader: reload_loader.with_error_renderer(load::Renderer::plain()),
+            process_options,
+            conversion,
+            date_range,
+        }
+    }
+}
+
+/// Owned form of [`Conversion`]: unlike the latter, it holds no arena
+/// reference, so it can be resolved against every session's context anew.
+pub struct ConversionSpec {
+    pub commodity: String,
+    pub strategy: ConversionStrategy,
+}
+
+impl ConversionSpec {
+    fn resolve<'ctx>(&self, ctx: &ReportContext<'ctx>) -> Result<Conversion<'ctx>, QueryError> {
+        let target = ctx.commodity(&self.commodity).ok_or_else(|| {
+            QueryError::CommodityNotFound(OwnedCommodity::from_string(self.commodity.clone()))
+        })?;
+        Ok(Conversion {
+            strategy: self.strategy,
+            target,
+        })
+    }
+}
+
+/// Runs the TUI session loop.
 ///
-/// Sets up the terminal (raw mode, alternate screen), installs a panic hook
-/// that restores the terminal before propagating, runs the event loop, and
-/// tears down the terminal on exit (normal or error).
+/// Each iteration owns one session: a fresh [`ReportContext`] over the
+/// (reset) arena and the data built from it. A reload ends the iteration,
+/// so every `'ctx` borrow dies with it and `arena.reset()` is safe; UI
+/// state crosses over as an owned [`UiSnapshot`].
 ///
-/// `ledger` is borrowed mutably so the register view can be computed on
-/// demand. `ctx` is borrowed for the lifetime of the session so amount
-/// values can be formatted lazily under the same `ReportContext` that
-/// produced them.
-pub fn run_ui<'ctx>(
-    mut app: App<'ctx>,
-    ledger: &mut Ledger<'ctx>,
-    ctx: &ReportContext<'ctx>,
+/// The terminal (raw mode, alternate screen; panic hook installed by
+/// `ratatui::init`) is entered lazily once the first session builds, so
+/// startup errors print to the normal terminal. It is restored on exit
+/// (normal or error).
+pub fn run_ui<F: load::FileSystem>(
+    arena: &mut Bump,
+    source_display: String,
+    reload: &ReloadContext<F>,
 ) -> anyhow::Result<()> {
-    let mut terminal = ratatui::init();
-    let result = event::run(&mut terminal, &mut app, ledger, ctx);
-    ratatui::restore();
+    let mut terminal = None;
+    let result = session_loop(arena, &source_display, reload, &mut terminal);
+    if terminal.is_some() {
+        ratatui::restore();
+    }
     result
+}
+
+fn session_loop<F: load::FileSystem>(
+    arena: &mut Bump,
+    source_display: &str,
+    reload: &ReloadContext<F>,
+    terminal: &mut Option<DefaultTerminal>,
+) -> anyhow::Result<()> {
+    let mut snapshot: Option<UiSnapshot> = None;
+    let mut first = true;
+    loop {
+        if !first {
+            arena.reset();
+        }
+        let mut ctx = ReportContext::new(arena);
+        let loader = if first {
+            &reload.initial_loader
+        } else {
+            &reload.reload_loader
+        };
+        let built = build_session(&mut ctx, loader, reload, source_display, snapshot.as_ref());
+        let (mut ledger, mut app, has_data) = match built {
+            Ok(SessionData { ledger, app }) => (ledger, app, true),
+            // A startup failure aborts before the terminal is set up.
+            Err(err) if first => return Err(err),
+            // A failed reload shows an empty session with the error in a modal;
+            // `r` retries from there. The last snapshot is kept so a later
+            // successful reload still restores the pre-error UI state.
+            Err(err) => {
+                let template = RegisterQueryTemplate {
+                    conversion: None,
+                    date_range: reload.date_range,
+                };
+                let mut app = App::new(source_display.to_owned(), Vec::new(), template);
+                app.overlay = Some(error_overlay(source_display, err.as_ref()));
+                (Ledger::empty(&ctx), app, false)
+            }
+        };
+        first = false;
+        let terminal = terminal.get_or_insert_with(ratatui::init);
+        match event::run(terminal, &mut app, &mut ledger, &ctx)? {
+            event::RunOutcome::Quit => return Ok(()),
+            event::RunOutcome::Reload => {
+                if has_data {
+                    snapshot = Some(app.snapshot());
+                }
+            }
+        }
+    }
+}
+
+/// One session's worth of arena-backed data.
+#[derive(Debug)]
+struct SessionData<'ctx> {
+    ledger: Ledger<'ctx>,
+    app: App<'ctx>,
+}
+
+/// Loads and processes the source into `ctx` and builds the session data,
+/// restoring the UI state from `snapshot` when given.
+fn build_session<'ctx, F: load::FileSystem>(
+    ctx: &mut ReportContext<'ctx>,
+    loader: &load::Loader<F>,
+    reload: &ReloadContext<F>,
+    source_display: &str,
+    snapshot: Option<&UiSnapshot>,
+) -> anyhow::Result<SessionData<'ctx>> {
+    let mut ledger = report::process(ctx, loader, &reload.process_options)?;
+    let conversion = reload
+        .conversion
+        .as_ref()
+        .map(|spec| spec.resolve(ctx))
+        .transpose()?;
+    let query = BalanceQuery {
+        account: AccountFilter::All,
+        conversion,
+        date_range: reload.date_range,
+    };
+    let balance = ledger.balance(ctx, &query)?.into_owned();
+    let rows: Vec<BalanceRow<'ctx>> = balance
+        .into_vec()
+        .into_iter()
+        .map(|(account, amount)| BalanceRow { account, amount })
+        .collect();
+    let template = RegisterQueryTemplate {
+        conversion,
+        date_range: reload.date_range,
+    };
+    let mut app = App::new(source_display.to_owned(), rows, template);
+    if let Some(snapshot) = snapshot
+        && let Some((account, index)) = app.restore(snapshot)
+    {
+        // The snapshot had the register screen open; re-query its rows
+        // against the fresh data.
+        match event::load_register(&mut ledger, ctx, &app.register_template, account) {
+            Ok(rows) => app.show_register_at(account, rows, index),
+            Err(err) => {
+                app.error_toast = Some(format!(
+                    "failed to load register for {}: {}",
+                    account.as_str(),
+                    error_summary(err.as_ref())
+                ));
+            }
+        }
+    }
+    Ok(SessionData { ledger, app })
+}
+
+/// One-line summary of an error chain, suitable for the TUI footer. Each
+/// cause can render multi-line (annotate-snippets), so only the first line
+/// of each is kept.
+fn error_summary(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut summary = first_line(&err.to_string());
+    let mut source = err.source();
+    while let Some(err) = source {
+        summary.push_str(": ");
+        summary.push_str(&first_line(&err.to_string()));
+        source = err.source();
+    }
+    summary
+}
+
+fn first_line(s: &str) -> String {
+    s.lines().next().unwrap_or_default().to_owned()
+}
+
+/// Full rendering of an error chain, for the error modal.
+///
+/// Unlike [`error_summary`], every cause's complete `Display` is kept: for a
+/// parse or book-keeping failure the useful part — the annotate-snippets
+/// source excerpt — lives entirely past the first line, and
+/// `ReportError::BookKeep` has no `source()` at all, so its snippet *is* the
+/// whole message. Returned pre-split into display lines for [`ErrorPopup`].
+fn error_detail(err: &(dyn std::error::Error + 'static)) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = Some(err);
+    let mut depth = 0usize;
+    while let Some(err) = current {
+        if depth > 0 {
+            lines.push(String::new());
+            lines.push(format!("caused by ({depth}):"));
+        }
+        lines.extend(err.to_string().lines().map(str::to_owned));
+        current = err.source();
+        depth += 1;
+    }
+    lines
+}
+
+/// Builds the modal shown when loading `source_display` failed.
+///
+/// The title carries only the file name: a long absolute path would fill the
+/// whole title bar and truncate. The full path stays visible in the window
+/// title and in the error body's own location line.
+fn error_overlay(source_display: &str, err: &(dyn std::error::Error + 'static)) -> Overlay {
+    let name = std::path::Path::new(source_display)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(source_display);
+    Overlay::Error(ErrorPopup::new(
+        format!(" failed to load {name} "),
+        error_detail(err),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use assert_matches::assert_matches;
+    use okane_core::load::FakeFileSystem;
+
+    use app::Screen;
+
+    const V1: &str = "2024/01/01 Init\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Expenses:Food    3 USD\n    Equity\n";
+    // V1 plus a new account sorting before all others.
+    const V2: &str = "2024/01/01 Init\n    Assets:Aaa    1 USD\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Expenses:Food    3 USD\n    Equity\n";
+    // V1 without Expenses:Food.
+    const V3: &str =
+        "2024/01/01 Init\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Equity\n";
+    const BROKEN: &str = "@@ this is not a valid ledger file @@\n";
+    // Parses fine, fails book-keeping — `ReportError::BookKeep`, whose whole
+    // payload is its `Display` (no `source()` behind it).
+    const UNBALANCED: &str =
+        "2024/01/01 Groceries\n    Expenses:Food    30 CHF\n    Assets:Bank    -25 CHF\n";
+
+    fn fake_loader(content: &str) -> load::Loader<FakeFileSystem> {
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("test.ledger"), content.as_bytes().to_vec());
+        load::Loader::new(
+            PathBuf::from("test.ledger"),
+            load::FakeFileSystem::from(map),
+        )
+    }
+
+    fn reload_ctx(content: &str) -> ReloadContext<FakeFileSystem> {
+        ReloadContext::new(
+            fake_loader(content),
+            fake_loader(content),
+            ProcessOptions::default(),
+            None,
+            DateRange::default(),
+        )
+    }
+
+    /// Builds one session from `content` the way the session loop does.
+    fn build<'ctx>(
+        ctx: &mut ReportContext<'ctx>,
+        content: &str,
+        snapshot: Option<&UiSnapshot>,
+    ) -> anyhow::Result<SessionData<'ctx>> {
+        let reload = reload_ctx(content);
+        build_session(ctx, &reload.reload_loader, &reload, "test", snapshot)
+    }
+
+    fn account_names(app: &App<'_>) -> Vec<String> {
+        app.balance_rows
+            .iter()
+            .map(|r| r.account.as_str().to_owned())
+            .collect()
+    }
+
+    #[test]
+    fn rebuild_swaps_rows_and_follows_selection() {
+        let mut arena = Bump::new();
+        let snapshot = {
+            let mut ctx = ReportContext::new(&arena);
+            let SessionData { mut app, .. } = build(&mut ctx, V1, None).unwrap();
+            assert_eq!(
+                account_names(&app),
+                ["Assets:Bank", "Assets:Cash", "Equity", "Expenses:Food"]
+            );
+            app.balance_nav.select(3); // Expenses:Food
+            app.snapshot()
+        };
+        arena.reset();
+
+        let mut ctx = ReportContext::new(&arena);
+        let SessionData { app, .. } = build(&mut ctx, V2, Some(&snapshot)).unwrap();
+
+        assert_eq!(app.error_toast, None);
+        assert_eq!(
+            account_names(&app),
+            [
+                "Assets:Aaa",
+                "Assets:Bank",
+                "Assets:Cash",
+                "Equity",
+                "Expenses:Food"
+            ]
+        );
+        // The selection followed Expenses:Food to its new index.
+        assert_eq!(app.balance_nav.table_state.selected(), Some(4));
+    }
+
+    /// The reason reload rebuilds from scratch: interned entries of the
+    /// previous session (accounts, and likewise aliases) must not leak
+    /// into the fresh context.
+    #[test]
+    fn rebuild_drops_stale_interned_accounts() {
+        let mut arena = Bump::new();
+        {
+            let mut ctx = ReportContext::new(&arena);
+            build(&mut ctx, V1, None).unwrap();
+            assert!(ctx.account("Expenses:Food").is_some());
+        }
+        arena.reset();
+
+        let mut ctx = ReportContext::new(&arena);
+        build(&mut ctx, V3, None).unwrap();
+        assert_eq!(ctx.account("Expenses:Food"), None);
+    }
+
+    #[test]
+    fn rebuild_reopens_register_screen() {
+        let mut arena = Bump::new();
+        let snapshot = {
+            let mut ctx = ReportContext::new(&arena);
+            let SessionData {
+                mut app,
+                mut ledger,
+            } = build(&mut ctx, V1, None).unwrap();
+            let account = ctx.account("Assets:Bank").unwrap();
+            let rows =
+                event::load_register(&mut ledger, &ctx, &app.register_template, account).unwrap();
+            app.show_register(account, rows);
+            app.snapshot()
+        };
+        arena.reset();
+
+        let mut ctx = ReportContext::new(&arena);
+        let SessionData { app, .. } = build(&mut ctx, V2, Some(&snapshot)).unwrap();
+
+        assert_eq!(app.error_toast, None);
+        let Screen::Register(view) = &app.screen else {
+            panic!("expected register screen");
+        };
+        assert_eq!(view.account.as_str(), "Assets:Bank");
+        assert_eq!(view.rows.len(), 1);
+        assert_eq!(view.nav.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn rebuild_register_account_vanished_returns_to_balance() {
+        let mut arena = Bump::new();
+        let snapshot = {
+            let mut ctx = ReportContext::new(&arena);
+            let SessionData {
+                mut app,
+                mut ledger,
+            } = build(&mut ctx, V1, None).unwrap();
+            let account = ctx.account("Expenses:Food").unwrap();
+            let rows =
+                event::load_register(&mut ledger, &ctx, &app.register_template, account).unwrap();
+            app.show_register(account, rows);
+            app.snapshot()
+        };
+        arena.reset();
+
+        let mut ctx = ReportContext::new(&arena);
+        let SessionData { app, .. } = build(&mut ctx, V3, Some(&snapshot)).unwrap();
+
+        assert_matches!(&app.screen, Screen::Balance);
+        assert_matches!(&app.error_toast, Some(_));
+        assert_eq!(
+            account_names(&app),
+            ["Assets:Bank", "Assets:Cash", "Equity"]
+        );
+    }
+
+    #[test]
+    fn build_session_broken_input_fails() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let err = build(&mut ctx, BROKEN, None).unwrap_err();
+        // The footer summary is a single line even though the parse error
+        // renders as a multi-line snippet.
+        assert!(!error_summary(err.as_ref()).contains('\n'));
+    }
+
+    #[test]
+    fn error_detail_keeps_the_whole_snippet() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let err = build(&mut ctx, BROKEN, None).unwrap_err();
+        let lines = error_detail(err.as_ref());
+        // Far more than the one line per cause `error_summary` keeps.
+        assert!(lines.len() > 3, "too few lines: {lines:#?}");
+        let text = lines.join("\n");
+        // The offending source line is what makes the modal worth reading.
+        assert!(text.contains("this is not a valid ledger file"), "{text}");
+        assert!(text.contains("caused by"), "{text}");
+    }
+
+    /// The case that motivated the modal: `error_summary` reduces this to
+    /// `"failed to balance the transaction"`, throwing the snippet away.
+    #[test]
+    fn error_detail_keeps_book_keeping_snippet() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let err = build(&mut ctx, UNBALANCED, None).unwrap_err();
+        assert!(!error_summary(err.as_ref()).contains('\n'));
+
+        let text = error_detail(err.as_ref()).join("\n");
+        assert!(text.contains("unbalanced postings"), "{text}");
+        // The source excerpt and its caret row are the point of the modal.
+        assert!(text.contains("Assets:Bank    -25 CHF"), "{text}");
+        assert!(text.contains('^'), "{text}");
+    }
+
+    /// Stands in for `ReportError::BookKeep`, whose whole payload is a
+    /// multi-line `Display` with no `source()` behind it.
+    #[derive(Debug)]
+    struct Flat;
+
+    impl std::fmt::Display for Flat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "something broke\n  here:\n  ^^^^")
+        }
+    }
+
+    impl std::error::Error for Flat {}
+
+    #[test]
+    fn error_detail_of_sourceless_error_has_no_caused_by() {
+        assert_eq!(
+            error_detail(&Flat),
+            ["something broke", "  here:", "  ^^^^"]
+        );
+    }
+
+    #[test]
+    fn error_overlay_titles_the_source() {
+        assert_matches!(
+            error_overlay("main.ledger", &Flat),
+            Overlay::Error(popup) => {
+                assert!(popup.title.contains("failed to load main.ledger"), "{}", popup.title);
+                assert_eq!(popup.lines.len(), 3);
+                assert_eq!(popup.scroll, 0);
+            }
+        );
+    }
+
+    /// A long path would otherwise truncate the title to uselessness.
+    #[test]
+    fn error_overlay_title_uses_the_file_name_only() {
+        assert_matches!(
+            error_overlay("/some/very/long/path/to/main.ledger", &Flat),
+            Overlay::Error(popup) => {
+                assert_eq!(popup.title, " failed to load main.ledger ");
+            }
+        );
+    }
 }

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -5,6 +5,8 @@
 //! [`super::event`] translates raw `KeyEvent`s into messages based on the
 //! currently active screen and overlay.
 
+use std::cmp::{max, min};
+
 use chrono::NaiveDate;
 use okane_core::report::query::{Conversion, DateRange};
 use okane_core::report::{Account, Amount};
@@ -47,14 +49,17 @@ pub struct RegisterRow<'ctx> {
 impl RegisterRow<'_> {
     /// Number of rendered lines this row occupies (>= 1).
     pub fn line_count(&self) -> u16 {
-        amount_line_count(&self.amount).max(amount_line_count(&self.total))
+        max(
+            amount_line_count(&self.amount),
+            amount_line_count(&self.total),
+        )
     }
 }
 
 /// Number of lines an [`Amount`] would render as in a table.
 fn amount_line_count(amount: &Amount<'_>) -> u16 {
     let n = amount.iter().count();
-    n.max(1).min(u16::MAX as usize) as u16
+    n.clamp(1, u16::MAX as usize) as u16
 }
 
 /// Query parameters reused for every register lookup during the session
@@ -89,11 +94,78 @@ pub enum Screen<'ctx> {
     Register(RegisterView<'ctx>),
 }
 
-/// Modal overlay drawn on top of the current screen.
+/// A scroll request against a scrollable overlay body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollDelta {
+    Lines(i16),
+    Pages(i16),
+    Top,
+    Bottom,
+}
+
+/// Body of the error modal: a full error report the user scrolls through.
+///
+/// The message is pre-split into display lines, and the renderer does not
+/// re-wrap them (annotate-snippets output is column-aligned — soft wrapping
+/// would move the carets away from what they point at). That keeps
+/// `lines.len()` the exact rendered line count, so the scroll bound is
+/// computable — and testable — without a terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorPopup {
+    /// Modal title, e.g. `failed to load main.ledger`.
+    pub title: String,
+    /// The error report, one entry per display line.
+    pub lines: Vec<String>,
+    /// Index of the first visible line.
+    pub scroll: u16,
+    /// Last known height of the body. Updated each frame, the same way
+    /// [`crate::ui::table::TableNav::viewport_height`] is.
+    pub viewport_height: u16,
+}
+
+impl ErrorPopup {
+    pub fn new(title: String, lines: Vec<String>) -> Self {
+        Self {
+            title,
+            lines,
+            scroll: 0,
+            viewport_height: 0,
+        }
+    }
+
+    /// Rows the body can scroll before its last line reaches the bottom of the
+    /// viewport. Zero when everything already fits.
+    fn max_scroll(&self) -> u16 {
+        let lines = u16::try_from(self.lines.len()).unwrap_or(u16::MAX);
+        lines.saturating_sub(max(self.viewport_height, 1))
+    }
+
+    /// Applies a scroll request, clamped to the scrollable range.
+    pub fn scroll(&mut self, delta: ScrollDelta) {
+        let page = i32::from(max(self.viewport_height, 1));
+        let current = i32::from(self.scroll);
+        let target = match delta {
+            ScrollDelta::Lines(n) => current + i32::from(n),
+            ScrollDelta::Pages(n) => current + i32::from(n) * page,
+            ScrollDelta::Top => 0,
+            ScrollDelta::Bottom => i32::from(self.max_scroll()),
+        };
+        self.scroll = target.clamp(0, i32::from(self.max_scroll())) as u16;
+    }
+
+    /// Re-clamps the offset after the viewport height changes (terminal resize).
+    pub fn clamp(&mut self) {
+        self.scroll = min(self.scroll, self.max_scroll());
+    }
+}
+
+/// Modal overlay drawn on top of the current screen.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Overlay {
     /// "Quit? y/n" prompt shown when leaving the balance screen.
     QuitConfirm,
+    /// A failure the user must acknowledge, shown in full.
+    Error(ErrorPopup),
 }
 
 /// Phase of the modal (`/`) account search.
@@ -263,6 +335,8 @@ pub enum Message {
     ConfirmQuit,
     /// Dismiss the current overlay.
     DismissOverlay,
+    /// Scroll the body of a scrollable overlay.
+    OverlayScroll(ScrollDelta),
     /// Unconditional quit (Ctrl-C).
     QuitImmediate,
     /// Open the modal (`/`) balance search bar (incremental phase).
@@ -285,13 +359,46 @@ pub enum Message {
     /// Previous match (modal `N`); or, for interactive search, repeat backward
     /// / recall the previous pattern when empty (`C-r`).
     SearchPrev,
+    /// Re-read the ledger data from disk (`r` / `F5`), keeping the UI state.
+    Reload,
 }
 
 /// Effect requested by [`App::update`] that requires resources the pure
 /// state machine does not own (here: `&mut Ledger` to compute a register).
 #[derive(Debug, Clone, Copy)]
 pub enum Command<'ctx> {
-    LoadRegister { account: Account<'ctx> },
+    LoadRegister {
+        account: Account<'ctx>,
+    },
+    /// Re-run the whole load/process pipeline and swap the data in.
+    Reload,
+}
+
+/// Snapshot of register view that surives a reload, as part of [`UiSnapshot`].
+#[derive(Debug, Clone)]
+pub struct RegisterSnapshot {
+    /// account filter for the registry.
+    account: String,
+    /// Selected cursor index.
+    cursor: usize,
+}
+
+/// UI state that survives a reload, captured by [`App::snapshot`] and
+/// re-applied by [`App::restore`]. Everything is plain owned data — arena
+/// references would dangle across the reload's arena reset, so accounts
+/// are kept by name and re-resolved against the rebuilt session.
+#[derive(Debug, Clone)]
+pub struct UiSnapshot {
+    /// Carried over so page-up/down keeps working before the first frame.
+    viewport_height: u16,
+    /// Selected account on the balance screen, by name.
+    selected_account: Option<String>,
+    /// Snapshot of the register if it's register view.
+    /// Extend this once [`Screen`] is more than 2 states.
+    register: Option<RegisterSnapshot>,
+    /// Active search intent; the matches are recomputed on restore.
+    search: Option<SearchIntent>,
+    last_search: String,
 }
 
 /// Application state for the TUI session.
@@ -302,6 +409,10 @@ pub struct App<'ctx> {
     pub balance_nav: TableNav,
     pub screen: Screen<'ctx>,
     pub overlay: Option<Overlay>,
+    /// Transient one-line notice shown in the footer. Cleared on the next key
+    /// press. Failures worth reading in full go to [`Overlay::Error`] instead,
+    /// which is dismissed explicitly.
+    pub error_toast: Option<String>,
     /// Active account search on the balance screen, if any.
     pub search: Option<Search>,
     /// Most recently used search pattern, recalled by an empty interactive
@@ -325,6 +436,7 @@ impl<'ctx> App<'ctx> {
             balance_nav,
             screen: Screen::Balance,
             overlay: None,
+            error_toast: None,
             search: None,
             last_search: String::new(),
             register_template,
@@ -349,6 +461,9 @@ impl<'ctx> App<'ctx> {
     /// Applies a message; optionally returns a [`Command`] for the event
     /// loop to execute (the only impure step in this flow).
     pub fn update(&mut self, msg: Message) -> Option<Command<'ctx>> {
+        // Any key press dismisses a transient error notice.
+        self.error_toast = None;
+
         // QuitImmediate is honored regardless of overlay/screen.
         if matches!(msg, Message::QuitImmediate) {
             self.should_quit = true;
@@ -359,6 +474,21 @@ impl<'ctx> App<'ctx> {
             match msg {
                 Message::ConfirmQuit => self.should_quit = true,
                 Message::DismissOverlay => self.overlay = None,
+                Message::OverlayScroll(delta) => {
+                    if let Some(Overlay::Error(popup)) = self.overlay.as_mut() {
+                        popup.scroll(delta);
+                    }
+                }
+                // Quitting from the error modal skips the dismiss step: fall
+                // through so the quit prompt replaces it.
+                Message::RequestQuit if matches!(self.overlay, Some(Overlay::Error(_))) => {
+                    self.overlay = Some(Overlay::QuitConfirm);
+                }
+                // Retrying from the error modal: the reload rebuilds the whole
+                // session (and this overlay with it).
+                Message::Reload if matches!(self.overlay, Some(Overlay::Error(_))) => {
+                    return Some(Command::Reload);
+                }
                 // Ignore other input while a modal is up.
                 _ => {}
             }
@@ -449,8 +579,12 @@ impl<'ctx> App<'ctx> {
             }
             Message::SearchNext => self.search_or_recall(SearchDirection::Forward),
             Message::SearchPrev => self.search_or_recall(SearchDirection::Backward),
-            // Already handled above.
-            Message::QuitImmediate | Message::ConfirmQuit | Message::DismissOverlay => {}
+            Message::Reload => return Some(Command::Reload),
+            // Already handled above, or only meaningful while an overlay is up.
+            Message::QuitImmediate
+            | Message::ConfirmQuit
+            | Message::DismissOverlay
+            | Message::OverlayScroll(_) => {}
         }
         None
     }
@@ -459,6 +593,84 @@ impl<'ctx> App<'ctx> {
     /// fulfilled.
     pub fn show_register(&mut self, account: Account<'ctx>, rows: Vec<RegisterRow<'ctx>>) {
         self.screen = Screen::Register(RegisterView::new(account, rows));
+    }
+
+    /// Like [`Self::show_register`], but restores a previous cursor position
+    /// (clamped to the new row count) instead of jumping to the last entry.
+    /// Used when re-entering the register after a reload.
+    pub fn show_register_at(
+        &mut self,
+        account: Account<'ctx>,
+        rows: Vec<RegisterRow<'ctx>>,
+        index: usize,
+    ) {
+        let mut view = RegisterView::new(account, rows);
+        if let Some(last) = view.nav.row_count.checked_sub(1) {
+            view.nav.select(min(index, last));
+        }
+        self.screen = Screen::Register(view);
+    }
+
+    /// Captures the UI state that should survive a reload as owned data
+    /// (no `'ctx` borrows): the whole session, arena included, is torn
+    /// down before the snapshot is restored into the next one.
+    pub fn snapshot(&self) -> UiSnapshot {
+        UiSnapshot {
+            viewport_height: self.balance_nav.viewport_height,
+            selected_account: self
+                .selected_balance_account()
+                .map(|a| a.as_str().to_owned()),
+            register: match &self.screen {
+                Screen::Balance => None,
+                Screen::Register(view) => Some(RegisterSnapshot {
+                    account: view.account.as_str().to_owned(),
+                    cursor: view.nav.table_state.selected().unwrap_or(0),
+                }),
+            },
+            search: self.search.as_ref().map(|s| s.intent.clone()),
+            last_search: self.last_search.clone(),
+        }
+    }
+
+    /// Restores a [`UiSnapshot`] into this freshly-built `App`: the balance
+    /// selection follows the previously selected account (or the closest one
+    /// by name when it disappeared), and any active search is recomputed
+    /// against the new rows.
+    ///
+    /// When the snapshot had the register screen open, returns
+    /// `Some((account, index))` asking the caller to query that account's
+    /// register and open it via [`Self::show_register_at`]. If the account
+    /// no longer exists, stays on the balance screen (with a notice) and
+    /// returns `None`.
+    pub fn restore(&mut self, snapshot: &UiSnapshot) -> Option<(Account<'ctx>, usize)> {
+        self.balance_nav.viewport_height = snapshot.viewport_height;
+        if let Some(prev) = &snapshot.selected_account
+            && let Some(idx) = restore_index(prev, &self.balance_rows)
+        {
+            self.balance_nav.select(idx);
+        }
+
+        self.last_search = snapshot.last_search.clone();
+        if let Some(intent) = &snapshot.search {
+            let mut intent = intent.clone();
+            intent.origin = min(intent.origin, self.balance_rows.len().saturating_sub(1));
+            let matches = SearchMatch::compute(&intent.input, &self.balance_rows);
+            self.search = Some(Search { intent, matches });
+        }
+
+        let RegisterSnapshot{account, cursor} = snapshot.register.as_ref()?;
+        match self
+            .balance_rows
+            .binary_search_by(|r| r.account.as_str().cmp(account.as_str()))
+        {
+            Ok(row) => Some((self.balance_rows[row].account, *cursor)),
+            Err(_) => {
+                self.error_toast = Some(format!(
+                    "account {account} is gone after reload; back to balance"
+                ));
+                None
+            }
+        }
     }
 
     /// Opens a search of the given style, recording the current selection as
@@ -569,6 +781,20 @@ impl<'ctx> App<'ctx> {
             self.balance_nav.select(idx);
         }
     }
+}
+
+/// Row index to restore after a reload: the row of `prev_name` when it still
+/// exists, otherwise the alphabetically closest row (insertion point, clamped
+/// to the end). `None` when `rows` is empty.
+///
+/// Relies on `rows` being sorted by account name, which is the order
+/// `Balance::into_vec` produces.
+fn restore_index(prev_name: &str, rows: &[BalanceRow<'_>]) -> Option<usize> {
+    let last = rows.len().checked_sub(1)?;
+    let idx = rows
+        .binary_search_by(|r| r.account.as_str().cmp(prev_name))
+        .unwrap_or_else(|insertion| insertion);
+    Some(min(idx, last))
 }
 
 #[cfg(test)]
@@ -1136,6 +1362,129 @@ mod tests {
         assert_eq!(app.balance_nav.table_state.selected(), Some(0));
     }
 
+    fn popup(lines: usize, viewport_height: u16) -> ErrorPopup {
+        let mut popup = ErrorPopup::new(
+            "failed to load test.ledger".to_owned(),
+            (0..lines).map(|i| format!("line {i}")).collect(),
+        );
+        popup.viewport_height = viewport_height;
+        popup
+    }
+
+    fn app_with_error_modal<'ctx>() -> App<'ctx> {
+        let mut app = app_no_rows();
+        app.overlay = Some(Overlay::Error(popup(10, 4)));
+        app
+    }
+
+    #[test]
+    fn popup_scroll_clamps_at_top() {
+        let mut p = popup(10, 4);
+        p.scroll(ScrollDelta::Lines(-1));
+        assert_eq!(p.scroll, 0);
+    }
+
+    #[test]
+    fn popup_scroll_clamps_at_bottom() {
+        let mut p = popup(10, 4);
+        p.scroll(ScrollDelta::Lines(100));
+        assert_eq!(p.scroll, 6);
+    }
+
+    #[test]
+    fn popup_scroll_pinned_when_body_fits() {
+        let mut p = popup(5, 10);
+        assert_eq!(p.max_scroll(), 0);
+        p.scroll(ScrollDelta::Bottom);
+        assert_eq!(p.scroll, 0);
+    }
+
+    #[test]
+    fn popup_page_scroll_uses_viewport_height() {
+        let mut p = popup(100, 4);
+        p.scroll(ScrollDelta::Pages(1));
+        assert_eq!(p.scroll, 4);
+        p.scroll(ScrollDelta::Pages(-1));
+        assert_eq!(p.scroll, 0);
+    }
+
+    #[test]
+    fn popup_top_and_bottom_jump() {
+        let mut p = popup(10, 4);
+        p.scroll(ScrollDelta::Bottom);
+        assert_eq!(p.scroll, 6);
+        p.scroll(ScrollDelta::Top);
+        assert_eq!(p.scroll, 0);
+    }
+
+    #[test]
+    fn popup_scroll_without_viewport_does_not_panic() {
+        // The first key can in principle arrive before a frame has been drawn;
+        // an unknown viewport falls back to a single line per page.
+        let mut p = popup(10, 0);
+        p.scroll(ScrollDelta::Pages(1));
+        assert_eq!(p.scroll, 1);
+        p.scroll(ScrollDelta::Bottom);
+        assert_eq!(p.scroll, 9);
+    }
+
+    #[test]
+    fn popup_clamps_after_viewport_shrink() {
+        let mut p = popup(10, 4);
+        p.scroll(ScrollDelta::Bottom);
+        p.viewport_height = 10;
+        p.clamp();
+        assert_eq!(p.scroll, 0);
+    }
+
+    #[test]
+    fn error_modal_scrolls_on_overlay_scroll() {
+        let mut app = app_with_error_modal();
+        assert!(
+            app.update(Message::OverlayScroll(ScrollDelta::Bottom))
+                .is_none()
+        );
+        assert_matches!(&app.overlay, Some(Overlay::Error(p)) if p.scroll == 6);
+    }
+
+    #[test]
+    fn error_modal_survives_key_that_clears_footer_notice() {
+        let mut app = app_with_error_modal();
+        app.error_toast = Some("transient".to_owned());
+        app.update(Message::MoveDown);
+        assert!(app.error_toast.is_none());
+        assert_matches!(app.overlay, Some(Overlay::Error(_)));
+    }
+
+    #[test]
+    fn request_quit_replaces_error_modal_with_quit_prompt() {
+        let mut app = app_with_error_modal();
+        app.update(Message::RequestQuit);
+        assert_eq!(app.overlay, Some(Overlay::QuitConfirm));
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn dismiss_closes_error_modal() {
+        let mut app = app_with_error_modal();
+        app.update(Message::DismissOverlay);
+        assert_eq!(app.overlay, None);
+    }
+
+    #[test]
+    fn reload_through_error_modal_returns_command() {
+        let mut app = app_with_error_modal();
+        assert_matches!(app.update(Message::Reload), Some(Command::Reload));
+    }
+
+    #[test]
+    fn reload_during_quit_prompt_is_ignored() {
+        let mut app = app_no_rows();
+        app.update(Message::RequestQuit);
+        assert!(app.update(Message::Reload).is_none());
+        assert_eq!(app.overlay, Some(Overlay::QuitConfirm));
+    }
+
     #[test]
     fn leave_register_returns_to_balance() {
         let arena = Bump::new();
@@ -1150,6 +1499,210 @@ mod tests {
         });
         app.update(Message::LeaveRegister);
         assert!(matches!(app.screen, Screen::Balance));
+    }
+
+    /// Balance rows for `names` (must be sorted, matching `Balance::into_vec`
+    /// order) resolved against an existing context.
+    fn rows_of<'ctx>(ctx: &ReportContext<'ctx>, names: &[&str]) -> Vec<BalanceRow<'ctx>> {
+        names
+            .iter()
+            .map(|n| BalanceRow {
+                account: ctx.account(n).unwrap(),
+                amount: Amount::zero(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn restore_index_prefers_exact_match() {
+        let arena = Bump::new();
+        let (ctx, _app) = make_balance_app(&arena, ACCOUNTS);
+        let rows = rows_of(&ctx, ACCOUNTS);
+        assert_eq!(restore_index("Expenses:Food", &rows), Some(2));
+    }
+
+    #[test]
+    fn restore_index_falls_back_to_insertion_point() {
+        let arena = Bump::new();
+        let (ctx, _app) = make_balance_app(&arena, ACCOUNTS);
+        let rows = rows_of(&ctx, ACCOUNTS);
+        // Between Assets:Cash (1) and Expenses:Food (2).
+        assert_eq!(restore_index("Assets:Extra", &rows), Some(2));
+        // Before every row.
+        assert_eq!(restore_index("Aaa", &rows), Some(0));
+        // Past the last row, clamped.
+        assert_eq!(restore_index("Zzz", &rows), Some(4));
+    }
+
+    #[test]
+    fn restore_index_empty_rows_is_none() {
+        let rows: &[BalanceRow<'_>] = &[];
+        assert_eq!(restore_index("Assets:Bank", rows), None);
+    }
+
+    #[test]
+    fn reload_message_produces_command() {
+        let mut app = app_no_rows();
+        assert_matches!(app.update(Message::Reload), Some(Command::Reload));
+    }
+
+    #[test]
+    fn any_key_clears_error_notice() {
+        let mut app = app_no_rows();
+        app.error_toast = Some("boom".to_owned());
+        app.update(Message::MoveDown);
+        assert_eq!(app.error_toast, None);
+    }
+
+    /// A fresh `App` over `names`, as if built for the next session.
+    fn next_app<'ctx>(ctx: &ReportContext<'ctx>, names: &[&str]) -> App<'ctx> {
+        App::new("test".to_owned(), rows_of(ctx, names), template())
+    }
+
+    #[test]
+    fn restore_follows_selected_account() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        app.balance_nav.select(2); // Expenses:Food
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(
+            &ctx,
+            &[
+                "Assets:Cash",
+                "Expenses:Food",
+                "Income:Salary",
+                "Liabilities:Card",
+            ],
+        );
+        assert_matches!(app.restore(&snapshot), None);
+        // Expenses:Food moved from index 2 to 1.
+        assert_eq!(selected(&app), Some(1));
+    }
+
+    #[test]
+    fn restore_vanished_account_selects_closest() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        app.balance_nav.select(2); // Expenses:Food
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(
+            &ctx,
+            &[
+                "Assets:Bank",
+                "Assets:Cash",
+                "Income:Salary",
+                "Liabilities:Card",
+            ],
+        );
+        app.restore(&snapshot);
+        // Expenses:Food is gone; the insertion point lands on Income:Salary.
+        assert_eq!(selected(&app), Some(2));
+    }
+
+    #[test]
+    fn restore_keeps_viewport_height() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        app.balance_nav.viewport_height = 12;
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(&ctx, ACCOUNTS);
+        app.restore(&snapshot);
+        assert_eq!(app.balance_nav.viewport_height, 12);
+    }
+
+    #[test]
+    fn restore_recomputes_search_matches() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        app.update(Message::StartModalSearch);
+        for c in "assets".chars() {
+            app.update(Message::SearchPush(c));
+        }
+        app.update(Message::SearchSubmit); // fixed
+        assert_eq!(app.search.as_ref().unwrap().matched_rows(), [0, 1]);
+        app.last_search = "salary".to_owned();
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(&ctx, &["Assets:Bank", "Income:Salary"]);
+        app.restore(&snapshot);
+        let search = app.search.as_ref().unwrap();
+        assert_eq!(search.intent.input, "assets");
+        assert_eq!(search.matched_rows(), [0]);
+        // Origin is clamped into the new row range.
+        assert!(search.intent.origin < 2);
+        assert_eq!(&app.last_search, "salary");
+    }
+
+    #[test]
+    fn restore_requests_register_requery() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        let account = ctx.account("Assets:Cash").unwrap();
+        let mut nav = TableNav::new(5);
+        nav.select(3);
+        app.screen = Screen::Register(RegisterView {
+            account,
+            rows: Vec::new(),
+            nav,
+        });
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(&ctx, ACCOUNTS);
+        let got = app.restore(&snapshot);
+        assert_matches!(got, Some((acc, 3)) if acc.as_str() == "Assets:Cash");
+        // The screen stays on balance until the caller queries the rows and
+        // opens the register via `show_register_at`.
+        assert!(matches!(app.screen, Screen::Balance));
+        assert_eq!(app.error_toast, None);
+    }
+
+    #[test]
+    fn restore_register_account_vanished_falls_back() {
+        let arena = Bump::new();
+        let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
+        let account = ctx.account("Assets:Cash").unwrap();
+        app.screen = Screen::Register(RegisterView {
+            account,
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        let snapshot = app.snapshot();
+
+        let mut app = next_app(&ctx, &["Assets:Bank", "Income:Salary"]);
+        let got = app.restore(&snapshot);
+        assert_matches!(got, None);
+        assert!(matches!(app.screen, Screen::Balance));
+        assert_matches!(&app.error_toast, Some(_));
+    }
+
+    #[test]
+    fn show_register_at_clamps_index() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:Cash");
+        let rows: Vec<RegisterRow<'_>> = (0..3)
+            .map(|i| RegisterRow {
+                date: NaiveDate::from_ymd_opt(2024, 1, i + 1).unwrap(),
+                payee: "payee".to_owned(),
+                amount: Amount::zero(),
+                total: Amount::zero(),
+            })
+            .collect();
+
+        let mut app = app_no_rows();
+        app.show_register_at(account, rows.clone(), 10);
+        let Screen::Register(view) = &app.screen else {
+            panic!("expected register screen");
+        };
+        assert_eq!(view.nav.table_state.selected(), Some(2));
+
+        app.show_register_at(account, rows, 1);
+        let Screen::Register(view) = &app.screen else {
+            panic!("expected register screen");
+        };
+        assert_eq!(view.nav.table_state.selected(), Some(1));
     }
 
     #[test]

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -20,20 +20,34 @@ use ratatui::DefaultTerminal;
 use crate::ui::keys::is_ctrl;
 
 use super::app::{
-    App, Command, Message, Overlay, RegisterQueryTemplate, RegisterRow, Screen, SearchDirection,
-    SearchMode, SearchPhase,
+    App, Command, Message, Overlay, RegisterQueryTemplate, RegisterRow, Screen, ScrollDelta,
+    SearchDirection, SearchMode, SearchPhase,
 };
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);
 
-/// Runs the event loop until the user quits.
-pub fn run<'ctx>(
+fn scroll(delta: ScrollDelta) -> Option<Message> {
+    Some(Message::OverlayScroll(delta))
+}
+
+/// Why the event loop returned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RunOutcome {
+    /// The user quit.
+    Quit,
+    /// The user asked for a reload; the session loop in [`super::run_ui`]
+    /// fulfills it by tearing this session down and rebuilding from scratch.
+    Reload,
+}
+
+/// Runs the event loop until the user quits or asks for a reload.
+pub(super) fn run<'ctx>(
     terminal: &mut DefaultTerminal,
     app: &mut App<'ctx>,
     ledger: &mut Ledger<'ctx>,
     ctx: &ReportContext<'ctx>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<RunOutcome> {
     while !app.should_quit {
         terminal.draw(|frame| render::draw(frame, app, ctx))?;
         if event::poll(POLL_TIMEOUT)?
@@ -41,10 +55,19 @@ pub fn run<'ctx>(
             && let Some(msg) = key_to_message(app, key)
             && let Some(cmd) = app.update(msg)
         {
-            fulfill(app, ledger, ctx, cmd)?;
+            match cmd {
+                Command::Reload => return Ok(RunOutcome::Reload),
+                Command::LoadRegister { account } => {
+                    let rows = load_register(ledger, ctx, &app.register_template, account)
+                        .with_context(|| {
+                            format!("failed to load register for {}", account.as_str())
+                        })?;
+                    app.show_register(account, rows);
+                }
+            }
         }
     }
-    Ok(())
+    Ok(RunOutcome::Quit)
 }
 
 /// Pure: translate a raw `KeyEvent` into a [`Message`] given the current
@@ -62,14 +85,40 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         return Some(Message::QuitImmediate);
     }
 
-    if app.overlay == Some(Overlay::QuitConfirm) {
-        return match key.code {
-            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => Some(Message::ConfirmQuit),
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Char('q') => {
-                Some(Message::DismissOverlay)
-            }
-            _ => None,
-        };
+    match &app.overlay {
+        Some(Overlay::QuitConfirm) => {
+            return match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                    Some(Message::ConfirmQuit)
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Char('q') => {
+                    Some(Message::DismissOverlay)
+                }
+                _ => None,
+            };
+        }
+        // Scrolling mirrors the common navigation block below so the modal
+        // needs no new muscle memory. `r`/`F5` retry the load without a
+        // dismiss step; `q` goes straight to the quit prompt.
+        Some(Overlay::Error(_)) => {
+            return match key.code {
+                KeyCode::Esc | KeyCode::Enter => Some(Message::DismissOverlay),
+                KeyCode::Char('q') => Some(Message::RequestQuit),
+                KeyCode::Up | KeyCode::Char('k') => scroll(ScrollDelta::Lines(-1)),
+                KeyCode::Char('p') if ctrl => scroll(ScrollDelta::Lines(-1)),
+                KeyCode::Down | KeyCode::Char('j') => scroll(ScrollDelta::Lines(1)),
+                KeyCode::Char('n') if ctrl => scroll(ScrollDelta::Lines(1)),
+                KeyCode::PageUp => scroll(ScrollDelta::Pages(-1)),
+                KeyCode::Char('b') if ctrl => scroll(ScrollDelta::Pages(-1)),
+                KeyCode::PageDown => scroll(ScrollDelta::Pages(1)),
+                KeyCode::Char('f') if ctrl => scroll(ScrollDelta::Pages(1)),
+                KeyCode::Home | KeyCode::Char('g') => scroll(ScrollDelta::Top),
+                KeyCode::End | KeyCode::Char('G') => scroll(ScrollDelta::Bottom),
+                KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
+                _ => None,
+            };
+        }
+        None => {}
     }
 
     // Balance account-search capture. The editing phases (modal incremental,
@@ -126,6 +175,7 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         KeyCode::Char('f') if ctrl => Some(Message::PageDown),
         KeyCode::Home | KeyCode::Char('g') => Some(Message::SelectFirst),
         KeyCode::End | KeyCode::Char('G') => Some(Message::SelectLast),
+        KeyCode::F(5) => Some(Message::Reload),
         _ => None,
     };
     if nav.is_some() {
@@ -143,33 +193,15 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         }
         (Screen::Balance, KeyCode::Enter) => Some(Message::OpenRegister),
         (Screen::Balance, KeyCode::Char('q') | KeyCode::Esc) => Some(Message::RequestQuit),
+        (Screen::Balance | Screen::Register(_), KeyCode::Char('r')) => Some(Message::Reload),
         (Screen::Register(_), KeyCode::Char('q') | KeyCode::Esc) => Some(Message::LeaveRegister),
         _ => None,
     }
 }
 
-/// Executes a [`Command`] returned from [`App::update`]. The only impure
-/// step in the loop — it owns the `&mut Ledger` the pure state machine
-/// cannot touch.
-fn fulfill<'ctx>(
-    app: &mut App<'ctx>,
-    ledger: &mut Ledger<'ctx>,
-    ctx: &ReportContext<'ctx>,
-    cmd: Command<'ctx>,
-) -> anyhow::Result<()> {
-    match cmd {
-        Command::LoadRegister { account } => {
-            let rows = load_register(ledger, ctx, &app.register_template, account)
-                .with_context(|| format!("failed to load register for {}", account.as_str()))?;
-            app.show_register(account, rows);
-            Ok(())
-        }
-    }
-}
-
 /// Collects the register rows for `account` into owned [`RegisterRow`]s so
 /// they can be displayed without keeping the `FallibleLender` alive.
-fn load_register<'ctx>(
+pub fn load_register<'ctx>(
     ledger: &mut Ledger<'ctx>,
     ctx: &ReportContext<'ctx>,
     template: &RegisterQueryTemplate<'ctx>,
@@ -207,7 +239,7 @@ mod tests {
 
     use crate::ui::table::TableNav;
 
-    use super::super::app::{RegisterView, Search, SearchIntent, SearchMatch};
+    use super::super::app::{ErrorPopup, RegisterView, Search, SearchIntent, SearchMatch};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -370,6 +402,93 @@ mod tests {
         );
     }
 
+    fn app_with_error_modal<'ctx>() -> App<'ctx> {
+        let mut app = app();
+        app.overlay = Some(Overlay::Error(ErrorPopup::new(
+            "failed to load test.ledger".to_owned(),
+            vec!["boom".to_owned()],
+        )));
+        app
+    }
+
+    #[test]
+    fn error_overlay_scroll_keys() {
+        let app = app_with_error_modal();
+        for (k, delta) in [
+            (key(KeyCode::Char('j')), ScrollDelta::Lines(1)),
+            (key(KeyCode::Down), ScrollDelta::Lines(1)),
+            (ctrl_key('n'), ScrollDelta::Lines(1)),
+            (key(KeyCode::Char('k')), ScrollDelta::Lines(-1)),
+            (key(KeyCode::Up), ScrollDelta::Lines(-1)),
+            (ctrl_key('p'), ScrollDelta::Lines(-1)),
+            (key(KeyCode::PageDown), ScrollDelta::Pages(1)),
+            (ctrl_key('f'), ScrollDelta::Pages(1)),
+            (key(KeyCode::PageUp), ScrollDelta::Pages(-1)),
+            (ctrl_key('b'), ScrollDelta::Pages(-1)),
+            (key(KeyCode::Char('g')), ScrollDelta::Top),
+            (key(KeyCode::Home), ScrollDelta::Top),
+            (key(KeyCode::Char('G')), ScrollDelta::Bottom),
+            (key(KeyCode::End), ScrollDelta::Bottom),
+        ] {
+            assert_eq!(
+                key_to_message(&app, k),
+                Some(Message::OverlayScroll(delta)),
+                "{k:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_overlay_dismiss_and_quit_keys() {
+        let app = app_with_error_modal();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Esc)),
+            Some(Message::DismissOverlay)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Enter)),
+            Some(Message::DismissOverlay)
+        );
+        // Unlike the quit prompt, `q` here means quit, matching the normal
+        // balance screen.
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('q'))),
+            Some(Message::RequestQuit)
+        );
+    }
+
+    /// Retrying straight from the modal — contrast with
+    /// [`r_during_quit_overlay_is_unmapped`].
+    #[test]
+    fn error_overlay_r_and_f5_reload() {
+        let app = app_with_error_modal();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('r'))),
+            Some(Message::Reload)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::F(5))),
+            Some(Message::Reload)
+        );
+    }
+
+    #[test]
+    fn error_overlay_swallows_other_keys() {
+        let app = app_with_error_modal();
+        assert_eq!(key_to_message(&app, key(KeyCode::Char('/'))), None);
+        assert_eq!(key_to_message(&app, key(KeyCode::Char('y'))), None);
+        assert_eq!(key_to_message(&app, ctrl_key('s')), None);
+    }
+
+    #[test]
+    fn ctrl_c_quits_through_the_error_modal() {
+        let app = app_with_error_modal();
+        assert_eq!(
+            key_to_message(&app, ctrl_key('c')),
+            Some(Message::QuitImmediate)
+        );
+    }
+
     fn fixed_search() -> Search {
         Search {
             intent: SearchIntent {
@@ -520,5 +639,69 @@ mod tests {
         let release =
             KeyEvent::new_with_kind(KeyCode::Down, KeyModifiers::NONE, KeyEventKind::Release);
         assert_eq!(key_to_message(&app, release), None);
+    }
+
+    #[test]
+    fn plain_r_and_f5_reload_on_both_screens() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let mut app = app();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('r'))),
+            Some(Message::Reload)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::F(5))),
+            Some(Message::Reload)
+        );
+        app.screen = Screen::Register(RegisterView {
+            account,
+            rows: Vec::new(),
+            nav: TableNav::new(0),
+        });
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('r'))),
+            Some(Message::Reload)
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::F(5))),
+            Some(Message::Reload)
+        );
+    }
+
+    #[test]
+    fn r_during_search_editing_is_captured_as_input() {
+        // Modal incremental: every character belongs to the pattern.
+        let mut modal_app = app();
+        modal_app.update(Message::StartModalSearch);
+        assert_eq!(
+            key_to_message(&modal_app, key(KeyCode::Char('r'))),
+            Some(Message::SearchPush('r'))
+        );
+        // Interactive i-search: same.
+        let mut isearch_app = app();
+        isearch_app.search = Some(interactive_search());
+        assert_eq!(
+            key_to_message(&isearch_app, key(KeyCode::Char('r'))),
+            Some(Message::SearchPush('r'))
+        );
+    }
+
+    #[test]
+    fn r_during_fixed_search_reloads() {
+        let mut app = app();
+        app.search = Some(fixed_search());
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('r'))),
+            Some(Message::Reload)
+        );
+    }
+
+    #[test]
+    fn r_during_quit_overlay_is_unmapped() {
+        let mut app = app();
+        app.overlay = Some(Overlay::QuitConfirm);
+        assert_eq!(key_to_message(&app, key(KeyCode::Char('r'))), None);
+        assert_eq!(key_to_message(&app, key(KeyCode::F(5))), None);
     }
 }

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -5,6 +5,8 @@
 //! render a `Clear` widget over a centered rect, then render the popup
 //! contents on top.
 
+use std::cmp::{max, min};
+
 use okane_core::report::{Amount, ReportContext};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
@@ -14,13 +16,16 @@ use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table};
 use unicode_width::UnicodeWidthStr;
 
 use super::app::{
-    App, BalanceRow, Overlay, RegisterRow, RegisterView, Screen, Search, SearchDirection,
-    SearchMatch, SearchMode, SearchPhase,
+    App, BalanceRow, ErrorPopup, Overlay, RegisterRow, RegisterView, Screen, Search,
+    SearchDirection, SearchMatch, SearchMode, SearchPhase,
 };
 use crate::ui::table::TableNav;
 
-const FOOTER_HINT_BALANCE: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · / search · C-s isearch · q quit ";
-const FOOTER_HINT_REGISTER: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · q/Esc back ";
+const FOOTER_HINT_BALANCE: &str = " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · / search · C-s isearch · r reload · q quit ";
+const FOOTER_HINT_REGISTER: &str =
+    " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back ";
+const ERROR_POPUP_HINT: &str =
+    " ↑/↓ scroll · PgUp/PgDn page · g/G top/end · r reload · Esc/Enter close · q quit ";
 
 /// Renders a frame for the given app state.
 pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
@@ -48,19 +53,25 @@ pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'c
                 matches,
                 ctx,
             );
-            match &app.search {
-                Some(search) => draw_search_bar(frame, layout[2], search),
-                None => draw_footer(frame, layout[2], FOOTER_HINT_BALANCE),
+            match (&app.error_toast, &app.search) {
+                (Some(msg), _) => draw_error(frame, layout[2], msg),
+                (None, Some(search)) => draw_search_bar(frame, layout[2], search),
+                (None, None) => draw_footer(frame, layout[2], FOOTER_HINT_BALANCE),
             }
         }
         Screen::Register(view) => {
             draw_register_body(frame, layout[1], view, ctx);
-            draw_footer(frame, layout[2], FOOTER_HINT_REGISTER);
+            match &app.error_toast {
+                Some(msg) => draw_error(frame, layout[2], msg),
+                None => draw_footer(frame, layout[2], FOOTER_HINT_REGISTER),
+            }
         }
     }
 
-    if app.overlay == Some(Overlay::QuitConfirm) {
-        draw_quit_confirm(frame, area);
+    match &mut app.overlay {
+        Some(Overlay::QuitConfirm) => draw_quit_confirm(frame, area),
+        Some(Overlay::Error(popup)) => draw_error_popup(frame, area, popup),
+        None => {}
     }
 }
 
@@ -194,6 +205,14 @@ fn draw_footer(frame: &mut Frame, area: Rect, hint: &str) {
     frame.render_widget(footer, area);
 }
 
+/// Renders a transient error notice (e.g. a failed reload) in the footer
+/// slot. Takes priority over the key hint and the search bar; cleared by
+/// [`App::update`] on the next key press.
+fn draw_error(frame: &mut Frame, area: Rect, message: &str) {
+    let footer = Paragraph::new(format!(" {message} ")).style(Style::default().fg(Color::Red));
+    frame.render_widget(footer, area);
+}
+
 /// Renders the balance search bar in the footer slot: a prompt + the typed
 /// pattern (red on an invalid regex) plus a dim hint suffix. While editing it
 /// also places the terminal cursor at the end of the pattern.
@@ -245,10 +264,8 @@ fn draw_search_bar(frame: &mut Frame, area: Rect, search: &Search) {
     if show_cursor {
         // Cursor sits just past the last typed character (after the prompt),
         // clamped so it never leaves the footer row.
-        let cursor_x = area
-            .x
-            .saturating_add(display_width(&text) as u16)
-            .min(area.x + area.width.saturating_sub(1));
+        let cursor_x = area.x.saturating_add(display_width(&text) as u16);
+        let cursor_x = min(cursor_x, area.x + area.width.saturating_sub(1));
         frame.set_cursor_position((cursor_x, area.y));
     }
 }
@@ -270,10 +287,73 @@ fn draw_quit_confirm(frame: &mut Frame, area: Rect) {
     frame.render_widget(body, popup);
 }
 
+/// Near-full-screen modal showing a failure in full, e.g. a reload that could
+/// not parse the ledger.
+///
+/// The body is deliberately *not* wrapped: annotate-snippets output aligns a
+/// line-number gutter, the source line and a caret row by column, and soft
+/// wrapping would move the carets away from what they point at. Long lines are
+/// clipped instead. That also keeps `lines.len()` the rendered line count, so
+/// [`ErrorPopup::scroll`] can clamp exactly.
+fn draw_error_popup(frame: &mut Frame, area: Rect, popup: &mut ErrorPopup) {
+    let rect = error_popup_rect(area);
+    // Clear first so the popup paints over the table cleanly.
+    frame.render_widget(Clear, rect);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(popup.title.as_str())
+        .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let layout = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+    // The body height is only known here; keep it fresh for the scroll math,
+    // the same way the tables refresh `TableNav::viewport_height`.
+    popup.viewport_height = layout[0].height;
+    popup.clamp();
+
+    let body: Vec<Line> = popup
+        .lines
+        .iter()
+        .map(|line| Line::from(line.as_str()))
+        .collect();
+    frame.render_widget(
+        Paragraph::new(body)
+            .style(
+                Style::default()
+                    .fg(Color::Reset)
+                    .remove_modifier(Modifier::BOLD),
+            )
+            .scroll((popup.scroll, 0)),
+        layout[0],
+    );
+
+    // Split so the position counter survives on narrow terminals; the hint
+    // is the part that gets clipped.
+    let position = format!(" {}/{} ", popup.scroll + 1, popup.lines.len());
+    let dim = Style::default().add_modifier(Modifier::DIM);
+    let footer = Layout::horizontal([
+        Constraint::Min(0),
+        Constraint::Length(display_width(&position) as u16),
+    ])
+    .split(layout[1]);
+    frame.render_widget(Paragraph::new(ERROR_POPUP_HINT).style(dim), footer[0]);
+    frame.render_widget(Paragraph::new(position).style(dim), footer[1]);
+}
+
+/// Four fifths of the screen, with a floor so tiny terminals still show
+/// something usable.
+fn error_popup_rect(area: Rect) -> Rect {
+    let width = (u32::from(area.width) * 4 / 5) as u16;
+    let height = (u32::from(area.height) * 4 / 5) as u16;
+    centered_rect(area, max(width, 20), max(height, 5))
+}
+
 /// Returns a sub-rect of `area` of the given size, centered.
 fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
-    let width = width.min(area.width);
-    let height = height.min(area.height);
+    let width = min(width, area.width);
+    let height = min(height, area.height);
     let x = area.x + (area.width.saturating_sub(width)) / 2;
     let y = area.y + (area.height.saturating_sub(height)) / 2;
     Rect {
@@ -350,10 +430,17 @@ fn display_width(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use bumpalo::Bump;
+    use okane_core::report::query::DateRange;
     use okane_core::report::{Amount, ReportContext};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Position;
     use rust_decimal_macros::dec;
 
+    use super::super::app::{Message, RegisterQueryTemplate, ScrollDelta};
     use super::*;
 
     #[test]
@@ -424,5 +511,92 @@ mod tests {
         let r = centered_rect(area, 40, 6);
         assert_eq!(r.width, 10);
         assert_eq!(r.height, 4);
+    }
+
+    #[test]
+    fn error_popup_rect_is_four_fifths() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 30,
+        };
+        let r = error_popup_rect(area);
+        assert_eq!(r.width, 80);
+        assert_eq!(r.height, 24);
+    }
+
+    #[test]
+    fn error_popup_rect_has_a_floor_on_tiny_terminals() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 12,
+            height: 4,
+        };
+        // The floor exceeds the area, so it clamps back to the whole screen.
+        let r = error_popup_rect(area);
+        assert_eq!(r.width, 12);
+        assert_eq!(r.height, 4);
+    }
+
+    /// Renders `app` into an 80×24 headless terminal and returns the plain text.
+    fn render<'ctx>(app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) -> String {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, app, ctx)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[Position { x, y }].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    fn golden(name: &str) -> okane_golden::Golden {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../testdata/report/ui")
+            .join(format!("{name}.txt"));
+        okane_golden::Golden::new(path).unwrap()
+    }
+
+    /// The state a failed reload leaves behind: no rows, error modal up.
+    fn app_with_error_modal<'ctx>() -> App<'ctx> {
+        let mut app = App::new(
+            "test.ledger".to_owned(),
+            Vec::new(),
+            RegisterQueryTemplate {
+                conversion: None,
+                date_range: DateRange::default(),
+            },
+        );
+        let lines = (0..40).map(|i| format!("error line {i}")).collect();
+        app.overlay = Some(Overlay::Error(ErrorPopup::new(
+            " failed to load test.ledger ".to_owned(),
+            lines,
+        )));
+        app
+    }
+
+    #[test]
+    fn render_error_modal() {
+        let arena = Bump::new();
+        let ctx = ReportContext::new(&arena);
+        let mut app = app_with_error_modal();
+        golden("render_error_modal").assert(&render(&mut app, &ctx));
+    }
+
+    #[test]
+    fn render_error_modal_scrolled_to_bottom() {
+        let arena = Bump::new();
+        let ctx = ReportContext::new(&arena);
+        let mut app = app_with_error_modal();
+        // The first frame is what teaches the popup its viewport height.
+        render(&mut app, &ctx);
+        app.update(Message::OverlayScroll(ScrollDelta::Bottom));
+        golden("render_error_modal_scrolled_to_bottom").assert(&render(&mut app, &ctx));
     }
 }

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -1,6 +1,12 @@
 //! Contains the functions to load Ledger file,
 //! with recursively resolving the `include` directives.
 
+// Re-exported because it appears in the public [`Loader`] API (see
+// [`Loader::with_error_renderer`]); lets downstream crates name the type
+// without pinning their own (possibly mismatched) annotate-snippets
+// dependency.
+pub use annotate_snippets::Renderer;
+
 use std::{
     borrow::Cow,
     collections::HashMap,

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -189,6 +189,19 @@ pub struct EvalContext {
 }
 
 impl<'ctx> Ledger<'ctx> {
+    /// Returns a `Ledger` with no transactions at all. Useful as a
+    /// placeholder when processing failed but a `Ledger` instance is still
+    /// required (e.g. an error state in an interactive UI).
+    pub fn empty(ctx: &ReportContext<'ctx>) -> Self {
+        Self {
+            arena: ctx.arena,
+            transactions: Vec::new(),
+            date_sorted_txns: None,
+            raw_balance: Balance::default(),
+            price_repos: price_db::PriceRepositoryBuilder::default().build(),
+        }
+    }
+
     /// Returns iterator for all transactions.
     pub fn transactions(&self) -> impl Iterator<Item = &Transaction<'ctx>> {
         self.transactions.iter()

--- a/testdata/report/ui/render_error_modal.txt
+++ b/testdata/report/ui/render_error_modal.txt
@@ -1,0 +1,24 @@
+ okane ui — test.ledger                                                         
+┌──────────────────────────────────────────────────────────────────────────────┐
+│       ┌ failed to load test.ledger ──────────────────────────────────┐       │
+│       │error line 0                                                  │       │
+│       │error line 1                                                  │       │
+│       │error line 2                                                  │       │
+│       │error line 3                                                  │       │
+│       │error line 4                                                  │       │
+│       │error line 5                                                  │       │
+│       │error line 6                                                  │       │
+│       │error line 7                                                  │       │
+│       │error line 8                                                  │       │
+│       │error line 9                                                  │       │
+│       │error line 10                                                 │       │
+│       │error line 11                                                 │       │
+│       │error line 12                                                 │       │
+│       │error line 13                                                 │       │
+│       │error line 14                                                 │       │
+│       │error line 15                                                 │       │
+│       │ ↑/↓ scroll · PgUp/PgDn page · g/G top/end · r reload ·  1/40 │       │
+│       └──────────────────────────────────────────────────────────────┘       │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+ ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · / search · C-s is

--- a/testdata/report/ui/render_error_modal_scrolled_to_bottom.txt
+++ b/testdata/report/ui/render_error_modal_scrolled_to_bottom.txt
@@ -1,0 +1,24 @@
+ okane ui — test.ledger                                                         
+┌──────────────────────────────────────────────────────────────────────────────┐
+│       ┌ failed to load test.ledger ──────────────────────────────────┐       │
+│       │error line 24                                                 │       │
+│       │error line 25                                                 │       │
+│       │error line 26                                                 │       │
+│       │error line 27                                                 │       │
+│       │error line 28                                                 │       │
+│       │error line 29                                                 │       │
+│       │error line 30                                                 │       │
+│       │error line 31                                                 │       │
+│       │error line 32                                                 │       │
+│       │error line 33                                                 │       │
+│       │error line 34                                                 │       │
+│       │error line 35                                                 │       │
+│       │error line 36                                                 │       │
+│       │error line 37                                                 │       │
+│       │error line 38                                                 │       │
+│       │error line 39                                                 │       │
+│       │ ↑/↓ scroll · PgUp/PgDn page · g/G top/end · r reload · 25/40 │       │
+│       └──────────────────────────────────────────────────────────────┘       │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+ ↑/↓ scroll · PgUp/PgDn page · g/G home/end · Enter register · / search · C-s is


### PR DESCRIPTION
Adds reload (`r` / `F5`) to the balance/register TUI (`okane ui`).

## What

- `r` / `F5` re-reads the ledger source and rebuilds the view, carrying over the UI state: the balance selection (followed by account name, falling back to the closest row when the account disappeared), an open register screen with its cursor, and the active search plus the last-used pattern.
- A failed reload (e.g. a syntax error while the file is being edited) shows an empty view with a one-line error in the footer; `r` retries, and the pre-error UI state is still restored on the next successful reload.
- Startup is unchanged: an invalid file aborts with the styled error before the TUI ever starts.

## How

The second commit makes reload a *session boundary* instead of re-processing into the live `ReportContext`. The intern stores in `ReportContext` (accounts, commodities, aliases) are append-only, so reusing the context across reloads would keep stale aliases/accounts resolvable forever. Instead:

- `run_ui` owns a session loop: each iteration builds a fresh `ReportContext` + `Ledger` + `App` over the arena, and `Bump::reset()` runs between iterations once every `'ctx` borrow has died with the previous session.
- Only an owned `UiSnapshot` (account names, indices, search intent) crosses the boundary and is re-resolved against the rebuilt rows.
- `ReloadContext` holds the fully-owned session config: loaders (styled for startup errors, plain for in-TUI errors), `ProcessOptions`, an owned `--exchange` spec resolved anew per session, and the date range. The build logic previously duplicated between `UiCmd::run` and the reload path now lives in one `build_session`.
- `event::run` returns `RunOutcome::{Quit, Reload}`; the event loop no longer touches the loader at all.
- core: adds `Ledger::empty` as the placeholder for the failed-reload view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
