### PR TITLE
core: add BalanceTree for hierarchical balances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 orbs:
-  rust: circleci/rust@1.8.0
+  rust: circleci/rust@2.0.0
 workflows:
   production:
     jobs:
       - rust/lint-test-build:
-          version: "1.88.0"
+          version: "1.89.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 version = "0.20.0"
 authors = ["kikeg"]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 license = "MIT"
 repository = "https://github.com/xkikeg/okane"
 

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -3,6 +3,7 @@
 
 mod account;
 mod balance;
+mod balance_tree;
 mod book_keeping;
 mod commodity;
 mod context;
@@ -15,8 +16,9 @@ mod transaction;
 
 use std::borrow::Borrow;
 
-pub use account::Account;
+pub use account::{Account, AccountAggregate, AccountTree, AccountTreeKey};
 pub use balance::Balance;
+pub use balance_tree::{BalanceTree, BalanceTreeNode};
 pub use commodity::{Commodity, CommodityStore, CommodityTag, OwnedCommodity};
 pub use context::ReportContext;
 pub use error::ReportError;

--- a/core/src/report/account.rs
+++ b/core/src/report/account.rs
@@ -1,9 +1,14 @@
 //! Defines account and its related types.
 
-use bumpalo::Bump;
-use bumpalo_intern::direct::{DirectInternStore, FromInterned, InternedStr, Iter, OccupiedError};
+use std::collections::{HashMap, hash_map};
 
-/// Interned `&str` for accounts within the `'arena` bounded allocator lifetime.
+use bumpalo::Bump;
+use bumpalo_intern::direct::{
+    DirectInternStore, FromInterned, InternedStr, OccupiedError, StoredValue,
+};
+
+/// Account which used in the Ledger format to store the balance with,
+/// such as `Assets:Bank:Foo` or `Income:Salary`.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct Account<'arena>(InternedStr<'arena>);
 
@@ -19,6 +24,7 @@ impl<'arena> FromInterned<'arena> for Account<'arena> {
 
 impl<'arena> Account<'arena> {
     /// Returns the `&str`.
+    #[inline]
     pub fn as_str(&self) -> &'arena str {
         self.0.as_str()
     }
@@ -26,6 +32,7 @@ impl<'arena> Account<'arena> {
 
 /// Manages [`Account`] instances.
 pub struct AccountStore<'arena> {
+    /// Interned Account store.
     intern: DirectInternStore<'arena, Account<'arena>>,
 }
 
@@ -37,7 +44,7 @@ impl<'arena> AccountStore<'arena> {
         }
     }
 
-    /// Returns the Account with the given `value`,
+    /// Returns the [`Account`] with the given `value`,
     /// potentially resolving the alias.
     /// If not available, registers the given `value` as the canonical.
     pub fn ensure(&mut self, value: &str) -> Account<'arena> {
@@ -59,8 +66,349 @@ impl<'arena> AccountStore<'arena> {
         self.intern.register_alias(value, canonical)
     }
 
