### PR TITLE
cli: virtualize the register table for large datasets

### DIFF
--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -76,6 +76,11 @@ pub struct RegisterView<'ctx> {
     pub account: Account<'ctx>,
     pub rows: Vec<RegisterRow<'ctx>>,
     pub nav: TableNav,
+    /// Cached `(amount, total)` column widths. The amounts are fixed for the
+    /// life of the view, so the renderer computes these once (scanning all
+    /// rows) on first draw and reuses them, keeping per-frame work
+    /// proportional to the viewport rather than the row count.
+    pub col_widths: Option<(u16, u16)>,
 }
 
 impl<'ctx> RegisterView<'ctx> {
@@ -83,7 +88,12 @@ impl<'ctx> RegisterView<'ctx> {
         let mut nav = TableNav::new(rows.len());
         // Most recent entry is the most useful starting point.
         nav.select_last();
-        Self { account, rows, nav }
+        Self {
+            account,
+            rows,
+            nav,
+            col_widths: None,
+        }
     }
 }
 
@@ -1498,6 +1508,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         app.update(Message::LeaveRegister);
         assert!(matches!(app.screen, Screen::Balance));
@@ -1649,6 +1660,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav,
+            col_widths: None,
         });
         let snapshot = app.snapshot();
 
@@ -1670,6 +1682,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         let snapshot = app.snapshot();
 
@@ -1716,6 +1729,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         assert!(app.update(Message::RequestQuit).is_none());
         // From register, q/Esc leaves to balance (mapped at the event layer)

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -323,6 +323,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         assert_eq!(
             key_to_message(&app, key(KeyCode::Char('q'))),
@@ -343,6 +344,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         assert_eq!(key_to_message(&app, key(KeyCode::Enter)), None);
     }
@@ -366,6 +368,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         assert_eq!(
             key_to_message(&app, ctrl_key('c')),
@@ -659,6 +662,7 @@ mod tests {
             account,
             rows: Vec::new(),
             nav: TableNav::new(0),
+            col_widths: None,
         });
         assert_eq!(
             key_to_message(&app, key(KeyCode::Char('r'))),

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -13,7 +13,7 @@ use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
 use unicode_width::UnicodeWidthStr;
 
 use super::app::{
@@ -120,7 +120,7 @@ fn draw_balance_body<'ctx>(
     let amount_width = compute_amount_width(&formatted);
     let table_rows: Vec<Row> = rows
         .iter()
-        .zip(formatted.iter())
+        .zip(&formatted)
         .enumerate()
         .map(|(i, (row, lines))| {
             make_balance_row(row, lines, matches.is_some_and(|m| m.contains_row(i)))
@@ -164,21 +164,46 @@ fn draw_register_body<'ctx>(
     ])
     .style(Style::default().add_modifier(Modifier::BOLD));
 
-    let amount_lines: Vec<Vec<String>> = view
-        .rows
+    // The amount/total column widths are fixed for the life of the view, so
+    // compute them once (scanning all rows) and cache them. Everything else
+    // below only touches the visible window, keeping per-frame work
+    // proportional to the viewport rather than the (potentially large) row
+    // count of the register.
+    let (amount_width, total_width) = match view.col_widths {
+        Some(t) => t,
+        None => {
+            let amount_width = compute_amount_width(
+                view.rows
+                    .iter()
+                    .map(|row| format_amount_lines(&row.amount, ctx)),
+            );
+            let total_width = compute_amount_width(
+                view.rows
+                    .iter()
+                    .map(|row| format_amount_lines(&row.total, ctx)),
+            );
+            view.col_widths = Some((amount_width, total_width));
+            (amount_width, total_width)
+        }
+    };
+
+    // Virtualize: build widget rows only for the slice that is actually
+    // visible. The absolute selection stays in `nav.table_state`; the local
+    // `TableState` below carries the viewport-relative position for rendering.
+    let (offset, end) = view.nav.visible_window(|i| view.rows[i].line_count());
+
+    let visible = &view.rows[offset..end];
+    // these are collected as the following register row is borrowing this String.
+    let amount_lines: Vec<Vec<String>> = visible
         .iter()
         .map(|row| format_amount_lines(&row.amount, ctx))
         .collect();
-    let total_lines: Vec<Vec<String>> = view
-        .rows
+    let total_lines: Vec<Vec<String>> = visible
         .iter()
         .map(|row| format_amount_lines(&row.total, ctx))
         .collect();
-    let amount_width = compute_amount_width(&amount_lines);
-    let total_width = compute_amount_width(&total_lines);
 
-    let table_rows: Vec<Row> = view
-        .rows
+    let table_rows: Vec<Row> = visible
         .iter()
         .zip(amount_lines.iter())
         .zip(total_lines.iter())
@@ -198,7 +223,10 @@ fn draw_register_body<'ctx>(
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .block(block);
 
-    frame.render_stateful_widget(table, area, &mut view.nav.table_state);
+    let mut state = TableState::default()
+        .with_offset(0)
+        .with_selected(Some(view.nav.selected_index() - offset));
+    frame.render_stateful_widget(table, area, &mut state);
 }
 
 fn draw_footer(frame: &mut Frame, area: Rect, hint: &str) {
@@ -410,12 +438,21 @@ fn amount_text<'a>(lines: &'a [String]) -> Text<'a> {
     Text::from(lines)
 }
 
