### PR TITLE
Fix CSV charge handling when no currency conversion is present

### DIFF
--- a/cli/src/import.rs
+++ b/cli/src/import.rs
@@ -340,7 +340,12 @@ mod tests {
         use single_entry::ReviewKind;
         let kinds: Vec<ReviewKind> = txns.iter().map(|t| t.review_kind()).collect();
         assert_eq!(
-            vec![ReviewKind::Pending, ReviewKind::Auto, ReviewKind::Unknown],
+            vec![
+                ReviewKind::Pending,
+                ReviewKind::Auto,
+                ReviewKind::Unknown,
+                ReviewKind::Unknown
+            ],
             kinds
         );
     }

--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -172,17 +172,6 @@ fn extract_transaction(
             commodity: commodity.clone().into_owned(),
         });
     }
-    if let Some(charge) = resolver.extract(FieldKey::Charge, r)? {
-        match str_to_comma_decimal(&charge)? {
-            Some(value) if !value.is_zero() => {
-                txn.add_charge(OwnedAmount {
-                    value,
-                    commodity: commodity.clone().into_owned(),
-                });
-            }
-            _ => (),
-        }
-    }
     let default_conversion =
         if rate.is_some() && secondary_amount.is_some() && secondary_commodity.is_some() {
             Some(default_conversion)
@@ -212,7 +201,7 @@ fn extract_transaction(
             )?;
         let (target, rate, computed_transferred) = match conv.rate.unwrap_or_default() {
             config::ConversionRateMode::PriceOfPrimary => (
-                commodity.into_owned(),
+                commodity.clone().into_owned(),
                 OwnedAmount {
                     commodity: secondary_commodity.to_owned(),
                     value: rate,
@@ -222,7 +211,7 @@ fn extract_transaction(
             config::ConversionRateMode::PriceOfSecondary => (
                 secondary_commodity.to_owned(),
                 OwnedAmount {
-                    commodity: commodity.into_owned(),
+                    commodity: commodity.clone().into_owned(),
                     value: rate,
                 },
                 amount / rate,
@@ -240,6 +229,27 @@ fn extract_transaction(
             value: transferred,
             commodity: secondary_commodity.to_owned(),
         });
+    }
+    if let Some(charge) = resolver.extract(FieldKey::Charge, r)?
+        && let Some(value) = str_to_comma_decimal(&charge)?
+        && !value.is_zero()
+    {
+        if txn.has_transferred_amount() {
+            txn.add_charge(OwnedAmount {
+                value,
+                commodity: commodity.into_owned(),
+            });
+        } else {
+            // If transferred_amount isn't set,
+            // Txn assumes dest_amount == -amount.
+            // This conflicts with having charge, because
+            // `dest_amount + charge` should be `-amount`.
+            // This is achievable via `try_add_charge_not_included`.
+            txn.try_add_charge_not_included(OwnedAmount {
+                value,
+                commodity: commodity.into_owned(),
+            })?;
+        }
     }
     Ok(Some(txn))
 }

--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -204,6 +204,11 @@ impl Txn {
         self
     }
 
+    /// Returns `true` if `transferred_amount` is set.
+    pub fn has_transferred_amount(&self) -> bool {
+        self.transferred_amount.is_some()
+    }
+
     /// Adds the commodity rate information.
     ///
     /// 1 target == rate.

--- a/testdata/import/index_amount.csv
+++ b/testdata/import/index_amount.csv
@@ -1,5 +1,6 @@
 header
-2021-9-1,-50.00,cashback
-2021-9-2,28.00,Debit Card 31415 Migros
-2021-9-3,1.45,Debit Card 14142 FooBar
+2021-9-1,-50.00,cashback,
+2021-9-2,28.00,Debit Card 31415 Migros,
+2021-9-3,1.45,Debit Card 14142 FooBar,
+2021-9-4,40.00,Debit Card 27182 CoffeeShop,1.50
 ,,,,

--- a/testdata/import/index_amount.ledger
+++ b/testdata/import/index_amount.ledger
@@ -10,3 +10,9 @@
     ! Expenses:Unknown                          1.45 USD
     Liabilities:Okane Card                     -1.45 USD
 
+2021/09/04 * (27182) CoffeeShop
+    ! Expenses:Unknown                         38.50 USD
+    Expenses:Commissions                        1.50 USD
+    ; Payee: Okane Card (fee)
+    Liabilities:Okane Card                    -40.00 USD
+

--- a/testdata/import/test_config.yml
+++ b/testdata/import/test_config.yml
@@ -16,6 +16,7 @@ path: index_amount.csv
 encoding: UTF-8
 account: "Liabilities:Okane Card"
 account_type: liability
+operator: Okane Card (fee)
 commodity: USD
 format:
   date: "%Y-%m-%d"
@@ -23,6 +24,7 @@ format:
     date: 1
     amount: 2
     payee: 3
+    charge: 4
 rewrite:
   - matcher:
       payee: Debit Card (?P<code>\d+) (?P<payee>.*)


### PR DESCRIPTION
## Summary
- Previously, the CSV `charge` field always called `Txn::add_charge`, which only balances correctly when `transferred_amount` was already set via a currency conversion. Without a conversion, this silently left the transaction unbalanced by the charge amount, relying on the `Equity:Adjustments` fallback instead of properly folding the charge into the destination amount.
- Add `Txn::has_transferred_amount()` and branch: use `add_charge` when a transferred amount already exists, otherwise `try_add_charge_not_included`, which recomputes the balancing dest amount so Main + Commission + Dest still sums to zero.
- Add a regression case to `testdata/import/index_amount.csv` (the one fixture with a single commodity and no conversion) exercising the new branch, and regenerate its golden output.

## Test plan
- [x] `cargo test -p okane` passes (245 unit + 7 golden import tests)
- [x] `cargo clippy -p okane --all-targets` clean
- [x] Golden regenerated with `UPDATE_GOLDEN=1 cargo test -p okane` and diff manually inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)