-    /// Returns the Iterator for all elements.
-    pub fn iter(&self) -> Iter<'arena, '_, Account<'arena>> {
-        self.intern.iter()
+    /// Returns the [`Iterator`] for just `Account`.
+    /// Order is unspecified.
+    pub fn iter(&self) -> impl Iterator<Item = Account<'arena>> {
+        self.intern.iter().filter_map(|v| match v {
+            StoredValue::Alias { .. } => None,
+            StoredValue::Canonical(a) => Some(a),
+        })
+    }
+}
+
+/// Represents not the [`Account`] itself, but rather a ancestor group which
+/// itself is not an acount.
+///
+/// For example, if the Ledger has `Assets:Bank:Foo`, `Assets:Bank` or `Assets`
+/// might be a [`AccountGroup`] if those don't appear as accounts.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct AccountAncestor<'arena>(InternedStr<'arena>);
+
+impl<'arena> FromInterned<'arena> for AccountAncestor<'arena> {
+    fn from_interned(v: InternedStr<'arena>) -> Self {
+        Self(v)
+    }
+
+    fn as_interned(&self) -> InternedStr<'arena> {
+        self.0
+    }
+}
+
+/// Represents either an [`AccountAncestor`] or an [`Account`].
+/// Useful for tree representation.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum AccountAggregate<'arena> {
+    /// Concrete account which appeared in the Ledger file.
+    Account(Account<'arena>),
+    /// Ancestor of the tree acounts, which doesn't appear in the Ledger.
+    Ancestor(AccountAncestor<'arena>),
+}
+
+impl<'arena> From<Account<'arena>> for AccountAggregate<'arena> {
+    fn from(value: Account<'arena>) -> Self {
+        Self::Account(value)
+    }
+}
+
+impl<'arena> From<AccountAncestor<'arena>> for AccountAggregate<'arena> {
+    fn from(value: AccountAncestor<'arena>) -> Self {
+        Self::Ancestor(value)
+    }
+}
+
+impl<'arena> AccountAggregate<'arena> {
+    /// Returns the `&str` representation.
+    #[inline]
+    pub fn as_str(&self) -> &'arena str {
+        match self {
+            AccountAggregate::Account(Account(v)) => v.as_str(),
+            AccountAggregate::Ancestor(AccountAncestor(v)) => v.as_str(),
+        }
+    }
+
+    /// Returns the [`Account`] if this is an account, otherwise `None`.
+    #[inline]
+    pub fn as_account(&self) -> Option<Account<'arena>> {
+        match self {
+            AccountAggregate::Account(a) => Some(*a),
+            AccountAggregate::Ancestor(_) => None,
+        }
+    }
+
+    /// Returns the last colon-separated segment of the account name, i.e. the
+    /// leaf label in a tree view (the whole name when there is no `:`).
+    #[inline]
+    pub fn last_segment(&self) -> &'arena str {
+        let full = self.as_str();
+        full.rsplit_once(':').map_or(full, |(_, leaf)| leaf)
+    }
+}
+
+/// Represents the tree structure of the accounts, stored in the [`AccountStore`].
+pub struct AccountTree<'arena> {
+    prefixes: DirectInternStore<'arena, AccountAncestor<'arena>>,
+    root_children: Vec<AccountAggregate<'arena>>,
+    nodes: HashMap<AccountAggregate<'arena>, Node<'arena>>,
+}
+
+impl<'arena> AccountTree<'arena> {
+    /// Creates a new instance.
+    ///
+    /// This constructs only a plain empty tree, and the actual work is done
+    /// in [`Self::construct()`] because we want to retain the `prefixes`
+    /// lifetime aligned with [`AccountStore`].
+    pub fn new(arena: &'arena Bump) -> Self {
+        Self {
+            prefixes: DirectInternStore::new(arena),
+            root_children: Vec::new(),
+            nodes: HashMap::new(),
+        }
+    }
+
+    /// Constructs the tree state from the given [`AccountStore`].
+    pub fn construct(&mut self, accounts: &AccountStore<'arena>) {
+        self.root_children.clear();
+        self.nodes.clear();
+        for account in accounts.iter() {
+            if self.nodes.contains_key(&account.into()) {
+                continue;
+            }
+            let mut current = AccountAggregate::Account(account);
+            loop {
+                let Some(parent) = self.ensure_parent(accounts, current) else {
+                    // parent is root.
+                    self.nodes.entry(current).or_insert_with(Node::placeholder);
+                    self.root_children.push(current);
+                    break;
+                };
+                let child_node = self.nodes.entry(current).or_insert_with(Node::placeholder);
+                child_node.parent = AccountTreeKey::Descendant(parent);
+                let (children, already_exists) = match self.nodes.entry(parent) {
+                    hash_map::Entry::Occupied(existing) => {
+                        (&mut existing.into_mut().children, true)
+                    }
+                    hash_map::Entry::Vacant(new) => {
+                        (&mut new.insert(Node::placeholder()).children, false)
+                    }
+                };
+                children.push(current);
+                if already_exists {
+                    break;
+                };
+                current = parent;
+            }
+        }
+        self.root_children.sort_by_key(AccountAggregate::as_str);
+        for node in self.nodes.values_mut() {
+            node.children.sort_by_key(AccountAggregate::as_str);
+        }
+    }
+
+    /// Ensures the parent of the given `child` account.
+    /// Returns `None` if the parent is Root element of the tree.
+    fn ensure_parent(
+        &mut self,
+        accounts: &AccountStore<'arena>,
+        child: AccountAggregate<'arena>,
+    ) -> Option<AccountAggregate<'arena>> {
+        // if this is `None`, this means the given child is simple "Foo", and the parent is the root.
+        let (parent, _) = child.as_str().rsplit_once(':')?;
+        Some(match accounts.resolve(parent) {
+            Some(v) => AccountAggregate::Account(v),
+            None => AccountAggregate::Ancestor(self.prefixes.ensure(parent)),
+        })
+    }
+
+    /// Resolves the [`AccountAncestor`] corresponding to the given `label`.
+    /// Returns `None` if not found.
+    /// Note that this would also return `None` if the given label is [`Account`].
+    /// See [`super::ReportContext::account_aggregate()`], that is more convenient.
+    pub fn resolve_ancestor(&self, label: &str) -> Option<AccountAncestor<'arena>> {
+        self.prefixes.resolve(label)
+    }
+
+    /// Returns the parent of the given node.
+    /// `None` if the given `account` is not found in the tree.
+    pub fn parent<T: Into<AccountAggregate<'arena>>>(
+        &self,
+        account: T,
+    ) -> Option<AccountTreeKey<'arena>> {
+        self.nodes.get(&account.into()).map(|node| node.parent)
+    }
+
+    /// Returns the children of the given node.
+    /// `None` if the given `key` is not found,
+    /// and empty slice for the leaf account.
+    pub fn children<T: Into<AccountTreeKey<'arena>>>(
+        &self,
+        key: T,
+    ) -> Option<&[AccountAggregate<'arena>]> {
+        match key.into() {
+            AccountTreeKey::Root => Some(&self.root_children),
+            AccountTreeKey::Descendant(account) => {
+                self.nodes.get(&account).map(|n| n.children.as_slice())
+            }
+        }
+    }
+}
+
+/// Key of the [`AccountTree`] which can be treated as a tree node.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum AccountTreeKey<'arena> {
+    /// Root of the tree.
+    Root,
+    /// Non-root element of the tree.
+    Descendant(AccountAggregate<'arena>),
+}
+
+impl<'arena> AccountTreeKey<'arena> {
+    /// Returns as [`Option<AccountAggregate>`].
+    /// It will be `Some` unless the self is root.
+    #[inline]
+    pub fn as_aggregate(self) -> Option<AccountAggregate<'arena>> {
+        match self {
+            Self::Root => None,
+            Self::Descendant(a) => Some(a),
+        }
+    }
+}
+
+impl<'arena> From<Account<'arena>> for AccountTreeKey<'arena> {
+    fn from(value: Account<'arena>) -> Self {
+        Self::Descendant(value.into())
+    }
+}
+
+impl<'arena> From<AccountAncestor<'arena>> for AccountTreeKey<'arena> {
+    fn from(value: AccountAncestor<'arena>) -> Self {
+        Self::Descendant(value.into())
+    }
+}
+
+impl<'arena> From<AccountAggregate<'arena>> for AccountTreeKey<'arena> {
+    fn from(value: AccountAggregate<'arena>) -> Self {
+        Self::Descendant(value)
+    }
+}
+
+/// Node of the [`AccountTree`].
+#[derive(Debug, Clone)]
+struct Node<'arena> {
+    parent: AccountTreeKey<'arena>,
+    children: Vec<AccountAggregate<'arena>>,
+}
+
+impl<'arena> Node<'arena> {
+    /// Creates a place holder.
+    fn placeholder() -> Self {
+        Self {
+            parent: AccountTreeKey::Root,
+            children: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn account_aggregate_last_segment() {
+        let arena = Bump::new();
+        let mut accounts = AccountStore::new(&arena);
+        let mut tree = AccountTree::new(&arena);
+        let grocery = accounts.ensure("Expenses:Grocery");
+        tree.construct(&accounts);
+        let expenses = tree.resolve_ancestor("Expenses").unwrap();
+        
+        assert_eq!("Grocery", AccountAggregate::from(grocery).last_segment());
+        assert_eq!("Expenses", AccountAggregate::from(expenses).last_segment());
+    }
+
+    mod account_tree {
+        use super::assert_eq;
+        use super::*;
+
+        #[test]
+        fn init_reuses_previous_value() {
+            let arena = Bump::new();
+            let mut accounts = AccountStore::new(&arena);
+            let mut tree = AccountTree::new(&arena);
+
+            let foo = accounts.ensure("Assets:Foo");
+            tree.construct(&accounts);
+            let assets = tree.parent(AccountAggregate::Account(foo)).unwrap();
+
+            tree.construct(&accounts);
+            let assets2 = tree.parent(AccountAggregate::Account(foo)).unwrap();
+
+            assert_eq!(assets, assets2);
+        }
+
+        #[test]
+        fn empty_tree() {
+            let arena = Bump::new();
+            let accounts = AccountStore::new(&arena);
+            let mut tree = AccountTree::new(&arena);
+
+            tree.construct(&accounts);
+
+            assert!(tree.children(AccountTreeKey::Root).unwrap().is_empty());
+        }
+
+        #[test]
+        fn tree_structure() {
+            let arena = Bump::new();
+            let mut accounts = AccountStore::new(&arena);
+
+            let foo = accounts.ensure("Assets:Banks:Foo");
+            let bar = accounts.ensure("Assets:Banks:Bar");
+            let food = accounts.ensure("Expenses:Food");
+            let food_special = accounts.ensure("Expenses:Food:Special");
+
+            let mut tree = AccountTree::new(&arena);
+            tree.construct(&accounts);
+
+            let assets = tree.resolve_ancestor("Assets").unwrap();
+            let banks = tree.resolve_ancestor("Assets:Banks").unwrap();
+            let expenses = tree.resolve_ancestor("Expenses").unwrap();
+            let parent_of: [(AccountTreeKey, AccountAggregate); _] = [
+                (AccountTreeKey::Root, assets.into()),
+                (AccountTreeKey::Root, expenses.into()),
+                (assets.into(), banks.into()),
+                (banks.into(), foo.into()),
+                (banks.into(), bar.into()),
+                (expenses.into(), food.into()),
+                (food.into(), food_special.into()),
+            ];
+            for (expected, child) in parent_of {
+                assert_eq!(expected, tree.parent(child).unwrap());
+            }
+            let children_of: [(&[AccountAggregate], AccountTreeKey); _] = [
+                (
+                    &[
+                        AccountAggregate::Ancestor(assets),
+                        AccountAggregate::Ancestor(expenses),
+                    ],
+                    AccountTreeKey::Root,
+                ),
+                (&[AccountAggregate::Ancestor(banks)], assets.into()),
+                (
+                    // alphabetically sorted.
+                    &[
+                        AccountAggregate::Account(bar),
+                        AccountAggregate::Account(foo),
+                    ],
+                    banks.into(),
+                ),
+                (&[AccountAggregate::Account(food)], expenses.into()),
+                (&[AccountAggregate::Account(food_special)], food.into()),
+            ];
+            for (expected, parent) in children_of {
+                assert_eq!(expected, tree.children(parent).unwrap());
+            }
+        }
     }
 }

--- a/core/src/report/balance_tree.rs
+++ b/core/src/report/balance_tree.rs
@@ -1,0 +1,447 @@
+//! Defines the [`BalanceTree`], tree of balance.
+
+use std::collections::{HashMap, HashSet};
+
+use super::account::{Account, AccountAggregate, AccountTreeKey};
+use super::balance::Balance;
+use super::context::ReportContext;
+use super::eval::Amount;
+use super::query::QueryError;
+
+/// Accumulated balance, considering the account hierarchy.
+#[derive(Debug)]
+pub struct BalanceTree<'ctx> {
+    /// Amount labeled with AccountAggregate.
+    /// Sorted alphabetically, also stored in hierarchical.
+    values: Vec<BalanceTreeNode<'ctx>>,
+}
+
+impl<'ctx> BalanceTree<'ctx> {
+    pub fn create(ctx: &ReportContext<'ctx>, balance: Balance<'ctx>) -> Result<Self, QueryError> {
+        let mut values: Vec<BalanceTreeNode<'ctx>> = vec![BalanceTreeNode::placeholder(
+            AccountTreeKey::Root,
+            0,
+            Amount::zero(),
+        )];
+        // To tell if the account aggregate is required or not,
+        // we need to maintain `required` to avoid going into unnecessary branch in accumulate DFS.
+        let mut required: HashSet<AccountAggregate<'ctx>> = HashSet::new();
+        for (account, _) in balance.iter() {
+            let mut account = (*account).into();
+            required.insert(account);
+            while let Some(parent) = parent_of(ctx, account)? {
+                if !required.insert(parent) {
+                    // other already inserted, no need to do.
+                    break;
+                }
+                account = parent;
+            }
+        }
+        accumulate(&mut balance.into_map(), &mut values, ctx, &required, 0)?;
+        Ok(Self { values })
+    }
+
+    /// Returns all nodes in the flat vector.
+    ///
+    /// The order is both alphabetical (by account name) and a pre-order
+    /// (DFS) flattening of the account hierarchy; index 0 is always the
+    /// synthetic [`AccountTreeKey::Root`].
+    pub fn nodes(&self) -> &[BalanceTreeNode<'ctx>] {
+        &self.values
+    }
+
+    /// Consumes the tree and returns the owned node vector.
+    /// See [`Self::nodes`] for the ordering guarantees.
+    pub fn into_nodes(self) -> Vec<BalanceTreeNode<'ctx>> {
+        self.values
+    }
+}
+
+fn parent_of<'ctx>(
+    ctx: &ReportContext<'ctx>,
+    account: AccountAggregate<'ctx>,
+) -> Result<Option<AccountAggregate<'ctx>>, QueryError> {
+    let parent = ctx.account_tree.parent(account).ok_or_else(|| {
+        QueryError::Internal(format!(
+            "account {} isn't registered in the AccountTree",
+            account.as_str()
+        ))
+    })?;
+    Ok(match parent {
+        AccountTreeKey::Root => None,
+        AccountTreeKey::Descendant(parent) => Some(parent),
+    })
+}
+
+fn label(account: AccountTreeKey<'_>) -> &str {
+    account
+        .as_aggregate()
+        .map(|x| x.as_str())
+        .unwrap_or_default()
+}
+
+fn accumulate<'ctx>(
+    balance: &mut HashMap<Account<'ctx>, Amount<'ctx>>,
+    values: &mut Vec<BalanceTreeNode<'ctx>>,
+    ctx: &ReportContext<'ctx>,
+    required: &HashSet<AccountAggregate<'ctx>>,
+    i: usize,
+) -> Result<(Amount<'ctx>, NodeRange), QueryError> {
+    debug_assert!(i < values.len());
+    let account = values[i].account;
+    let depth = values[i].depth;
+    let mut total = values[i].self_amount.clone();
+    let mut children: Vec<NodeRange> = Vec::new();
+    for account in ctx.account_tree.children(account).ok_or_else(|| {
+        QueryError::Internal(format!(
+            "account {} isn't registered in the AccountTree",
+            label(account)
+        ))
+    })? {
+        if !required.contains(account) {
+            continue;
+        }
+        let j = values.len();
+        let amount = match account {
+            AccountAggregate::Account(account) => balance.remove(account).unwrap_or_default(),
+            AccountAggregate::Ancestor(_) => Amount::default(),
+        };
+        values.push(BalanceTreeNode::placeholder(
+            (*account).into(),
+            depth + 1,
+            amount,
+        ));
+        let (child_amount, child_range) = accumulate(balance, values, ctx, required, j)?;
+        total += child_amount;
+        children.push(child_range);
+    }
+    let cover = NodeRange::cover(i, &children)?;
+    total.remove_zero_entries();
+    values[i].subtree_amount = total.clone();
+    values[i].children = children;
+    values[i].range = cover;
+    Ok((total, cover))
+}
+
+/// Node of the each element.
+#[derive(Debug, PartialEq, Eq)]
+pub struct BalanceTreeNode<'ctx> {
+    /// Account key of this node ([`AccountTreeKey::Root`] for the synthetic root).
+    pub account: AccountTreeKey<'ctx>,
+    /// Depth in the tree: root is `0`, its children `1`, and so on.
+    pub depth: u16,
+    /// Amount of the node itself, excluding descendants.
+    pub self_amount: Amount<'ctx>,
+    /// Amount of the node and all its descendants.
+    pub subtree_amount: Amount<'ctx>,
+    /// Children, expressed as Vector index range.
+    children: Vec<NodeRange>,
+    /// Contiguous span of this node plus all its descendants in the flat vector.
+    range: NodeRange,
+}
+
+impl<'ctx> BalanceTreeNode<'ctx> {
+    /// Creates a new instance with place holder.
+    fn placeholder(account: AccountTreeKey<'ctx>, depth: u16, self_amount: Amount<'ctx>) -> Self {
+        Self {
+            account,
+            depth,
+            self_amount,
+            // all placeholders below
+            subtree_amount: Amount::zero(),
+            children: Vec::new(),
+            range: NodeRange { start: 0, size: 0 },
+        }
+    }
+
+    /// Returns `true` when the node has at least one child.
+    pub fn has_children(&self) -> bool {
+        !self.children.is_empty()
+    }
+
+    /// Range of this node and all its descendants in [`BalanceTree::nodes`].
+    ///
+    /// The node itself is at `range.start`; its descendants (if any) occupy
+    /// `range.start + 1 .. range.end`.
+    pub fn subtree_range(&self) -> std::ops::Range<usize> {
+        self.range.into()
+    }
+}
+
+/// Range with Copy dedicated for node range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NodeRange {
+    pub start: usize,
+    pub size: usize,
+}
+
+impl NodeRange {
+    /// Constructs a single NodeRange as a cover of given `[i]` + `ranges`.
+    /// Each range must be in order (smaller to larger), continuous.
+    fn cover(i: usize, ranges: &[NodeRange]) -> Result<Self, QueryError> {
+        let start = i;
+        let mut size = 1;
+        for range in ranges {
+            if start + size != range.start {
+                return Err(QueryError::Internal(format!(
+                    "NodeRange::cover can only cover continuous and mutually exclusive ranges: total start={start}, size={size}, current start={}",
+                    range.start
+                )));
+            }
+            size += range.size;
+        }
+        Ok(Self { start, size })
+    }
+}
+
+impl From<std::ops::Range<usize>> for NodeRange {
+    fn from(value: std::ops::Range<usize>) -> Self {
+        Self {
+            start: value.start,
+            size: value.end.checked_sub(value.start).unwrap(),
+        }
+    }
+}
+
+impl From<NodeRange> for std::ops::Range<usize> {
+    fn from(value: NodeRange) -> Self {
+        Self {
+            start: value.start,
+            end: value.start + value.size,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bumpalo::Bump;
+    use maplit::hashmap;
+    use pretty_assertions::assert_eq;
+    use rust_decimal::Decimal;
+    use assert_matches::assert_matches;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn construct_fails_on_unknown_account() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodities.ensure("USD");
+
+        // balance is constructed after tree construction.
+        // this will make the balance creation in invalid state.
+        ctx.account_tree.construct(&ctx.accounts);
+        let balance = Balance::from_iter(hashmap! {
+            ctx.accounts.ensure("Assets:Bank") => Amount::from_value(usd, dec!(1)),
+            ctx.accounts.ensure("Assets:Bank:Checking") => Amount::from_value(usd, dec!(3)),
+        });
+
+        let got_err = BalanceTree::create(&ctx, balance).unwrap_err();
+        assert_matches!(got_err, QueryError::Internal(msg) if msg.contains("isn't registered in the AccountTree"));
+    }
+
+    #[test]
+    fn simple_tree_for_non_overlapping_balance() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let chf = ctx.commodities.ensure("CHF");
+        let jpy = ctx.commodities.ensure("JPY");
+        let usd = ctx.commodities.ensure("USD");
+
+        let balance = Balance::from_iter(hashmap! {
+            ctx.accounts.ensure("Assets") =>
+                Amount::from_iter([(chf, dec!(10)), (usd, dec!(1))]),
+            ctx.accounts.ensure("Expenses") =>
+                Amount::from_value(jpy, Decimal::ZERO),
+        });
+        ctx.account_tree.construct(&ctx.accounts);
+
+        let tree = BalanceTree::create(&ctx, balance).unwrap();
+        let got = tree.into_nodes();
+        let want = vec![
+            BalanceTreeNode {
+                account: AccountTreeKey::Root,
+                depth: 0,
+                self_amount: Amount::zero(),
+                subtree_amount: Amount::from_iter([(chf, dec!(10)), (usd, dec!(1))]),
+                children: vec![(1..2).into(), (2..3).into()],
+                range: (0..3).into(),
+            },
+            BalanceTreeNode {
+                account: ctx.accounts.resolve("Assets").unwrap().into(),
+                depth: 1,
+                self_amount: Amount::from_iter([(chf, dec!(10)), (usd, dec!(1))]),
+                subtree_amount: Amount::from_iter([(chf, dec!(10)), (usd, dec!(1))]),
+                children: vec![],
+                range: (1..2).into(),
+            },
+            BalanceTreeNode {
+                account: ctx.accounts.resolve("Expenses").unwrap().into(),
+                depth: 1,
+                self_amount: Amount::zero(),
+                subtree_amount: Amount::zero(),
+                children: vec![],
+                range: (2..3).into(),
+            },
+        ];
+        assert_eq!(want, got);
+
+        assert_eq!(2..3, got[2].subtree_range());
+        assert!(got[0].has_children());
+        assert!(!got[2].has_children());
+    }
+
+    /// Resolves `name` to its tree key, whether it is a posted account or an
+    /// ancestor-only prefix.
+    fn account_key<'a>(ctx: &ReportContext<'a>, name: &str) -> AccountTreeKey<'a> {
+        if let Some(account) = ctx.accounts.resolve(name) {
+            account.into()
+        } else {
+            ctx.account_tree
+                .resolve_ancestor(name)
+                .expect("account or prefix")
+                .into()
+        }
+    }
+
+    #[test]
+    fn tree_with_overlapping_and_ancestor_accounts() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodities.ensure("USD");
+
+        let balance = Balance::from_iter(hashmap! {
+            ctx.accounts.ensure("Assets:Bank") => Amount::from_value(usd, dec!(1)),
+            ctx.accounts.ensure("Assets:Bank:Checking") => Amount::from_value(usd, dec!(3)),
+            ctx.accounts.ensure("Assets:Cash") => Amount::from_value(usd, dec!(5)),
+            ctx.accounts.ensure("Expenses:Property") => Amount::from_value(usd, dec!(1_000)),
+            ctx.accounts.ensure("Expenses:Property:Maintenance") => Amount::from_value(usd, dec!(23)),
+            ctx.accounts.ensure("Expenses:Property Tax") => Amount::from_value(usd, dec!(13)),
+            ctx.accounts.ensure("Expenses:Travel:Taxi") => Amount::from_value(usd, dec!(11)),
+            // want to see if Expenses:Travel gets Amount::zero.
+            ctx.accounts.ensure("Expenses:Travel:Train") => Amount::from_value(usd, dec!(-11)),
+        });
+        // this account exists, but not included in the balance.
+        ctx.accounts.ensure("Income:Salary");
+        ctx.account_tree.construct(&ctx.accounts);
+
+        let amount = |v| Amount::from_value(usd, v);
+        let key = |name: &str| account_key(&ctx, name);
+
+        let tree = BalanceTree::create(&ctx, balance).unwrap();
+        let got = tree.into_nodes();
+        let want = vec![
+            // 0: Root — spans the whole vector.
+            BalanceTreeNode {
+                account: AccountTreeKey::Root,
+                depth: 0,
+                self_amount: Amount::zero(),
+                subtree_amount: amount(dec!(1045)),
+                children: vec![(1..5).into(), (5..12).into()],
+                range: (0..12).into(),
+            },
+            // 1: Assets — ancestor with no posting of its own.
+            BalanceTreeNode {
+                account: key("Assets"),
+                depth: 1,
+                self_amount: Amount::zero(),
+                subtree_amount: amount(dec!(9)),
+                children: vec![(2..4).into(), (4..5).into()],
+                range: (1..5).into(),
+            },
+            // 2: Assets:Bank — posted *and* a parent; keeps its own 1 USD.
+            BalanceTreeNode {
+                account: key("Assets:Bank"),
+                depth: 2,
+                self_amount: amount(dec!(1)),
+                subtree_amount: amount(dec!(4)),
+                children: vec![(3..4).into()],
+                range: (2..4).into(),
+            },
+            // 3: Assets:Bank:Checking — leaf.
+            BalanceTreeNode {
+                account: key("Assets:Bank:Checking"),
+                depth: 3,
+                self_amount: amount(dec!(3)),
+                subtree_amount: amount(dec!(3)),
+                children: vec![],
+                range: (3..4).into(),
+            },
+            // 4: Assets:Cash — leaf sibling of Assets:Bank.
+            BalanceTreeNode {
+                account: key("Assets:Cash"),
+                depth: 2,
+                self_amount: amount(dec!(5)),
+                subtree_amount: amount(dec!(5)),
+                children: vec![],
+                range: (4..5).into(),
+            },
+            // 5: Expenses — ancestor.
+            BalanceTreeNode {
+                account: key("Expenses"),
+                depth: 1,
+                self_amount: Amount::zero(),
+                subtree_amount: amount(dec!(1036)),
+                children: vec![(6..8).into(), (8..9).into(), (9..12).into()],
+                range: (5..12).into(),
+            },
+            // 6: Expenses:Property — posted and the parent of Maintenance.
+            BalanceTreeNode {
+                account: key("Expenses:Property"),
+                depth: 2,
+                self_amount: amount(dec!(1_000)),
+                subtree_amount: amount(dec!(1_023)),
+                children: vec![(7..8).into()],
+                range: (6..8).into(),
+            },
+            // 7: Expenses:Property:Maintenance — child of Property; stays grouped
+            // under it even though "Property Tax" sorts before it by full name.
+            BalanceTreeNode {
+                account: key("Expenses:Property:Maintenance"),
+                depth: 3,
+                self_amount: amount(dec!(23)),
+                subtree_amount: amount(dec!(23)),
+                children: vec![],
+                range: (7..8).into(),
+            },
+            // 8: Expenses:Property Tax — sibling leaf of Property (not its child).
+            BalanceTreeNode {
+                account: key("Expenses:Property Tax"),
+                depth: 2,
+                self_amount: amount(dec!(13)),
+                subtree_amount: amount(dec!(13)),
+                children: vec![],
+                range: (8..9).into(),
+            },
+            // 9: Expenses:Travel — ancestor with a single posted descendant.
+            BalanceTreeNode {
+                account: key("Expenses:Travel"),
+                depth: 2,
+                self_amount: Amount::zero(),
+                subtree_amount: Amount::zero(),
+                children: vec![(10..11).into(), (11..12).into()],
+                range: (9..12).into(),
+            },
+            // 10: Expenses:Travel:Taxi — leaf.
+            BalanceTreeNode {
+                account: key("Expenses:Travel:Taxi"),
+                depth: 3,
+                self_amount: amount(dec!(11)),
+                subtree_amount: amount(dec!(11)),
+                children: vec![],
+                range: (10..11).into(),
+            },
+            // 11: Expenses:Travel:Train — leaf.
+            BalanceTreeNode {
+                account: key("Expenses:Travel:Train"),
+                depth: 3,
+                self_amount: amount(dec!(-11)),
+                subtree_amount: amount(dec!(-11)),
+                children: vec![],
+                range: (11..12).into(),
+            },
+        ];
+        assert_eq!(want, got);
+    }
+}