-/// Returns the display width (in columns) needed for an amount column.
-fn compute_amount_width(formatted: &[Vec<String>]) -> u16 {
+/// Returns the display width (in columns) needed for an amount column, given
+/// the per-row formatted lines. Accepts anything iterable-of-iterable-of-str,
+/// so callers can pass either a materialized `&[Vec<String>]` (the balance
+/// screen, which needs the lines again to build rows) or a lazy iterator of
+/// `Vec<String>` (the register, which only needs the width).
+fn compute_amount_width<Rows, Lines, S>(formatted: Rows) -> u16
+where
+    Rows: IntoIterator<Item = Lines>,
+    Lines: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
     let max = formatted
-        .iter()
-        .flat_map(|lines| lines.iter())
-        .map(|s| display_width(s))
+        .into_iter()
+        .flatten()
+        .map(|s| display_width(s.as_ref()))
         .max()
         .unwrap_or(0);
     // Add a 1-column right padding so the value never abuts the border.
@@ -558,7 +595,7 @@ mod tests {
                 // (non-CJK) width — the one ratatui used to lay the glyph out —
                 // so East-Asian *ambiguous* cells (│, ─, ·, ↑) that occupy a
                 // single cell are not mistaken for wide glyphs.
-                x += max(UnicodeWidthStr::width(sym) as u16,1);
+                x += max(UnicodeWidthStr::width(sym) as u16, 1);
             }
             s.push('\n');
         }
@@ -656,7 +693,6 @@ mod tests {
             "escape bytes should be consumed by the parser, not rendered as glyphs"
         );
     }
