### PR TITLE
cli: enable colors for the reload error modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* CLI: `ui` reload errors are now shown in color instead of plain text (https://github.com/xkikeg/okane/issues/489).
+
 ### Fixed
 
 ## [0.20.0] - 2026-06-24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1753,7 @@ dependencies = [
 name = "okane"
 version = "0.20.0"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "assert_cmd",
  "assert_matches",
@@ -2944,7 +2967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ name = "okane"
 okane-core = { version = "0.20.0", path = "../core" }
 
 # anstream = "0.6"
+ansi-to-tui = "8.0.1"
 anyhow.workspace = true
 bumpalo.workspace = true
 chrono.workspace = true

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -426,15 +426,14 @@ impl UiCmd {
         // All report data is built inside `run_ui`: its session loop resets
         // the arena on reload (`r` / `F5`), which requires that nothing out
         // here borrows it.
-        let reload = ui::report::ReloadContext::new(
-            load::new_loader(self.source.clone()),
+        let config = ui::report::SessionConfig::new(
             load::new_loader(self.source.clone()),
             self.eval_options.to_process_options(),
             self.eval_options.to_conversion_spec(),
             self.eval_options.to_date_range()?,
         );
         let mut arena = Bump::new();
-        ui::report::run_ui(&mut arena, self.source.display().to_string(), &reload)
+        ui::report::run_ui(&mut arena, self.source.display().to_string(), &config)
             .context("failed to run TUI")
     }
 }

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -29,19 +29,16 @@ use ratatui::DefaultTerminal;
 
 use app::{ErrorPopup, Overlay, UiSnapshot};
 
-/// Everything needed to build (and rebuild) a session: the loaders re-read
+/// Everything needed to build (and rebuild) a session: the loader re-reads
 /// the source from disk on every `load` call, and the options carry the CLI
 /// configuration. Fully owned — no arena references — so it survives the
 /// arena resets between sessions.
-pub struct ReloadContext<F: load::FileSystem> {
-    /// Loader for the very first build. Keeps its (styled) renderer: a
-    /// startup error aborts before the terminal is set up and prints to the
-    /// normal terminal.
-    initial_loader: load::Loader<F>,
-    /// Loader for reload builds. The error renderer is forced to plain
-    /// because the rendered message is shown inside the TUI, where ANSI
-    /// escape sequences would garble the error modal.
-    reload_loader: load::Loader<F>,
+pub struct SessionConfig<F: load::FileSystem> {
+    /// Loader shared by the first build and every reload. Errors from the
+    /// first build print to the normal terminal (before it's set up);
+    /// errors from a reload are shown in the TUI's error modal, which
+    /// renders the (styled) ANSI output via `ansi-to-tui`.
+    loader: load::Loader<F>,
     process_options: ProcessOptions,
     /// `--exchange` conversion as owned data, re-resolved against each
     /// session's fresh [`ReportContext`].
@@ -49,18 +46,16 @@ pub struct ReloadContext<F: load::FileSystem> {
     date_range: DateRange,
 }
 
-impl<F: load::FileSystem> ReloadContext<F> {
-    /// Wraps two loaders for the same source plus the query configuration.
+impl<F: load::FileSystem> SessionConfig<F> {
+    /// Wraps a loader for the source plus the query configuration.
     pub fn new(
-        initial_loader: load::Loader<F>,
-        reload_loader: load::Loader<F>,
+        loader: load::Loader<F>,
         process_options: ProcessOptions,
         conversion: Option<ConversionSpec>,
         date_range: DateRange,
     ) -> Self {
         Self {
-            initial_loader,
-            reload_loader: reload_loader.with_error_renderer(load::Renderer::plain()),
+            loader,
             process_options,
             conversion,
             date_range,
@@ -101,10 +96,10 @@ impl ConversionSpec {
 pub fn run_ui<F: load::FileSystem>(
     arena: &mut Bump,
     source_display: String,
-    reload: &ReloadContext<F>,
+    config: &SessionConfig<F>,
 ) -> anyhow::Result<()> {
     let mut terminal = None;
-    let result = session_loop(arena, &source_display, reload, &mut terminal);
+    let result = session_loop(arena, &source_display, config, &mut terminal);
     if terminal.is_some() {
         ratatui::restore();
     }
@@ -114,7 +109,7 @@ pub fn run_ui<F: load::FileSystem>(
 fn session_loop<F: load::FileSystem>(
     arena: &mut Bump,
     source_display: &str,
-    reload: &ReloadContext<F>,
+    config: &SessionConfig<F>,
     terminal: &mut Option<DefaultTerminal>,
 ) -> anyhow::Result<()> {
     let mut snapshot: Option<UiSnapshot> = None;
@@ -124,12 +119,7 @@ fn session_loop<F: load::FileSystem>(
             arena.reset();
         }
         let mut ctx = ReportContext::new(arena);
-        let loader = if first {
-            &reload.initial_loader
-        } else {
-            &reload.reload_loader
-        };
-        let built = build_session(&mut ctx, loader, reload, source_display, snapshot.as_ref());
+        let built = build_session(&mut ctx, config, source_display, snapshot.as_ref());
         let (mut ledger, mut app, has_data) = match built {
             Ok(SessionData { ledger, app }) => (ledger, app, true),
             // A startup failure aborts before the terminal is set up.
@@ -140,7 +130,7 @@ fn session_loop<F: load::FileSystem>(
             Err(err) => {
                 let template = RegisterQueryTemplate {
                     conversion: None,
-                    date_range: reload.date_range,
+                    date_range: config.date_range,
                 };
                 let mut app = App::new(source_display.to_owned(), Vec::new(), template);
                 app.overlay = Some(error_overlay(source_display, err.as_ref()));
@@ -171,13 +161,12 @@ struct SessionData<'ctx> {
 /// restoring the UI state from `snapshot` when given.
 fn build_session<'ctx, F: load::FileSystem>(
     ctx: &mut ReportContext<'ctx>,
-    loader: &load::Loader<F>,
-    reload: &ReloadContext<F>,
+    config: &SessionConfig<F>,
     source_display: &str,
     snapshot: Option<&UiSnapshot>,
 ) -> anyhow::Result<SessionData<'ctx>> {
-    let mut ledger = report::process(ctx, loader, &reload.process_options)?;
-    let conversion = reload
+    let mut ledger = report::process(ctx, &config.loader, &config.process_options)?;
+    let conversion = config
         .conversion
         .as_ref()
         .map(|spec| spec.resolve(ctx))
@@ -185,7 +174,7 @@ fn build_session<'ctx, F: load::FileSystem>(
     let query = BalanceQuery {
         account: AccountFilter::All,
         conversion,
-        date_range: reload.date_range,
+        date_range: config.date_range,
     };
     let balance = ledger.balance(ctx, &query)?.into_owned();
     let rows: Vec<BalanceRow<'ctx>> = balance
@@ -195,7 +184,7 @@ fn build_session<'ctx, F: load::FileSystem>(
         .collect();
     let template = RegisterQueryTemplate {
         conversion,
-        date_range: reload.date_range,
+        date_range: config.date_range,
     };
     let mut app = App::new(source_display.to_owned(), rows, template);
     if let Some(snapshot) = snapshot
@@ -307,9 +296,8 @@ mod tests {
         )
     }
 
-    fn reload_ctx(content: &str) -> ReloadContext<FakeFileSystem> {
-        ReloadContext::new(
-            fake_loader(content),
+    fn session_config(content: &str) -> SessionConfig<FakeFileSystem> {
+        SessionConfig::new(
             fake_loader(content),
             ProcessOptions::default(),
             None,
@@ -323,8 +311,8 @@ mod tests {
         content: &str,
         snapshot: Option<&UiSnapshot>,
     ) -> anyhow::Result<SessionData<'ctx>> {
-        let reload = reload_ctx(content);
-        build_session(ctx, &reload.reload_loader, &reload, "test", snapshot)
+        let config = session_config(content);
+        build_session(ctx, &config, "test", snapshot)
     }
 
     fn account_names(app: &App<'_>) -> Vec<String> {

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -7,6 +7,7 @@
 
 use std::cmp::{max, min};
 
+use ansi_to_tui::IntoText;
 use okane_core::report::{Amount, ReportContext};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
@@ -313,11 +314,8 @@ fn draw_error_popup(frame: &mut Frame, area: Rect, popup: &mut ErrorPopup) {
     popup.viewport_height = layout[0].height;
     popup.clamp();
 
-    let body: Vec<Line> = popup
-        .lines
-        .iter()
-        .map(|line| Line::from(line.as_str()))
-        .collect();
+    let joined = popup.lines.join("\n");
+    let body = joined.into_text().unwrap_or_else(|_| Text::from(joined));
     frame.render_widget(
         Paragraph::new(body)
             .style(
@@ -598,5 +596,53 @@ mod tests {
         render(&mut app, &ctx);
         app.update(Message::OverlayScroll(ScrollDelta::Bottom));
         golden("render_error_modal_scrolled_to_bottom").assert(&render(&mut app, &ctx));
+    }
+
+    /// The point of #489: ANSI SGR codes in the error text (as produced by
+    /// annotate-snippets' styled renderer) are parsed into real cell colors
+    /// instead of showing up as literal escape bytes.
+    #[test]
+    fn render_error_modal_parses_ansi_colors() {
+        let arena = Bump::new();
+        let ctx = ReportContext::new(&arena);
+        let mut app = App::new(
+            "test.ledger".to_owned(),
+            Vec::new(),
+            RegisterQueryTemplate {
+                conversion: None,
+                date_range: DateRange::default(),
+            },
+        );
+        app.overlay = Some(Overlay::Error(ErrorPopup::new(
+            " failed to load test.ledger ".to_owned(),
+            vec!["\u{1b}[32mgreen\u{1b}[0m plain".to_owned()],
+        )));
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, &mut app, &ctx)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+
+        let mut found_green = false;
+        let mut found_escape_byte = false;
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                let cell = &buf[Position { x, y }];
+                if cell.symbol() == "g" && cell.fg == Color::Green {
+                    found_green = true;
+                }
+                if cell.symbol().contains('\u{1b}') {
+                    found_escape_byte = true;
+                }
+            }
+        }
+        assert!(
+            found_green,
+            "expected a cell styled green from the parsed ANSI escape"
+        );
+        assert!(
+            !found_escape_byte,
+            "escape bytes should be consumed by the parser, not rendered as glyphs"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Merge `ReloadContext`'s two `Loader`s (`initial_loader` / `reload_loader`) into a single styled `loader`. The `reload_loader` no longer needs to be downgraded to `Renderer::plain()`.
- `draw_error_popup` now parses the styled `annotate-snippets` ANSI output through `ansi-to-tui`'s `IntoText` into a real `ratatui::text::Text`, instead of rendering escape bytes as literal text.
- Rename `ReloadContext` to `SessionConfig`, since it's the general config `run_ui` needs, not something reload-specific.

Closes #489.

## Test plan

- [x] `cargo build -p okane`
- [x] `cargo test --workspace` (all passing, including a new regression test `render_error_modal_parses_ansi_colors` that asserts ANSI-coded text renders with real cell colors and no literal escape bytes)
- [x] `cargo clippy -p okane --all-targets`
- [x] Manually confirmed the startup-failure path (before the TUI takes over the terminal) still prints colored `annotate-snippets` output to the real terminal, unaffected by the loader merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)