--- a/core/src/report/context.rs
+++ b/core/src/report/context.rs
@@ -1,15 +1,15 @@
 use bumpalo::Bump;
-use bumpalo_intern::direct::StoredValue;
 
-use crate::report::commodity::CommodityTag;
+use crate::report::AccountAggregate;
 
-use super::account::{Account, AccountStore};
-use super::commodity::CommodityStore;
+use super::account::{Account, AccountStore, AccountTree};
+use super::commodity::{CommodityStore, CommodityTag};
 
 /// Context object extensively used across Ledger file evaluation.
 pub struct ReportContext<'ctx> {
     pub(super) arena: &'ctx Bump,
     pub(super) accounts: AccountStore<'ctx>,
+    pub(super) account_tree: AccountTree<'ctx>,
     pub(super) commodities: CommodityStore<'ctx>,
 }
 
@@ -17,20 +17,19 @@ impl<'ctx> ReportContext<'ctx> {
     /// Create a new instance of `ReportContext`.
     pub fn new(arena: &'ctx Bump) -> Self {
         let accounts = AccountStore::new(arena);
+        let account_tree = AccountTree::new(arena);
         let commodities = CommodityStore::new(arena);
         Self {
             arena,
             accounts,
+            account_tree,
             commodities,
         }
     }
 
     /// Returns all accounts, sorted as string order.
     pub(super) fn all_accounts_unsorted(&self) -> impl Iterator<Item = Account<'ctx>> + '_ {
-        self.accounts.iter().filter_map(|x| match x {
-            StoredValue::Canonical(x) => Some(x),
-            StoredValue::Alias { .. } => None,
-        })
+        self.accounts.iter()
     }
     /// Returns all accounts, sorted as string order.
     pub(super) fn all_accounts(&self) -> Vec<Account<'ctx>> {
@@ -40,20 +39,36 @@ impl<'ctx> ReportContext<'ctx> {
     }
 
     /// Returns the given account, or `None` if not found.
+    #[inline]
     pub fn account(&self, value: &str) -> Option<Account<'ctx>> {
         self.accounts.resolve(value)
     }
 