-
     fn template<'ctx>() -> RegisterQueryTemplate<'ctx> {
         RegisterQueryTemplate {
             conversion: None,
@@ -767,5 +803,94 @@ mod tests {
         let arena = Bump::new();
         let (ctx, mut app) = register_app(&arena, &input);
         golden(&golden_name(&input, "register")).assert(&render(&mut app, &ctx));
+    }
+
+    /// Renders `app` into a `width`×`height` headless terminal, plain text.
+    fn render_sized<'ctx>(
+        app: &mut App<'ctx>,
+        ctx: &ReportContext<'ctx>,
+        width: u16,
+        height: u16,
+    ) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, app, ctx)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[Position { x, y }].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    /// A register view backed by `n` real entries against one account, plus the
+    /// context that keeps its arena references alive.
+    fn register_app_with_rows<'ctx>(
+        arena: &'ctx Bump,
+        n: usize,
+    ) -> (ReportContext<'ctx>, App<'ctx>) {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        use okane_core::report::query::DateRange;
+        use okane_core::{load, report};
+
+        // Same date for every entry (distinct payees are what we assert on), so
+        // we don't have to worry about month/day arithmetic.
+        let mut content = String::new();
+        for i in 0..n {
+            content.push_str(&format!(
+                "2024/01/01 Payee{i:02}\n    Assets:Cash    1 USD\n    Equity\n\n"
+            ));
+        }
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("test.ledger"), content.into_bytes());
+        let loader = load::Loader::new(
+            PathBuf::from("test.ledger"),
+            load::FakeFileSystem::from(map),
+        );
+        let mut ctx = ReportContext::new(arena);
+        let mut ledger =
+            report::process(&mut ctx, loader, &report::ProcessOptions::default()).unwrap();
+        let account = ctx.account("Assets:Cash").unwrap();
+        let template = RegisterQueryTemplate {
+            conversion: None,
+            date_range: DateRange::default(),
+        };
+        let rows =
+            super::super::event::load_register(&mut ledger, &ctx, &template, account).unwrap();
+        assert_eq!(rows.len(), n);
+        let mut app = App::new("test.ledger".to_owned(), Vec::new(), template);
+        app.show_register(account, rows);
+        (ctx, app)
+    }
+
+    /// A register far longer than the viewport renders only a window: it opens
+    /// on the last entry (bottom pinned) and scrolls to the top on `g`, showing
+    /// entries at the far end but not the other.
+    #[test]
+    fn register_renders_only_the_visible_window() {
+        let arena = Bump::new();
+        let (ctx, mut app) = register_app_with_rows(&arena, 50);
+
+        // Opens pinned to the last entry.
+        let bottom = render_sized(&mut app, &ctx, 80, 10);
+        assert!(bottom.contains("Payee49"), "last entry should be visible");
+        assert!(
+            !bottom.contains("Payee00"),
+            "first entry should be scrolled off:\n{bottom}"
+        );
+
+        // Jump to the top: now the first entries show and the last are gone.
+        app.update(Message::SelectFirst);
+        let top = render_sized(&mut app, &ctx, 80, 10);
+        assert!(top.contains("Payee00"), "first entry should be visible");
+        assert!(
+            !top.contains("Payee49"),
+            "last entry should be scrolled off:\n{top}"
+        );
     }
 }

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -13,6 +13,10 @@ pub struct TableNav {
     /// Last known viewport height for the table body. Updated each frame and
     /// used to size page-up/page-down jumps.
     pub viewport_height: u16,
+    /// Index of the first visible row, maintained by the register renderer's
+    /// virtualization ([`visible_window`]). The balance table leaves this at 0
+    /// and relies on ratatui's built-in scrolling instead.
+    pub offset: usize,
 }
 
 impl TableNav {
@@ -25,11 +29,17 @@ impl TableNav {
             table_state,
             row_count,
             viewport_height: 0,
+            offset: 0,
         }
     }
 
     pub fn is_empty(&self) -> bool {
         self.row_count == 0
+    }
+
+    /// Current selection index, defaulting to 0 when nothing is selected.
+    pub fn selected_index(&self) -> usize {
+        self.table_state.selected().unwrap_or(0)
     }
 
     fn last_index(&self) -> Option<usize> {
@@ -69,5 +79,175 @@ impl TableNav {
         if index < self.row_count {
             self.table_state.select(Some(index));
         }
+    }
+
+    /// Recomputes the virtualized window from the current selection, stores the
+    /// new [`offset`](Self::offset), and returns the visible `[offset, end)`.
+    /// `height_of(i)` gives row `i`'s rendered line count (always `>= 1`).
+    ///
+    /// Thin wrapper over [`visible_window`]: the window math lives there, tested
+    /// in isolation; this just feeds it the nav's own fields and writes the
+    /// offset back so the caller can't compute it and forget to store it.
+    pub fn visible_window(&mut self, height_of: impl Fn(usize) -> u16) -> (usize, usize) {
+        let selected = self.selected_index();
+        let (offset, end) = visible_window(
+            selected,
+            self.offset,
+            self.viewport_height,
+            self.row_count,
+            height_of,
+        );
+        self.offset = offset;
+        (offset, end)
+    }
+}
+
+/// Computes the visible row window `[offset, end)` for a variable-height table,
+/// scrolling the minimum amount needed to keep `selected` in view.
+///
+/// This is the virtualization primitive for the register table: rather than
+/// building a widget row for every entry (O(n) per frame), the renderer builds
+/// rows only for `[offset, end)`. `height_of(i)` returns the rendered line
+/// count of row `i` (always `>= 1`); `viewport_height` is the number of body
+/// lines available.
+///
+/// Guarantees `offset <= selected < end <= row_count` whenever `row_count > 0`
+/// and `selected < row_count`. Both scans touch at most a viewport's worth of
+/// rows, so it stays O(viewport) even when `selected` jumps to either end.
+///
+/// [`TableNav::visible_window`] is the ergonomic entry point; this free function
+/// is the pure primitive the unit tests drive directly.
+fn visible_window(
+    selected: usize,
+    prev_offset: usize,
+    viewport_height: u16,
+    row_count: usize,
+    height_of: impl Fn(usize) -> u16,
+) -> (usize, usize) {
+    if row_count == 0 {
+        return (0, 0);
+    }
+    let budget = u32::from(viewport_height);
+    // The window never starts below the selection; a selection above the
+    // previous offset pulls the window up to it (selection at the top).
+    let offset = prev_offset.min(selected);
+    let end = fill_from(offset, budget, row_count, &height_of);
+    if selected < end {
+        return (offset, end);
+    }
+    // Selection sits below the window: pin it to the bottom by walking up from
+    // it, accumulating heights until the viewport is full.
+    let mut offset = selected;
+    let mut used = u32::from(height_of(selected));
+    while offset > 0 {
+        let h = u32::from(height_of(offset - 1));
+        if used + h > budget {
+            break;
+        }
+        used += h;
+        offset -= 1;
+    }
+    (offset, selected + 1)
+}
+
+/// Largest `end` such that rows `[start, end)` fit within `budget` lines,
+/// always including at least the `start` row (even if it alone overflows).
+fn fill_from(
+    start: usize,
+    budget: u32,
+    row_count: usize,
+    height_of: &impl Fn(usize) -> u16,
+) -> usize {
+    let mut end = start;
+    let mut used = 0u32;
+    while end < row_count {
+        let h = u32::from(height_of(end));
+        if end > start && used + h > budget {
+            break;
+        }
+        used += h;
+        end += 1;
+    }
+    end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All rows one line tall — the common register case.
+    fn uniform(_i: usize) -> u16 {
+        1
+    }
+
+    #[test]
+    fn empty_table_has_empty_window() {
+        assert_eq!(visible_window(0, 0, 10, 0, uniform), (0, 0));
+    }
+
+    #[test]
+    fn everything_fits_shows_all() {
+        // 5 rows, viewport of 10: whole table visible, offset stays 0.
+        assert_eq!(visible_window(4, 0, 10, 5, uniform), (0, 5));
+        assert_eq!(visible_window(0, 0, 10, 5, uniform), (0, 5));
+    }
+
+    #[test]
+    fn selection_above_offset_scrolls_up_to_top() {
+        // Window was scrolled down to offset 20; selecting row 5 pulls it up so
+        // row 5 sits at the top.
+        assert_eq!(visible_window(5, 20, 10, 100, uniform), (5, 15));
+    }
+
+    #[test]
+    fn selection_within_window_keeps_offset() {
+        // offset 10, viewport 10 → rows [10, 20); selecting 15 changes nothing.
+        assert_eq!(visible_window(15, 10, 10, 100, uniform), (10, 20));
+    }
+
+    #[test]
+    fn selection_below_window_pins_to_bottom() {
+        // offset 10, viewport 10 → rows [10, 20); selecting 25 scrolls down so
+        // 25 is the last visible row.
+        assert_eq!(visible_window(25, 10, 10, 100, uniform), (16, 26));
+    }
+
+    #[test]
+    fn jump_to_last_row_shows_final_page() {
+        // g→G style jump from the top: last row pinned to the bottom.
+        assert_eq!(visible_window(99, 0, 10, 100, uniform), (90, 100));
+    }
+
+    #[test]
+    fn jump_to_first_row_shows_first_page() {
+        assert_eq!(visible_window(0, 90, 10, 100, uniform), (0, 10));
+    }
+
+    #[test]
+    fn variable_heights_respect_line_budget() {
+        // Rows alternate 1 and 2 lines tall. Viewport of 5 lines from offset 0:
+        // row0(1)+row1(2)+row2(1) = 4, +row3(2)=6 > 5 → stop → rows [0, 3).
+        let heights = |i: usize| if i.is_multiple_of(2) { 1 } else { 2 };
+        assert_eq!(visible_window(0, 0, 5, 10, heights), (0, 3));
+    }
+
+    #[test]
+    fn variable_heights_pin_bottom_accounts_for_tall_rows() {
+        // Same alternating heights, viewport 5. Select row 5 (2 lines tall):
+        // walk up 5(2),4(1),3(2)=5 fits, 2(1)=6>5 stop → offset 3, end 6.
+        let heights = |i: usize| if i.is_multiple_of(2) { 1 } else { 2 };
+        assert_eq!(visible_window(5, 0, 5, 10, heights), (3, 6));
+    }
+
+    #[test]
+    fn row_taller_than_viewport_still_shows_selection() {
+        // A single 4-line row in a 2-line viewport: show it alone.
+        let heights = |_i: usize| 4u16;
+        assert_eq!(visible_window(7, 0, 2, 10, heights), (7, 8));
+    }
+
+    #[test]
+    fn zero_viewport_shows_only_selection() {
+        assert_eq!(visible_window(3, 0, 0, 10, uniform), (3, 4));
     }
 }


