### PR TITLE
cli: use hashmap! and indoc! in report UI tests

### DIFF
--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -267,29 +267,51 @@ fn error_overlay(source_display: &str, err: &(dyn std::error::Error + 'static)) 
 mod tests {
     use super::*;
 
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use assert_matches::assert_matches;
+    use indoc::indoc;
+    use maplit::hashmap;
     use okane_core::load::FakeFileSystem;
 
     use app::Screen;
 
-    const V1: &str = "2024/01/01 Init\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Expenses:Food    3 USD\n    Equity\n";
+    const V1: &str = indoc! {"
+        2024/01/01 Init
+            Assets:Bank    10 USD
+            Assets:Cash    5 USD
+            Expenses:Food    3 USD
+            Equity
+    "};
     // V1 plus a new account sorting before all others.
-    const V2: &str = "2024/01/01 Init\n    Assets:Aaa    1 USD\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Expenses:Food    3 USD\n    Equity\n";
+    const V2: &str = indoc! {"
+        2024/01/01 Init
+            Assets:Aaa    1 USD
+            Assets:Bank    10 USD
+            Assets:Cash    5 USD
+            Expenses:Food    3 USD
+            Equity
+    "};
     // V1 without Expenses:Food.
-    const V3: &str =
-        "2024/01/01 Init\n    Assets:Bank    10 USD\n    Assets:Cash    5 USD\n    Equity\n";
+    const V3: &str = indoc! {"
+        2024/01/01 Init
+            Assets:Bank    10 USD
+            Assets:Cash    5 USD
+            Equity
+    "};
     const BROKEN: &str = "@@ this is not a valid ledger file @@\n";
     // Parses fine, fails book-keeping — `ReportError::BookKeep`, whose whole
     // payload is its `Display` (no `source()` behind it).
-    const UNBALANCED: &str =
-        "2024/01/01 Groceries\n    Expenses:Food    30 CHF\n    Assets:Bank    -25 CHF\n";
+    const UNBALANCED: &str = indoc! {"
+        2024/01/01 Groceries
+            Expenses:Food    30 CHF
+            Assets:Bank    -25 CHF
+    "};
 
     fn fake_loader(content: &str) -> load::Loader<FakeFileSystem> {
-        let mut map = HashMap::new();
-        map.insert(PathBuf::from("test.ledger"), content.as_bytes().to_vec());
+        let map = hashmap! {
+            PathBuf::from("test.ledger") => content.as_bytes().to_vec(),
+        };
         load::Loader::new(
             PathBuf::from("test.ledger"),
             load::FakeFileSystem::from(map),

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -801,11 +801,11 @@ fn restore_index(prev_name: &str, rows: &[BalanceRow<'_>]) -> Option<usize> {
 mod tests {
     use super::*;
 
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use assert_matches::assert_matches;
     use bumpalo::Bump;
+    use maplit::hashmap;
     use okane_core::report::ReportContext;
     use okane_core::{load, report};
     use rust_decimal_macros::dec;
@@ -837,8 +837,9 @@ mod tests {
         account_name: &str,
     ) -> (ReportContext<'ctx>, Account<'ctx>) {
         let content = format!("2024/01/01 Init\n    {account_name}    100 USD\n    Equity\n");
-        let mut map = HashMap::new();
-        map.insert(PathBuf::from("test.ledger"), content.into_bytes());
+        let map = hashmap! {
+            PathBuf::from("test.ledger") => content.into_bytes(),
+        };
         let loader = load::Loader::new(
             PathBuf::from("test.ledger"),
             load::FakeFileSystem::from(map),
@@ -861,8 +862,9 @@ mod tests {
             content.push_str(&format!("    {name}    1 USD\n"));
         }
         content.push_str("    Equity\n");
-        let mut map = HashMap::new();
-        map.insert(PathBuf::from("test.ledger"), content.into_bytes());
+        let map = hashmap! {
+            PathBuf::from("test.ledger") => content.into_bytes(),
+        };
         let loader = load::Loader::new(
             PathBuf::from("test.ledger"),
             load::FakeFileSystem::from(map),

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -230,11 +230,11 @@ pub fn load_register<'ctx>(
 mod tests {
     use super::*;
 
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use bumpalo::Bump;
     use crossterm::event::KeyModifiers;
+    use maplit::hashmap;
     use okane_core::{load, report};
 
     use crate::ui::table::TableNav;
@@ -266,8 +266,9 @@ mod tests {
         account_name: &str,
     ) -> (report::ReportContext<'ctx>, Account<'ctx>) {
         let content = format!("2024/01/01 Init\n    {account_name}    1 USD\n    Equity\n");
-        let mut map = HashMap::new();
-        map.insert(PathBuf::from("test.ledger"), content.into_bytes());
+        let map = hashmap! {
+            PathBuf::from("test.ledger") => content.into_bytes(),
+        };
         let loader = load::Loader::new(
             PathBuf::from("test.ledger"),
             load::FakeFileSystem::from(map),


### PR DESCRIPTION
## Summary

Two small readability cleanups in the report UI test modules:

- Replace the `let mut map = HashMap::new(); map.insert(...)` boilerplate for building single-entry `FakeFileSystem` maps with `maplit::hashmap! {}`. The `mut` binding only existed for the initial insert, so the macro form is more direct. (4 sites across `report.rs`, `report/app.rs`, `report/event.rs`.)
- Rewrite the multi-line Ledger test fixtures (`V1`/`V2`/`V3`/`UNBALANCED`) as `indoc! {}` blocks so they read as actual ledger text instead of `\n`-escaped one-liners.

Both `maplit` and `indoc` were already workspace dev-dependencies and used this way in `core/src/load.rs`. The now-unused `use std::collections::HashMap;` imports are dropped.

## Test plan

- `cargo test -p okane --bins` — 303 passed
- `cargo clippy -p okane --bins --tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)