+    /// Returns the account aggregate, or `None` if not found.
+    #[inline]
+    pub fn account_aggregate(&self, value: &str) -> Option<AccountAggregate<'ctx>> {
+        match self.account(value) {
+            Some(v) => Some(AccountAggregate::Account(v)),
+            None => self
+                .account_tree
+                .resolve_ancestor(value)
+                .map(AccountAggregate::Ancestor),
+        }
+    }
+
     /// Returns the given commmodity, or `None` if not found.
+    #[inline]
     pub fn commodity(&self, value: &str) -> Option<CommodityTag<'ctx>> {
         self.commodities.resolve(value)
     }
 
     /// Returns [`CommodityStore`].
+    #[inline]
     pub fn commodity_store(&self) -> &CommodityStore<'ctx> {
         &self.commodities
     }
     /// Returns mut [`CommodityStore`].
+    #[inline]
     pub fn commodity_store_mut(&mut self) -> &mut CommodityStore<'ctx> {
         &mut self.commodities
     }

--- a/core/src/report/process.rs
+++ b/core/src/report/process.rs
@@ -44,6 +44,7 @@ where
             )
         })
     })?;
+    ctx.account_tree.construct(&ctx.accounts);
     if let Some(price_db_path) = options.price_db_path.as_deref() {
         accum
             .price_repos
@@ -129,4 +130,43 @@ fn process_commodity<'ctx>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use std::path::Path;
+
+    use assert_matches::assert_matches;
+    use bumpalo::Bump;
+
+    use super::super::account::{AccountAggregate,AccountTreeKey};
+
+    #[test]
+    fn process_constructs_account_tree() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let input =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../testdata/report/multi_commodity.ledger");
+
+        let _ = process(
+            &mut ctx,
+            load::new_loader(input),
+            &ProcessOptions::default(),
+        )
+        .unwrap();
+
+        let parent = ctx.account_aggregate("Assets:Banks").unwrap();
+        let child1 = ctx.account_aggregate("Assets:Banks:Swiss Bank").unwrap();
+        let child2 = ctx.account_aggregate("Assets:Banks:あおによし").unwrap();
+        assert_matches!(parent, AccountAggregate::Ancestor(_));
+        assert_matches!(child1, AccountAggregate::Account(_));
+        assert_matches!(child2, AccountAggregate::Account(_));
+        let children: &[_] = &[child1, child2];
+
+        assert_eq!(Some(children), ctx.account_tree.children(parent));
+        assert_eq!(Some(AccountTreeKey::Descendant(parent)), ctx.account_tree.parent(child1));
+    }
 }

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    account::Account,
+    account::{Account, AccountAggregate},
     balance::Balance,
     commodity::OwnedCommodity,
     context::ReportContext,