### PR DESCRIPTION
## Summary

The register view had no virtualization: `draw_register_body` re-formatted every row's amount and total (each a `rust_decimal` -> `String` allocation), rescanned all rows for the column widths, and rebuilt the full `Vec<Row>` on *every* frame — i.e. on every key press and every 250ms poll tick. That is O(n) per frame in the register's row count, and gets visibly heavy on large ledgers (40k+ lines, worse toward 100k-1M).

Makes register rendering O(viewport) instead of O(n):

- Cache the amount/total column widths on `RegisterView` (fixed for the life of the view), computed once on first draw instead of every frame. Stable widths also stop the columns from jittering while scrolling.
- Add `visible_window`, a pure, height-aware helper that returns the visible row slice `[offset, end)` keeping the selection in view, tracked via a new `TableNav::offset` field. The renderer now formats and builds widget rows only for that slice, rendering with a local viewport-relative `TableState`. The absolute selection stays in `nav.table_state`, so existing navigation math is unchanged. The balance table is untouched.

## Test plan

- [x] `cargo test -p okane` — 307 unit tests pass, including new `visible_window` unit tests (top/bottom jumps, variable row heights, a row taller than the viewport) and an end-to-end render test (`register_renders_only_the_visible_window`) asserting a register longer than the viewport shows only its visible window.
- [x] `cargo clippy -p okane --all-targets` — clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>