### PR TITLE
Make the charge/commission destination account configurable

### DIFF
--- a/cli/src/import.rs
+++ b/cli/src/import.rs
@@ -71,6 +71,7 @@ impl Importer {
         };
         let options = single_entry::Options {
             operator: config.operator.clone(),
+            charge_account: config.charge_account.clone(),
             commodity_rename: config.commodity.rename.clone(),
             commodity_format: display_context.commodity.clone(),
         };
@@ -275,6 +276,7 @@ mod tests {
             account: "Assets:Bank:Okane".to_string(),
             account_type: config::AccountType::Asset,
             operator: None,
+            charge_account: None,
             commodity: config::AccountCommoditySpec::default(),
             format: config::FormatSpec::default(),
             output: config::OutputSpec::default(),

--- a/cli/src/import/config.rs
+++ b/cli/src/import/config.rs
@@ -109,6 +109,9 @@ pub struct Config {
     /// Operator of the import target.
     /// Required only when some charges applied.
     pub operator: Option<String>,
+    /// Account charges (fees / commissions) are posted to.
+    /// Falls back to `Expenses:Commissions` when unset.
+    pub charge_account: Option<String>,
     /// Commodity handling about the account.
     pub commodity: commodity::AccountCommoditySpec,
     /// Format of the given input file.
@@ -143,6 +146,7 @@ impl TryFrom<ConfigFragment> for Config {
             account,
             account_type,
             operator: value.operator,
+            charge_account: value.charge_account,
             commodity,
             format,
             output,
@@ -159,6 +163,7 @@ impl From<Config> for ConfigFragment {
             account: Some(value.account),
             account_type: Some(value.account_type),
             operator: value.operator,
+            charge_account: value.charge_account,
             template: false,
             commodity: Some(value.commodity.into()),
             format: Some(value.format),
@@ -184,6 +189,9 @@ struct ConfigFragment {
     /// Operator of the import target.
     /// Required only when some charges applied.
     operator: Option<String>,
+    /// Account charges (fees / commissions) are posted to.
+    /// Falls back to `Expenses:Commissions` when unset.
+    charge_account: Option<String>,
     /// Set `true` to make this fragment "template".
     /// If the resolved config is all made up from template,
     /// It means no concrete config is matched and thus error.
@@ -208,6 +216,7 @@ impl Merge for ConfigFragment {
             account: other.account.or(self.account),
             account_type: other.account_type.or(self.account_type),
             operator: other.operator.or(self.operator),
+            charge_account: other.charge_account.or(self.charge_account),
             template: other.template && self.template,
             commodity: self.commodity,
             format: self.format,
@@ -300,6 +309,7 @@ mod tests {
             commodity: None,
             encoding: None,
             operator: None,
+            charge_account: None,
             template: false,
             format: None,
             output: None,
@@ -315,6 +325,7 @@ mod tests {
             path: path.to_owned(),
             account_type: Some(AccountType::Asset),
             operator: None,
+            charge_account: None,
             template: false,
             commodity: Some(AccountCommodityConfig::PrimaryCommodity("JPY".to_owned())),
             format: Some(format::FormatSpec {
@@ -457,6 +468,7 @@ mod tests {
             account: "Assets:Banks:Checking".to_string(),
             account_type: AccountType::Asset,
             operator: None,
+            charge_account: None,
             commodity: simple_commodity_spec("CHF".to_string()),
             format: format::FormatSpec {
                 date: "%Y/%m/%d".to_string(),
@@ -541,11 +553,16 @@ mod tests {
             operator: Some("foo operator".to_string()),
             ..create_empty_config_fragment("fragment/".to_string())
         };
+        let charge_account = || ConfigFragment {
+            charge_account: Some("Assets:Points".to_string()),
+            ..create_empty_config_fragment("fragment/".to_string())
+        };
         let cases: Vec<Box<dyn Fn() -> ConfigFragment>> = vec![
             Box::new(account),
             Box::new(account_type),
             Box::new(commodity),
             Box::new(operator),
+            Box::new(charge_account),
         ];
         for case in cases {
             assert_eq!(

--- a/cli/src/import/csv.rs
+++ b/cli/src/import/csv.rs
@@ -261,6 +261,7 @@ mod tests {
             account: "Assets:Bank".to_string(),
             account_type: config::AccountType::Asset,
             operator: None,
+            charge_account: None,
             commodity: config::AccountCommoditySpec::default(),
             format: config::FormatSpec::default(),
             output: config::OutputSpec::default(),

--- a/cli/src/import/single_entry.rs
+++ b/cli/src/import/single_entry.rs
@@ -74,6 +74,10 @@ pub struct Options {
     /// Operator of the account. Mandatory when charges are needed.
     pub operator: Option<String>,
 
+    /// Account charges (fees / commissions) are posted to.
+    /// Falls back to [`DEFAULT_CHARGE_ACCOUNT`] when unset.
+    pub charge_account: Option<String>,
+
     /// Renames the commodity in the key into the corresponding value.
     pub commodity_rename: HashMap<String, String>,
 
@@ -108,11 +112,18 @@ impl Options {
             commodity: amount.commodity,
         }
     }
+
+    /// Returns the account charges (fees / commissions) are posted to.
+    fn charge_account(&self) -> &str {
+        self.charge_account
+            .as_deref()
+            .unwrap_or(DEFAULT_CHARGE_ACCOUNT)
+    }
 }
 
-// TODO: Allow injecting these values from config.
-// https://github.com/xkikeg/okane/issues/287
-const LABEL_COMMISSIONS: &str = "Expenses:Commissions";
+/// Default account charges (fees / commissions) are posted to,
+/// unless [`Options::charge_account`] overrides it.
+pub(super) const DEFAULT_CHARGE_ACCOUNT: &str = "Expenses:Commissions";
 pub(super) const LABEL_ADJUSTMENTS: &str = "Equity:Adjustments";
 const LABEL_UNKNOWN_INCOME: &str = "Income:Unknown";
 const LABEL_UNKNOWN_EXPENSE: &str = "Expenses:Unknown";
@@ -366,7 +377,7 @@ impl Txn {
                         key: Cow::Borrowed("Payee"),
                         value: syntax::MetadataValue::Text(operator()?),
                     }],
-                    ..syntax::Posting::new_untracked(LABEL_COMMISSIONS)
+                    ..syntax::Posting::new_untracked(opts.charge_account())
                 },
                 PostingType::Adjustment => syntax::Posting {
                     clear_state: syntax::ClearState::Pending,
@@ -940,6 +951,7 @@ mod tests {
             let mut ctx = ReportContext::new(&arena);
             let opts = Options {
                 operator: None,
+                charge_account: None,
                 commodity_format: ConfigResolver::default(),
                 commodity_rename: HashMap::new(),
             };
@@ -974,6 +986,7 @@ mod tests {
             let mut ctx = ReportContext::new(&arena);
             let opts = Options {
                 operator: Some("Okane bank".to_string()),
+                charge_account: None,
                 commodity_format: ConfigResolver::default(),
                 commodity_rename: HashMap::new(),
             };
@@ -994,6 +1007,46 @@ mod tests {
                 got_err.error_kind(),
                 "error={got_err:?}"
             );
+        }
+
+        #[test]
+        fn commission_uses_charge_account_override() {
+            let arena = Bump::new();
+            let mut ctx = ReportContext::new(&arena);
+            let opts = Options {
+                operator: Some("Okane bank".to_string()),
+                charge_account: Some("Assets:Points".to_string()),
+                commodity_format: ConfigResolver::default(),
+                commodity_rename: HashMap::new(),
+            };
+            let mut txn = Txn::new(
+                NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
+                "foo",
+                owned_amount(dec!(-1000), "JPY"),
+            );
+            txn.dest_account("Expenses:Grocery")
+                .add_charge(owned_amount(dec!(100), "JPY"))
+                .transferred_amount(owned_amount(dec!(900), "JPY"));
+
+            let got = txn
+                .to_double_entry("Assets:Bank", &opts, &mut ctx)
+                .expect("to_double_entry must succeed");
+
+            let commission = got
+                .posts
+                .iter()
+                .find(|p| p.account == "Assets:Points")
+                .expect("a posting to the overridden charge_account must exist");
+            let amount = match &commission
+                .amount
+                .as_ref()
+                .expect("commission posting must have an amount")
+                .amount
+            {
+                syntax::expr::ValueExpr::Amount(amount) => amount,
+                other => panic!("unexpected value expr: {other:?}"),
+            };
+            assert_eq!(dec!(100), amount.value.value);
         }
     }
 
@@ -1031,6 +1084,7 @@ mod tests {
 
             let options = Options {
                 operator: None,
+                charge_account: None,
                 commodity_rename: hashmap! {
                     "米ドル".to_string() => "USD".to_string(),
                     "日本円".to_string() => "JPY".to_string(),

--- a/testdata/import/csv_template.ledger
+++ b/testdata/import/csv_template.ledger
@@ -1,7 +1,7 @@
 2025/08/05 * Sell - NINTENDO LTD FSPONSORED ADR 1 ADR REP 0.25 ORD SHS
     ; NINTENDO LTD FSPONSORED ADR 1 ADR REP 0.25 ORD SHS
     Assets:Brokers:Schrank                   1127.29 USD
-    Expenses:Commissions                        6.96 USD
+    Expenses:Broker Fees                        6.96 USD
     ; Payee: Broker Schrank
     ! Income:Unknown                          -50.00 NTDOY @ 22.685 USD
 

--- a/testdata/import/test_config.yml
+++ b/testdata/import/test_config.yml
@@ -178,6 +178,7 @@ account_type: asset
 commodity:
   primary: USD
 operator: Broker Schrank
+charge_account: "Expenses:Broker Fees"
 format:
   date: "%m/%d/%Y"
   fields:


### PR DESCRIPTION
## Summary
- Closes #287. Charges and hidden-fee spreads always posted to a hardcoded `Expenses:Commissions` account. Add a `charge_account` config field (at `Config`/`ConfigFragment` level, alongside `operator`) so it can be redirected to a different account (e.g. an asset account for cashback/point rewards), falling back to the renamed `DEFAULT_CHARGE_ACCOUNT` constant when unset.
- Add unit test coverage in `config.rs` (merge behavior) and `single_entry.rs` (Commission posting targets the override), plus an end-to-end golden case redirecting `csv_template.csv`'s commission postings to `Expenses:Broker Fees`.

## Test plan
- [x] `cargo test -p okane` passes (246 unit + 7 golden import tests)
- [x] `cargo clippy -p okane --all-targets` clean
- [x] Golden regenerated with `UPDATE_GOLDEN=1 cargo test -p okane`; diff limited to the intended `Expenses:Commissions` → `Expenses:Broker Fees` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)