@@ -56,6 +56,8 @@ pub enum QueryError {
     CommodityConversionFailure(#[from] ConversionError),
     #[error("unsupported conversion strategy for this query")]
     UnsupportedConversionStrategy,
+    #[error("internal failure: {0}")]
+    Internal(String),
 }
 
 /// Specifies the iteration order of `register` rows.
@@ -267,7 +269,7 @@ impl<'ctx> Ledger<'ctx> {
         let account_filter = query.account.clone();
         // When the account filter can never match, return an iterator that is
         // already exhausted instead of scanning everything.
-        let txns: TxnIter<'a, 'ctx> = if account_filter.is_exhaustive_empty() {
+        let txns: TxnIter<'a, 'ctx> = if account_filter.is_empty() {
             TxnIter::linear(&[])
         } else {
             match query.sort {
@@ -675,27 +677,28 @@ impl<'ctx> AccountFilter<'ctx> {
     /// Builds a filter matching `prefix` itself and every account nested
     /// under it — accounts which are equal to `prefix`, or their name starting with
     /// `"{prefix}:"`.
-    pub fn descendants_of(ctx: &ReportContext<'ctx>, prefix: Account<'ctx>) -> Self {
+    pub fn descendants_of(ctx: &ReportContext<'ctx>, prefix: AccountAggregate<'ctx>) -> Self {
         let mut matched: HashSet<Account<'ctx>> = HashSet::new();
-        for account in ctx.all_accounts_unsorted() {
-            let name = account.as_str();
-            let is_self = account == prefix;
-            let is_descendant = name
-                .strip_prefix(prefix.as_str())
-                .map(|rest| rest.starts_with(':'))
-                .unwrap_or(false);
-            if is_self || is_descendant {
+        let mut targets = vec![prefix];
+        while let Some(current) = targets.pop() {
+            if let Some(account) = current.as_account() {
                 matched.insert(account);
+            }
+            // if the current is not found in the [`AccountTree`],
+            // gracefully fallback to empty.
+            for child in ctx.account_tree.children(current).unwrap_or_default() {
+                targets.push(*child);
             }
         }
         Self::from_set(matched)
     }
 
     /// Returns `true` when the filter can never match any account.
-    fn is_exhaustive_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         matches!(self, AccountFilter::Set(s) if s.is_empty())
     }
 
+    /// Returns `true` if the given account matches this filter.
     fn is_match(&self, account: &Account<'ctx>) -> bool {
         match self {
             AccountFilter::All => true,
@@ -1595,13 +1598,31 @@ mod tests {
         }
 
         #[test]
+        fn descendants_of_ancestor_prefix_matches_subtree() {
+            let arena = Bump::new();
+            let (ctx, _ledger) = create_ledger(&arena);
+
+            // "Assets" only exists as an ancestor prefix; its whole subtree matches.
+            let assets =
+                AccountAggregate::Ancestor(ctx.account_tree.resolve_ancestor("Assets").unwrap());
+            let filter = AccountFilter::descendants_of(&ctx, assets);
+            assert_matches!(filter, AccountFilter::Set(s) => {
+                assert_eq!(s, hashset![
+                    ctx.account("Assets:CH Bank").unwrap(),
+                    ctx.account("Assets:Broker").unwrap(),
+                    ctx.account("Assets:J 銀行:普通").unwrap(),
+                ]);
+            });
+        }
+
+        #[test]
         fn descendants_of_leaf_collapses_to_exact() {
             let arena = Bump::new();
             let (ctx, _ledger) = create_ledger(&arena);
 
             // A leaf account has no descendants, so the filter is just itself.
             let broker = ctx.account("Assets:Broker").unwrap();
-            let filter = AccountFilter::descendants_of(&ctx, broker);
+            let filter = AccountFilter::descendants_of(&ctx, broker.into());
             assert_matches!(filter, AccountFilter::Exact(a) if a == broker);
         }
 
@@ -1611,7 +1632,7 @@ mod tests {
             let (ctx, _ledger) = create_ledger(&arena);
 
             let food = ctx.account("Expenses:Food").unwrap();
-            let filter = AccountFilter::descendants_of(&ctx, food);
+            let filter = AccountFilter::descendants_of(&ctx, food.into());
             assert_matches!(filter, AccountFilter::Set(s) => {
                 assert_eq!(s, hashset![
                     ctx.account("Expenses:Food").unwrap(),


### PR DESCRIPTION
Introduce `BalanceTree`, which arranges a `Balance` into the account hierarchy. It holds a flat vector of `BalanceTreeNode` that is at once alphabetical and a pre-order (DFS) flattening of the tree: index 0 is the synthetic root, and each node's descendants occupy a contiguous range right after it.

Each node carries its own posted amount (`self_amount`), the rolled-up subtree total (`subtree_amount`), its depth, and the index range spanning its subtree. `BalanceTree::create` builds it from a `Balance` and a `ReportContext` (whose `account_tree` must be constructed); `nodes()` / `into_nodes()` expose the nodes, with `has_children()`, `subtree_range()`, and `last_segment()` accessors for rendering and folding.

Also adds `AccountAggregate` / `AccountAncestor` to the account layer and upgrades the Rust version to 1.89.0 (for array-size inference).

This is the core foundation split out of the tree-balance work (#488) so it can land independently; the CLI tree UI builds on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)