### PR TITLE
cli: componentize report UI screens (balance/register)

### DIFF
--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -21,7 +21,8 @@ use okane_core::report::BalanceTreeNode;
 use super::balance::{BalanceSnapshot, BalanceView};
 use super::overlay::{Overlay, ScrollDelta};
 use super::register::{
-    RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterSnapshot, RegisterView, Screen,
+    RegisterAction, RegisterMessage, RegisterQueryTemplate, RegisterRow, RegisterScope,
+    RegisterSnapshot, RegisterView, Screen,
 };
 use super::search::{SearchDirection, SearchMode, SearchPhase};
 
@@ -43,8 +44,8 @@ pub enum Message {
     ToggleFoldAll,
     /// User asked to drill into the selected balance row.
     OpenRegister,
-    /// Leave the register view and go back to balance.
-    LeaveRegister,
+    /// A message routed to the active register screen.
+    Register(RegisterMessage),
     /// User asked to quit from balance — show the confirmation overlay.
     RequestQuit,
     /// Confirm quit from the overlay.
@@ -236,9 +237,12 @@ impl<'ctx> App<'ctx> {
                     return Some(Command::LoadRegister { scope });
                 }
             }
-            Message::LeaveRegister => {
-                if matches!(self.screen, Screen::Register(_)) {
-                    self.screen = Screen::Balance;
+            Message::Register(register_msg) => {
+                if let Screen::Register(view) = &mut self.screen {
+                    match view.update(register_msg) {
+                        Some(RegisterAction::Leave) => self.screen = Screen::Balance,
+                        None => {}
+                    }
                 }
             }
             Message::RequestQuit => {
@@ -883,7 +887,7 @@ mod tests {
         // Bypass show_register's RegisterView::new — it just needs *some*
         // register screen state to flip the enum variant.
         app.screen = register_screen(account, TableNav::new(0));
-        app.update(Message::LeaveRegister);
+        app.update(Message::Register(RegisterMessage::Leave));
         assert!(matches!(app.screen, Screen::Balance));
     }
 

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -14,36 +14,24 @@
 
 use std::cmp::min;
 
-use crate::ui::table::TableNav;
-
 use okane_core::report::BalanceTreeNode;
 
-use super::balance::{BalanceSnapshot, BalanceView};
+use super::balance::{BalanceAction, BalanceMessage, BalanceSnapshot, BalanceView};
 use super::overlay::{Overlay, ScrollDelta};
 use super::register::{
     RegisterAction, RegisterMessage, RegisterQueryTemplate, RegisterRow, RegisterScope,
     RegisterSnapshot, RegisterView, Screen,
 };
-use super::search::{SearchDirection, SearchMode, SearchPhase};
 
 /// Messages that drive state transitions (Elm-style).
+///
+/// [`App`] owns only the cross-screen messages; per-screen behavior is carried
+/// by [`BalanceMessage`] and [`RegisterMessage`] and routed to the focused
+/// component.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Message {
-    MoveUp,
-    MoveDown,
-    PageUp,
-    PageDown,
-    SelectFirst,
-    SelectLast,
-    // Balance-screen display toggles (flat/tree and folding).
-    /// Toggle between the flat list and the account tree (`t`).
-    ToggleTree,
-    /// Fold/unfold the selected tree node (`space`).
-    ToggleFold,
-    /// Fold or unfold every node in the tree (`x`).
-    ToggleFoldAll,
-    /// User asked to drill into the selected balance row.
-    OpenRegister,
+    /// A message routed to the balance screen.
+    Balance(BalanceMessage),
     /// A message routed to the active register screen.
     Register(RegisterMessage),
     /// User asked to quit from balance — show the confirmation overlay.
@@ -56,26 +44,6 @@ pub enum Message {
     OverlayScroll(ScrollDelta),
     /// Unconditional quit (Ctrl-C).
     QuitImmediate,
-    /// Open the modal (`/`) balance search bar (incremental phase).
-    StartModalSearch,
-    /// Open an interactive (`C-s`/`C-r`) search in the given direction.
-    StartISearch(SearchDirection),
-    /// Append a character to the search pattern.
-    SearchPush(char),
-    /// Remove the last character from the search pattern.
-    SearchPop,
-    /// Fix the current pattern (modal incremental → fixed); empty pattern exits.
-    SearchSubmit,
-    /// Cancel an editing search: restore the origin selection and exit.
-    SearchCancel,
-    /// Close the search: keep the current selection.
-    SearchClose,
-    /// Next match (modal `n`); or, for interactive search, repeat forward /
-    /// recall the previous pattern when empty (`C-s`).
-    SearchNext,
-    /// Previous match (modal `N`); or, for interactive search, repeat backward
-    /// / recall the previous pattern when empty (`C-r`).
-    SearchPrev,
     /// Re-read the ledger data from disk (`r` / `F5`), keeping the UI state.
     Reload,
 }
@@ -161,14 +129,6 @@ impl<'ctx> App<'ctx> {
         }
     }
 
-    /// Mutable handle to whichever nav drives the currently visible table.
-    fn active_nav_mut(&mut self) -> &mut TableNav {
-        match &mut self.screen {
-            Screen::Balance => &mut self.balance.nav,
-            Screen::Register(view) => &mut view.nav,
-        }
-    }
-
     /// Applies a message; optionally returns a [`Command`] for the event
     /// loop to execute (the only impure step in this flow).
     pub fn update(&mut self, msg: Message) -> Option<Command<'ctx>> {
@@ -207,41 +167,23 @@ impl<'ctx> App<'ctx> {
         }
 
         match msg {
-            Message::MoveUp => {
-                self.balance.end_interactive_search();
-                self.active_nav_mut().move_selection(-1);
-            }
-            Message::MoveDown => {
-                self.balance.end_interactive_search();
-                self.active_nav_mut().move_selection(1);
-            }
-            Message::PageUp => {
-                let nav = self.active_nav_mut();
-                let delta = -(nav.page_size() as isize);
-                nav.move_selection(delta);
-            }
-            Message::PageDown => {
-                let nav = self.active_nav_mut();
-                let delta = nav.page_size() as isize;
-                nav.move_selection(delta);
-            }
-            Message::SelectFirst => self.active_nav_mut().select_first(),
-            Message::SelectLast => self.active_nav_mut().select_last(),
-            Message::OpenRegister => {
+            // Route to the focused component; translate its action into the
+            // cross-screen effect App owns.
+            Message::Balance(balance_msg) => {
                 if matches!(self.screen, Screen::Balance)
-                    && let Some(scope) = self.balance.selected_scope()
+                    && let Some(action) = self.balance.update(balance_msg)
                 {
-                    // An interactive search drills in like the normal view:
-                    // end the search, keeping the cursor on the chosen account.
-                    self.balance.end_interactive_search();
-                    return Some(Command::LoadRegister { scope });
+                    return Some(match action {
+                        BalanceAction::OpenRegister { scope } => Command::LoadRegister { scope },
+                    });
                 }
             }
             Message::Register(register_msg) => {
-                if let Screen::Register(view) = &mut self.screen {
-                    match view.update(register_msg) {
-                        Some(RegisterAction::Leave) => self.screen = Screen::Balance,
-                        None => {}
+                if let Screen::Register(view) = &mut self.screen
+                    && let Some(action) = view.update(register_msg)
+                {
+                    match action {
+                        RegisterAction::Leave => self.screen = Screen::Balance,
                     }
                 }
             }
@@ -250,44 +192,7 @@ impl<'ctx> App<'ctx> {
                     self.overlay = Some(Overlay::QuitConfirm);
                 }
             }
-            // The screen guard mirrors the old inline guard: start a search on
-            // the balance screen, or continue editing one that is already open.
-            Message::StartModalSearch => {
-                if matches!(self.screen, Screen::Balance) || self.balance.search.is_some() {
-                    self.balance.start_search(
-                        SearchMode::Modal(SearchPhase::Incremental),
-                        SearchDirection::Forward,
-                    );
-                }
-            }
-            Message::StartISearch(dir) => {
-                if matches!(self.screen, Screen::Balance) || self.balance.search.is_some() {
-                    self.balance.start_search(SearchMode::Interactive, dir);
-                }
-            }
-            Message::SearchPush(c) => self.balance.search_push(c),
-            Message::SearchPop => self.balance.search_pop(),
-            Message::SearchSubmit => self.balance.search_submit(),
-            Message::SearchCancel => self.balance.search_cancel(),
-            Message::SearchClose => self.balance.search_close(),
-            Message::SearchNext => self.balance.search_next(),
-            Message::SearchPrev => self.balance.search_prev(),
             Message::Reload => return Some(Command::Reload),
-            Message::ToggleTree => {
-                if matches!(self.screen, Screen::Balance) {
-                    self.balance.toggle_tree();
-                }
-            }
-            Message::ToggleFold => {
-                if matches!(self.screen, Screen::Balance) {
-                    self.balance.fold_selected();
-                }
-            }
-            Message::ToggleFoldAll => {
-                if matches!(self.screen, Screen::Balance) {
-                    self.balance.fold_all();
-                }
-            }
             // Already handled above, or only meaningful while an overlay is up.
             Message::QuitImmediate
             | Message::ConfirmQuit
@@ -364,13 +269,11 @@ mod tests {
     use assert_matches::assert_matches;
     use bumpalo::Bump;
     use chrono::NaiveDate;
-    use indoc::indoc;
     use okane_core::report::{Account, Amount, ReportContext};
-    use rust_decimal_macros::dec;
 
     use crate::ui::table::TableNav;
 
-    use super::super::balance::{BalanceRow, DisplayMode, amount_line_count, restore_index};
+    use super::super::balance::BalanceRow;
     use super::super::overlay::ErrorPopup;
     use super::super::testing::{make_account, process, template};
 
@@ -416,346 +319,6 @@ mod tests {
     }
 
     #[test]
-    fn start_search_records_origin() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::MoveDown);
-        app.update(Message::MoveDown);
-        assert_eq!(selected(&app), Some(2));
-        app.update(Message::StartModalSearch);
-        let search = app.balance.search.as_ref().expect("search active");
-        assert_eq!(
-            search.intent.mode,
-            SearchMode::Modal(SearchPhase::Incremental)
-        );
-        assert_eq!(search.intent.origin, 2);
-        assert!(search.intent.input.is_empty());
-        assert!(search.matched_rows().is_empty());
-    }
-
-    #[test]
-    fn incremental_jumps_to_first_match_at_or_after_origin() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        // Origin at index 1.
-        app.update(Message::MoveDown);
-        app.update(Message::StartModalSearch);
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        let search = app.balance.search.as_ref().unwrap();
-        assert_eq!(search.matched_rows(), [0, 1]);
-        assert_matches!(search.err(), None);
-        // First match at-or-after origin 1 is 1.
-        assert_eq!(selected(&app), Some(1));
-    }
-
-    #[test]
-    fn incremental_wraps_when_no_match_after_origin() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        // Origin at index 3 — no "assets" match at-or-after, so wrap to 0.
-        for _ in 0..3 {
-            app.update(Message::MoveDown);
-        }
-        app.update(Message::StartModalSearch);
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        assert_eq!(app.balance.search.as_ref().unwrap().matched_rows(), [0, 1]);
-        assert_eq!(selected(&app), Some(0));
-    }
-
-    #[test]
-    fn incremental_invalid_regex_sets_error() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        app.update(Message::SearchPush('['));
-        let search = app.balance.search.as_ref().unwrap();
-        assert_matches!(search.err(), Some(_));
-        assert!(search.matched_rows().is_empty());
-    }
-
-    #[test]
-    fn backspace_recomputes_matches() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        for c in "cash".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        assert_eq!(app.balance.search.as_ref().unwrap().matched_rows(), [1]);
-        // Backspace down to "ca" — matches "Assets:Cash" and "Liabilities:Card".
-        app.update(Message::SearchPop);
-        app.update(Message::SearchPop);
-        assert_eq!(app.balance.search.as_ref().unwrap().matched_rows(), [1, 4]);
-    }
-
-    #[test]
-    fn submit_empty_exits_search() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        app.update(Message::SearchSubmit);
-        assert!(app.balance.search.is_none());
-    }
-
-    #[test]
-    fn submit_nonempty_enters_fixed_phase() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        app.update(Message::SearchPush('a'));
-        app.update(Message::SearchSubmit);
-        assert_eq!(
-            app.balance.search.as_ref().unwrap().intent.mode,
-            SearchMode::Modal(SearchPhase::Fixed)
-        );
-    }
-
-    #[test]
-    fn isearch_forward_jumps_and_repeats() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-
-        app.update(Message::StartISearch(SearchDirection::Forward));
-
-        let search = app.balance.search.as_ref().unwrap();
-        assert_eq!(search.intent.mode, SearchMode::Interactive);
-        assert_eq!(search.intent.dir, SearchDirection::Forward);
-
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
-        }
-
-        // First forward match at-or-after origin 0.
-        assert_eq!(app.balance.search.as_ref().unwrap().matched_rows(), [0, 1]);
-        assert_eq!(selected(&app), Some(0));
-        // C-s repeats forward, wrapping.
-        app.update(Message::SearchNext);
-        assert_eq!(selected(&app), Some(1));
-        app.update(Message::SearchNext);
-        assert_eq!(selected(&app), Some(0));
-    }
-
-    #[test]
-    fn isearch_backward_jumps_to_last_match() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        // Start at the last row so a backward search lands on the prior match.
-        app.update(Message::SelectLast);
-        app.update(Message::StartISearch(SearchDirection::Backward));
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        // Last match at-or-before origin 4 is index 1.
-        assert_eq!(selected(&app), Some(1));
-        // C-r repeats backward.
-        app.update(Message::SearchPrev);
-        assert_eq!(selected(&app), Some(0));
-    }
-
-    #[test]
-    fn isearch_repeat_direction_steers_later_input() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(
-            &arena,
-            &["Assets:A", "Bonds:x", "Assets:B", "Bonds:y", "Assets:C"],
-        );
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c)); // matches [0, 2, 4], at 0
-        }
-        assert_eq!(selected(&app), Some(0));
-        app.update(Message::SearchPrev); // C-r → backward, wraps to last match 4
-        assert_eq!(selected(&app), Some(4));
-        // Backspace keeps the backward direction: from point 4, last match <= 4.
-        app.update(Message::SearchPop); // "asset" still matches [0, 2, 4]
-        assert_eq!(selected(&app), Some(4));
-    }
-
-    #[test]
-    fn isearch_cancel_restores_origin() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::MoveDown);
-        app.update(Message::MoveDown); // origin 2
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c)); // jumps to 0
-        }
-        app.update(Message::SearchCancel);
-        assert!(app.balance.search.is_none());
-        assert_eq!(selected(&app), Some(2));
-    }
-
-    #[test]
-    fn search_pattern_is_remembered_for_recall() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        // Run and close a modal search to populate the last-used pattern.
-        app.update(Message::StartModalSearch);
-        for c in "salary".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        app.update(Message::SearchSubmit); // → fixed
-        app.update(Message::SearchClose);
-        assert_eq!(&app.balance.last_search, "salary");
-
-        // A fresh interactive search with an empty pattern recalls it on C-s.
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        app.update(Message::SearchNext);
-        let search = app.balance.search.as_ref().unwrap();
-        assert_eq!(search.intent.input, "salary");
-        assert!(!search.intent.no_previous);
-        assert_eq!(search.matched_rows(), [3]);
-        assert_eq!(selected(&app), Some(3));
-    }
-
-    #[test]
-    fn isearch_recall_without_history_shows_notice() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        // No previous search: C-s flips on the notice and waits for input.
-        app.update(Message::SearchNext);
-        let search = app.balance.search.as_ref().unwrap();
-        assert!(search.intent.no_previous);
-        assert!(search.intent.input.is_empty());
-        // Typing clears the notice and resumes a normal search.
-        app.update(Message::SearchPush('a'));
-        assert!(!app.balance.search.as_ref().unwrap().intent.no_previous);
-    }
-
-    #[test]
-    fn isearch_move_ends_search_and_navigates() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c)); // matches [0, 1], selection 0
-        }
-        // C-n (MoveDown) ends the i-search and moves one row down.
-        app.update(Message::MoveDown);
-        assert!(app.balance.search.is_none());
-        assert_eq!(selected(&app), Some(1));
-        // The pattern is remembered for later recall.
-        assert_eq!(&app.balance.last_search, "assets");
-    }
-
-    #[test]
-    fn isearch_enter_opens_register_and_ends_search() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        for c in "salary".chars() {
-            app.update(Message::SearchPush(c)); // selection 3
-        }
-        let cmd = app.update(Message::OpenRegister);
-        assert_matches!(cmd, Some(Command::LoadRegister { .. }));
-        assert!(app.balance.search.is_none());
-        assert_eq!(selected(&app), Some(3));
-    }
-
-    #[test]
-    fn modal_fixed_search_survives_navigation() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        app.update(Message::SearchSubmit); // fixed
-        // Unlike i-search, a modal search stays active during navigation.
-        app.update(Message::MoveDown);
-        assert!(app.balance.search.is_some());
-    }
-
-    #[test]
-    fn isearch_recall_backward_sets_direction() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.balance.last_search = "assets".to_owned();
-        app.update(Message::SelectLast); // origin 4
-        app.update(Message::StartISearch(SearchDirection::Forward));
-        // C-r on empty: recall + search backward from origin → last match (1).
-        app.update(Message::SearchPrev);
-        let search = app.balance.search.as_ref().unwrap();
-        assert_eq!(search.intent.input, "assets");
-        assert_eq!(search.intent.mode, SearchMode::Interactive);
-        assert_eq!(search.intent.dir, SearchDirection::Backward);
-        assert_eq!(selected(&app), Some(1));
-    }
-
-    #[test]
-    fn cancel_restores_origin() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::MoveDown);
-        app.update(Message::MoveDown); // origin = 2
-        app.update(Message::StartModalSearch);
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c)); // jumps selection to 0
-        }
-        assert_eq!(selected(&app), Some(0));
-        app.update(Message::SearchCancel);
-        assert!(app.balance.search.is_none());
-        assert_eq!(selected(&app), Some(2));
-    }
-
-    #[test]
-    fn close_keeps_selection() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        for c in "salary".chars() {
-            app.update(Message::SearchPush(c));
-        }
-        app.update(Message::SearchSubmit); // fixed; selection at the match (3)
-        assert_eq!(selected(&app), Some(3));
-        app.update(Message::SearchClose);
-        assert!(app.balance.search.is_none());
-        assert_eq!(selected(&app), Some(3));
-    }
-
-    #[test]
-    fn search_next_prev_wrap_over_matches() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
-        for c in "assets".chars() {
-            app.update(Message::SearchPush(c)); // matches [0, 1], selection 0
-        }
-        app.update(Message::SearchSubmit);
-        assert_eq!(selected(&app), Some(0));
-        app.update(Message::SearchNext);
-        assert_eq!(selected(&app), Some(1));
-        app.update(Message::SearchNext); // wrap
-        assert_eq!(selected(&app), Some(0));
-        app.update(Message::SearchPrev); // wrap backward
-        assert_eq!(selected(&app), Some(1));
-    }
-
-    #[test]
-    fn amount_line_count_zero_amount_is_one() {
-        let amount = Amount::zero();
-        assert_eq!(amount_line_count(&amount), 1);
-    }
-
-    #[test]
-    fn amount_line_count_matches_commodity_count() {
-        let arena = Bump::new();
-        let mut ctx = ReportContext::new(&arena);
-        let usd = ctx.commodity_store_mut().ensure("USD");
-        let eur = ctx.commodity_store_mut().ensure("EUR");
-        let one = Amount::from_value(usd, dec!(1));
-        let two = Amount::from_value(usd, dec!(1)) + Amount::from_value(eur, dec!(2));
-        assert_eq!(amount_line_count(&one), 1);
-        assert_eq!(amount_line_count(&two), 2);
-    }
-
-    #[test]
     fn request_quit_on_balance_opens_overlay() {
         let mut app = app_no_rows();
         assert!(app.update(Message::RequestQuit).is_none());
@@ -792,7 +355,10 @@ mod tests {
     #[test]
     fn open_register_with_no_selection_is_noop() {
         let mut app = app_no_rows();
-        assert!(app.update(Message::OpenRegister).is_none());
+        assert!(
+            app.update(Message::Balance(BalanceMessage::OpenRegister))
+                .is_none()
+        );
         assert!(matches!(app.screen, Screen::Balance));
     }
 
@@ -802,7 +368,7 @@ mod tests {
         // Pretend there are rows to move through by poking the nav directly.
         app.balance.nav = TableNav::new(3);
         app.update(Message::RequestQuit);
-        app.update(Message::MoveDown);
+        app.update(Message::Balance(BalanceMessage::MoveDown));
         assert_eq!(app.balance.nav.table_state.selected(), Some(0));
     }
 
@@ -835,7 +401,7 @@ mod tests {
     fn error_modal_survives_key_that_clears_footer_notice() {
         let mut app = app_with_error_modal();
         app.error_toast = Some("transient".to_owned());
-        app.update(Message::MoveDown);
+        app.update(Message::Balance(BalanceMessage::MoveDown));
         assert!(app.error_toast.is_none());
         assert_matches!(app.overlay, Some(Overlay::Error(_)));
     }
@@ -901,33 +467,6 @@ mod tests {
     }
 
     #[test]
-    fn restore_index_prefers_exact_match() {
-        let arena = Bump::new();
-        let (ctx, _app) = make_balance_app(&arena, ACCOUNTS);
-        let rows = rows_of(&ctx, ACCOUNTS);
-        assert_eq!(restore_index("Expenses:Food", &rows), Some(2));
-    }
-
-    #[test]
-    fn restore_index_falls_back_to_insertion_point() {
-        let arena = Bump::new();
-        let (ctx, _app) = make_balance_app(&arena, ACCOUNTS);
-        let rows = rows_of(&ctx, ACCOUNTS);
-        // Between Assets:Cash (1) and Expenses:Food (2).
-        assert_eq!(restore_index("Assets:Extra", &rows), Some(2));
-        // Before every row.
-        assert_eq!(restore_index("Aaa", &rows), Some(0));
-        // Past the last row, clamped.
-        assert_eq!(restore_index("Zzz", &rows), Some(4));
-    }
-
-    #[test]
-    fn restore_index_empty_rows_is_none() {
-        let rows: &[BalanceRow<'_>] = &[];
-        assert_eq!(restore_index("Assets:Bank", rows), None);
-    }
-
-    #[test]
     fn reload_message_produces_command() {
         let mut app = app_no_rows();
         assert_matches!(app.update(Message::Reload), Some(Command::Reload));
@@ -937,7 +476,7 @@ mod tests {
     fn any_key_clears_error_notice() {
         let mut app = app_no_rows();
         app.error_toast = Some("boom".to_owned());
-        app.update(Message::MoveDown);
+        app.update(Message::Balance(BalanceMessage::MoveDown));
         assert_eq!(app.error_toast, None);
     }
 
@@ -1004,11 +543,11 @@ mod tests {
     fn restore_recomputes_search_matches() {
         let arena = Bump::new();
         let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.update(Message::StartModalSearch);
+        app.update(Message::Balance(BalanceMessage::StartModalSearch));
         for c in "assets".chars() {
-            app.update(Message::SearchPush(c));
+            app.update(Message::Balance(BalanceMessage::SearchPush(c)));
         }
-        app.update(Message::SearchSubmit); // fixed
+        app.update(Message::Balance(BalanceMessage::SearchSubmit)); // fixed
         assert_eq!(app.balance.search.as_ref().unwrap().matched_rows(), [0, 1]);
         app.balance.last_search = "salary".to_owned();
         let snapshot = app.snapshot();
@@ -1095,179 +634,5 @@ mod tests {
         // From register, q/Esc leaves to balance (mapped at the event layer)
         // rather than opening the quit overlay.
         assert_eq!(app.overlay, None);
-    }
-
-    /// A ledger with a small nested hierarchy:
-    /// `Assets:Bank:Checking`, `Assets:Cash`, `Expenses:Food`, `Equity`.
-    const TREE_LEDGER: &str = indoc! {"
-        2024/01/01 Init
-            Assets:Bank:Checking    10 USD
-            Assets:Cash    5 USD
-            Expenses:Food    3 USD
-            Equity
-    "};
-
-    /// Builds a tree-backed app from ledger `content`, in the flat default mode.
-    fn tree_app<'ctx>(arena: &'ctx Bump, content: &str) -> (ReportContext<'ctx>, App<'ctx>) {
-        use okane_core::report::BalanceTree;
-        use okane_core::report::query::BalanceQuery;
-
-        let (ctx, mut ledger) = process(arena, content);
-        let balance = ledger
-            .balance(&ctx, &BalanceQuery::default())
-            .unwrap()
-            .into_owned();
-        let tree = BalanceTree::create(&ctx, balance).unwrap().into_nodes();
-        let app = App::new("test".to_owned(), tree, template());
-        (ctx, app)
-    }
-
-    fn row_labels(app: &App<'_>) -> Vec<String> {
-        app.balance.rows
-            .iter()
-            .map(|r| r.label.to_owned())
-            .collect()
-    }
-
-    fn full_names(app: &App<'_>) -> Vec<String> {
-        app.balance.rows
-            .iter()
-            .map(|r| r.full_name().to_owned())
-            .collect()
-    }
-
-    #[test]
-    fn flat_mode_shows_only_posted_accounts() {
-        let arena = Bump::new();
-        let (_ctx, app) = tree_app(&arena, TREE_LEDGER);
-        // Ancestor-only nodes (Assets, Assets:Bank, Expenses) have a zero own
-        // amount and are hidden; every posted account is shown, full-name.
-        assert_eq!(
-            full_names(&app),
-            [
-                "Assets:Bank:Checking",
-                "Assets:Cash",
-                "Equity",
-                "Expenses:Food",
-            ]
-        );
-    }
-
-    #[test]
-    fn toggle_tree_shows_hierarchy_with_leaf_labels() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        // Flat rows 0/1 are Assets:Bank:Checking (10 USD) and Assets:Cash (5 USD).
-        let checking = app.balance.rows[0].amount.clone();
-        let cash = app.balance.rows[1].amount.clone();
-        app.update(Message::ToggleTree);
-        assert_eq!(app.balance.mode, DisplayMode::Tree);
-        // Pre-order over the whole hierarchy, leaf labels, ancestors included.
-        assert_eq!(
-            full_names(&app),
-            [
-                "Assets",
-                "Assets:Bank",
-                "Assets:Bank:Checking",
-                "Assets:Cash",
-                "Equity",
-                "Expenses",
-                "Expenses:Food",
-            ]
-        );
-        assert_eq!(
-            row_labels(&app),
-            [
-                "Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"
-            ]
-        );
-        // Depth drives indentation: Assets is depth 1, Checking depth 3.
-        assert_eq!(app.balance.rows[0].depth, 1);
-        assert!(app.balance.rows[0].has_children);
-        assert_eq!(app.balance.rows[2].depth, 3);
-        assert!(!app.balance.rows[2].has_children);
-        // Tree view shows subtree totals: Assets rolls up Checking + Cash.
-        assert_eq!(app.balance.rows[0].amount, checking + cash);
-        // Back to flat.
-        app.update(Message::ToggleTree);
-        assert_eq!(app.balance.mode, DisplayMode::Flat);
-        assert_eq!(app.balance.rows.len(), 4);
-    }
-
-    #[test]
-    fn toggle_fold_hides_selected_subtree() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        app.update(Message::ToggleTree);
-        app.balance.nav.select(0); // Assets
-        app.update(Message::ToggleFold);
-        // Assets is folded: its Bank/Checking/Cash descendants disappear.
-        assert_eq!(
-            full_names(&app),
-            ["Assets", "Equity", "Expenses", "Expenses:Food"]
-        );
-        assert!(app.balance.rows[0].folded);
-        // Selection stays on the fold point.
-        assert_eq!(app.balance.nav.table_state.selected(), Some(0));
-        // Unfolding restores the descendants.
-        app.update(Message::ToggleFold);
-        assert!(!app.balance.rows[0].folded);
-        assert_eq!(app.balance.rows.len(), 7);
-    }
-
-    #[test]
-    fn toggle_fold_all_collapses_then_expands() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        app.update(Message::ToggleTree);
-        app.update(Message::ToggleFoldAll);
-        // Every foldable node collapses: only top-level rows remain.
-        assert_eq!(full_names(&app), ["Assets", "Equity", "Expenses"]);
-        app.update(Message::ToggleFoldAll);
-        assert_eq!(app.balance.rows.len(), 7);
-    }
-
-    #[test]
-    fn tree_open_register_drills_into_subtree() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        app.update(Message::ToggleTree);
-        app.balance.nav.select(0); // Assets
-        let cmd = app.update(Message::OpenRegister);
-        assert_matches!(
-            cmd,
-            Some(Command::LoadRegister { scope: RegisterScope::Subtree(agg) }) if agg.as_str() == "Assets"
-        );
-    }
-
-    #[test]
-    fn flat_open_register_drills_into_single_account() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        app.balance.nav.select(1); // Assets:Cash
-        let cmd = app.update(Message::OpenRegister);
-        assert_matches!(
-            cmd,
-            Some(Command::LoadRegister { scope: RegisterScope::Single(account) }) if account.as_str() == "Assets:Cash"
-        );
-    }
-
-    #[test]
-    fn tree_state_survives_snapshot_restore() {
-        let arena = Bump::new();
-        let (_ctx, mut app) = tree_app(&arena, TREE_LEDGER);
-        app.update(Message::ToggleTree);
-        app.balance.nav.select(0); // Assets
-        app.update(Message::ToggleFold); // fold Assets
-        let snapshot = app.snapshot();
-
-        let (_ctx2, mut app2) = tree_app(&arena, TREE_LEDGER);
-        assert_matches!(app2.restore(&snapshot), None);
-        assert_eq!(app2.balance.mode, DisplayMode::Tree);
-        assert_eq!(
-            full_names(&app2),
-            ["Assets", "Equity", "Expenses", "Expenses:Food"]
-        );
-        assert!(app2.balance.rows[0].folded);
     }
 }

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -271,7 +271,7 @@ mod tests {
     use chrono::NaiveDate;
     use okane_core::report::{Account, Amount, ReportContext};
 
-    use crate::ui::table::TableNav;
+    use crate::ui::table::{NavCommand, TableNav};
 
     use super::super::balance::BalanceRow;
     use super::super::overlay::ErrorPopup;
@@ -368,7 +368,7 @@ mod tests {
         // Pretend there are rows to move through by poking the nav directly.
         app.balance.nav = TableNav::new(3);
         app.update(Message::RequestQuit);
-        app.update(Message::Balance(BalanceMessage::MoveDown));
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
         assert_eq!(app.balance.nav.table_state.selected(), Some(0));
     }
 
@@ -401,7 +401,7 @@ mod tests {
     fn error_modal_survives_key_that_clears_footer_notice() {
         let mut app = app_with_error_modal();
         app.error_toast = Some("transient".to_owned());
-        app.update(Message::Balance(BalanceMessage::MoveDown));
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
         assert!(app.error_toast.is_none());
         assert_matches!(app.overlay, Some(Overlay::Error(_)));
     }
@@ -476,7 +476,7 @@ mod tests {
     fn any_key_clears_error_notice() {
         let mut app = app_no_rows();
         app.error_toast = Some("boom".to_owned());
-        app.update(Message::Balance(BalanceMessage::MoveDown));
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
         assert_eq!(app.error_toast, None);
     }
 

--- a/cli/src/ui/report/balance.rs
+++ b/cli/src/ui/report/balance.rs
@@ -11,10 +11,12 @@
 use std::cmp::min;
 use std::collections::HashSet;
 
+use crossterm::event::{KeyCode, KeyEvent};
 #[cfg(test)]
 use okane_core::report::Account;
 use okane_core::report::{AccountAggregate, AccountTreeKey, Amount, BalanceTreeNode};
 
+use crate::ui::keys::is_ctrl;
 use crate::ui::table::TableNav;
 
 use super::register::{OwnedRegisterScope, RegisterScope};
@@ -128,6 +130,51 @@ pub struct BalanceSnapshot {
     folded: Vec<String>,
 }
 
+/// Messages handled by the balance screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BalanceMessage {
+    MoveUp,
+    MoveDown,
+    PageUp,
+    PageDown,
+    SelectFirst,
+    SelectLast,
+    /// Toggle between the flat list and the account tree (`t`).
+    ToggleTree,
+    /// Fold/unfold the selected tree node (`space`).
+    ToggleFold,
+    /// Fold or unfold every node in the tree (`x`).
+    ToggleFoldAll,
+    /// Drill into the selected balance row's register.
+    OpenRegister,
+    /// Open the modal (`/`) search bar (incremental phase).
+    StartModalSearch,
+    /// Open an interactive (`C-s`/`C-r`) search in the given direction.
+    StartISearch(SearchDirection),
+    /// Append a character to the search pattern.
+    SearchPush(char),
+    /// Remove the last character from the search pattern.
+    SearchPop,
+    /// Fix the current pattern (modal incremental → fixed); empty pattern exits.
+    SearchSubmit,
+    /// Cancel an editing search: restore the origin selection and exit.
+    SearchCancel,
+    /// Close the search: keep the current selection.
+    SearchClose,
+    /// Next match (modal `n` / interactive `C-s`).
+    SearchNext,
+    /// Previous match (modal `N` / interactive `C-r`).
+    SearchPrev,
+}
+
+/// Effect a [`BalanceView`] asks the [`App`](super::app::App) to perform;
+/// everything else is handled inside the view.
+#[derive(Debug, Clone, Copy)]
+pub enum BalanceAction<'ctx> {
+    /// Drill into the register for `scope` (App loads the rows via the Ledger).
+    OpenRegister { scope: RegisterScope<'ctx> },
+}
+
 /// State for the balance screen: the account tree, the rows derived from it,
 /// the display mode and fold state, and the active account search.
 #[derive(Debug)]
@@ -200,8 +247,133 @@ impl<'ctx> BalanceView<'ctx> {
     }
 
     /// The drill target of the currently-selected balance row, if any.
-    pub(super) fn selected_scope(&self) -> Option<RegisterScope<'ctx>> {
+    fn selected_scope(&self) -> Option<RegisterScope<'ctx>> {
         self.selected_row().map(|r| r.scope)
+    }
+
+    /// Applies a [`BalanceMessage`], returning a [`BalanceAction`] for the
+    /// cross-screen transitions the view cannot perform itself.
+    pub(super) fn update(&mut self, msg: BalanceMessage) -> Option<BalanceAction<'ctx>> {
+        match msg {
+            BalanceMessage::MoveUp => {
+                self.end_interactive_search();
+                self.nav.move_selection(-1);
+            }
+            BalanceMessage::MoveDown => {
+                self.end_interactive_search();
+                self.nav.move_selection(1);
+            }
+            BalanceMessage::PageUp => {
+                let delta = -(self.nav.page_size() as isize);
+                self.nav.move_selection(delta);
+            }
+            BalanceMessage::PageDown => {
+                let delta = self.nav.page_size() as isize;
+                self.nav.move_selection(delta);
+            }
+            BalanceMessage::SelectFirst => self.nav.select_first(),
+            BalanceMessage::SelectLast => self.nav.select_last(),
+            BalanceMessage::OpenRegister => {
+                if let Some(scope) = self.selected_scope() {
+                    // An interactive search drills in like the normal view:
+                    // end the search, keeping the cursor on the chosen account.
+                    self.end_interactive_search();
+                    return Some(BalanceAction::OpenRegister { scope });
+                }
+            }
+            BalanceMessage::StartModalSearch => self.start_search(
+                SearchMode::Modal(SearchPhase::Incremental),
+                SearchDirection::Forward,
+            ),
+            BalanceMessage::StartISearch(dir) => self.start_search(SearchMode::Interactive, dir),
+            BalanceMessage::SearchPush(c) => self.search_push(c),
+            BalanceMessage::SearchPop => self.search_pop(),
+            BalanceMessage::SearchSubmit => self.search_submit(),
+            BalanceMessage::SearchCancel => self.search_cancel(),
+            BalanceMessage::SearchClose => self.search_close(),
+            BalanceMessage::SearchNext => self.search_next(),
+            BalanceMessage::SearchPrev => self.search_prev(),
+            BalanceMessage::ToggleTree => self.toggle_tree(),
+            BalanceMessage::ToggleFold => self.fold_selected(),
+            BalanceMessage::ToggleFoldAll => self.fold_all(),
+        }
+        None
+    }
+
+    /// Translates a key event into a [`BalanceMessage`]. The editing search
+    /// phases own every key; otherwise navigation and the balance actions map
+    /// as usual. Global keys (quit, reload) return `None` for [`super::event`]
+    /// to handle.
+    pub(super) fn key_to_message(&self, key: KeyEvent) -> Option<BalanceMessage> {
+        let ctrl = is_ctrl(key.modifiers);
+
+        // Search capture. The editing phases (modal incremental, interactive
+        // i-search) own every key; the modal fixed phase intercepts only its
+        // own controls and lets the rest fall through so full navigation (and
+        // Enter-to-register) keep working.
+        if let Some(search) = &self.search {
+            match search.intent.mode {
+                SearchMode::Modal(SearchPhase::Incremental) => {
+                    return match key.code {
+                        KeyCode::Esc => Some(BalanceMessage::SearchCancel),
+                        KeyCode::Enter => Some(BalanceMessage::SearchSubmit),
+                        KeyCode::Backspace => Some(BalanceMessage::SearchPop),
+                        KeyCode::Char(c) if !ctrl => Some(BalanceMessage::SearchPush(c)),
+                        _ => None,
+                    };
+                }
+                SearchMode::Modal(SearchPhase::Fixed) => match key.code {
+                    KeyCode::Esc => return Some(BalanceMessage::SearchClose),
+                    KeyCode::Char('n') => return Some(BalanceMessage::SearchNext),
+                    KeyCode::Char('N') => return Some(BalanceMessage::SearchPrev),
+                    _ => {} // fall through to normal UI
+                },
+                SearchMode::Interactive => match key.code {
+                    KeyCode::Char('s') if ctrl => return Some(BalanceMessage::SearchNext),
+                    KeyCode::Char('r') if ctrl => return Some(BalanceMessage::SearchPrev),
+                    KeyCode::Char('g') if ctrl => return Some(BalanceMessage::SearchCancel),
+                    KeyCode::Esc => return Some(BalanceMessage::SearchCancel),
+                    KeyCode::Backspace => return Some(BalanceMessage::SearchPop),
+                    KeyCode::Char(c) if !ctrl => return Some(BalanceMessage::SearchPush(c)),
+                    _ => {} // fall through to normal UI
+                },
+            }
+        }
+
+        // Navigation.
+        let nav = match key.code {
+            KeyCode::Up | KeyCode::Char('k') => Some(BalanceMessage::MoveUp),
+            KeyCode::Char('p') if ctrl => Some(BalanceMessage::MoveUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(BalanceMessage::MoveDown),
+            KeyCode::Char('n') if ctrl => Some(BalanceMessage::MoveDown),
+            KeyCode::PageUp => Some(BalanceMessage::PageUp),
+            KeyCode::Char('b') if ctrl => Some(BalanceMessage::PageUp),
+            KeyCode::PageDown => Some(BalanceMessage::PageDown),
+            KeyCode::Char('f') if ctrl => Some(BalanceMessage::PageDown),
+            KeyCode::Home | KeyCode::Char('g') => Some(BalanceMessage::SelectFirst),
+            KeyCode::End | KeyCode::Char('G') => Some(BalanceMessage::SelectLast),
+            _ => None,
+        };
+        if nav.is_some() {
+            return nav;
+        }
+
+        // Balance-specific actions.
+        match key.code {
+            KeyCode::Char('/') => Some(BalanceMessage::StartModalSearch),
+            KeyCode::Char('s') if ctrl => {
+                Some(BalanceMessage::StartISearch(SearchDirection::Forward))
+            }
+            KeyCode::Char('r') if ctrl => {
+                Some(BalanceMessage::StartISearch(SearchDirection::Backward))
+            }
+            KeyCode::Char('t') => Some(BalanceMessage::ToggleTree),
+            KeyCode::Char(' ') => Some(BalanceMessage::ToggleFold),
+            KeyCode::Char('x') => Some(BalanceMessage::ToggleFoldAll),
+            KeyCode::Enter => Some(BalanceMessage::OpenRegister),
+            // q/Esc (quit) and r/F5 (reload) are handled by `super::event`.
+            _ => None,
+        }
     }
 
     /// Recomputes [`Self::rows`] from the tree for the current mode and fold
@@ -320,7 +492,7 @@ impl<'ctx> BalanceView<'ctx> {
     /// Toggles between the flat list and the account tree, dropping any active
     /// search (row identity changes between modes, so stale match indices must
     /// not carry over the reshape) and rebuilding the rows.
-    pub(super) fn toggle_tree(&mut self) {
+    fn toggle_tree(&mut self) {
         self.search = None;
         self.mode = match self.mode {
             DisplayMode::Flat => DisplayMode::Tree,
@@ -331,14 +503,14 @@ impl<'ctx> BalanceView<'ctx> {
 
     /// Folds/unfolds the selected node (tree view only, and only when it has
     /// children), rebuilds the rows, then recomputes the active search.
-    pub(super) fn fold_selected(&mut self) {
+    fn fold_selected(&mut self) {
         self.toggle_fold_selected();
         self.recompute_search();
     }
 
     /// Folds or unfolds every node (tree view only), rebuilds the rows, then
     /// recomputes the active search.
-    pub(super) fn fold_all(&mut self) {
+    fn fold_all(&mut self) {
         self.toggle_fold_all();
         self.recompute_search();
     }
@@ -478,7 +650,7 @@ impl<'ctx> BalanceView<'ctx> {
 
     /// Opens a search of the given style, recording the current selection as
     /// the origin.
-    pub(super) fn start_search(&mut self, mode: SearchMode, dir: SearchDirection) {
+    fn start_search(&mut self, mode: SearchMode, dir: SearchDirection) {
         let origin = self.nav.table_state.selected().unwrap_or(0);
         self.search = Some(Search {
             intent: SearchIntent {
@@ -493,7 +665,7 @@ impl<'ctx> BalanceView<'ctx> {
     }
 
     /// Appends a character to the active search pattern and recomputes matches.
-    pub(super) fn search_push(&mut self, c: char) {
+    fn search_push(&mut self, c: char) {
         if let Some(search) = self.search.as_mut() {
             search.intent.input.push(c);
             search.intent.no_previous = false;
@@ -502,7 +674,7 @@ impl<'ctx> BalanceView<'ctx> {
     }
 
     /// Removes the last character from the active search pattern and recomputes.
-    pub(super) fn search_pop(&mut self) {
+    fn search_pop(&mut self) {
         if let Some(search) = self.search.as_mut() {
             search.intent.input.pop();
             search.intent.no_previous = false;
@@ -512,7 +684,7 @@ impl<'ctx> BalanceView<'ctx> {
 
     /// Fixes the current pattern (modal incremental → fixed); an empty pattern
     /// exits the search instead.
-    pub(super) fn search_submit(&mut self) {
+    fn search_submit(&mut self) {
         match &self.search {
             // If empty pattern submitted, simply exits the search mode.
             Some(s) if s.intent.input.is_empty() => self.search = None,
@@ -529,7 +701,7 @@ impl<'ctx> BalanceView<'ctx> {
     }
 
     /// Cancels an editing search: restores the origin selection and exits.
-    pub(super) fn search_cancel(&mut self) {
+    fn search_cancel(&mut self) {
         if let Some(search) = self.search.take() {
             // on cancel, search query won't be saved.
             self.nav.select(search.intent.origin);
@@ -537,26 +709,26 @@ impl<'ctx> BalanceView<'ctx> {
     }
 
     /// Closes the search, keeping the current selection.
-    pub(super) fn search_close(&mut self) {
+    fn search_close(&mut self) {
         self.search = None;
     }
 
     /// Next match (modal `n`); or, for interactive search, repeat forward /
     /// recall the previous pattern when empty (`C-s`).
-    pub(super) fn search_next(&mut self) {
+    fn search_next(&mut self) {
         self.search_or_recall(SearchDirection::Forward);
     }
 
     /// Previous match (modal `N`); or, for interactive search, repeat backward
     /// / recall the previous pattern when empty (`C-r`).
-    pub(super) fn search_prev(&mut self) {
+    fn search_prev(&mut self) {
         self.search_or_recall(SearchDirection::Backward);
     }
 
     /// Ends an active interactive search, keeping the current selection. Used
     /// by keys that both navigate and leave i-search (`C-n`/`C-p`, Enter). A
     /// no-op for modal searches, which stay active during navigation.
-    pub(super) fn end_interactive_search(&mut self) {
+    fn end_interactive_search(&mut self) {
         if self
             .search
             .as_ref()
@@ -622,7 +794,7 @@ impl<'ctx> BalanceView<'ctx> {
     /// Modal searches always jump relative to the fixed origin; interactive
     /// searches jump relative to the current point, mirroring isearch. No-op
     /// when no search is active.
-    pub(super) fn recompute_search(&mut self) {
+    fn recompute_search(&mut self) {
         let Some(search) = self.search.as_mut() else {
             return;
         };
@@ -656,4 +828,734 @@ pub(super) fn restore_index(prev_name: &str, rows: &[BalanceRow<'_>]) -> Option<
         .binary_search_by(|r| r.full_name().cmp(prev_name))
         .unwrap_or_else(|insertion| insertion);
     Some(min(idx, last))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use bumpalo::Bump;
+    use crossterm::event::KeyModifiers;
+    use indoc::indoc;
+    use okane_core::report::ReportContext;
+    use rust_decimal_macros::dec;
+
+    use super::super::testing::process;
+
+    const ACCOUNTS: &[&str] = &[
+        "Assets:Bank",      // 0
+        "Assets:Cash",      // 1
+        "Expenses:Food",    // 2
+        "Income:Salary",    // 3
+        "Liabilities:Card", // 4
+    ];
+
+    /// A ledger with a small nested hierarchy:
+    /// `Assets:Bank:Checking`, `Assets:Cash`, `Expenses:Food`, `Equity`.
+    const TREE_LEDGER: &str = indoc! {"
+        2024/01/01 Init
+            Assets:Bank:Checking    10 USD
+            Assets:Cash    5 USD
+            Expenses:Food    3 USD
+            Equity
+    "};
+
+    /// Balance rows for `names`, in order, with zero amounts (no backing tree).
+    fn rows_of<'ctx>(ctx: &ReportContext<'ctx>, names: &[&str]) -> Vec<BalanceRow<'ctx>> {
+        names
+            .iter()
+            .map(|n| BalanceRow::flat(ctx.account(n).unwrap(), Amount::zero()))
+            .collect()
+    }
+
+    /// A [`BalanceView`] whose rows are `names`, in order, with no backing tree.
+    fn view_from_names<'ctx>(
+        arena: &'ctx Bump,
+        names: &[&str],
+    ) -> (ReportContext<'ctx>, BalanceView<'ctx>) {
+        let mut content = String::from("2024/01/01 Init\n");
+        for name in names {
+            content.push_str(&format!("    {name}    1 USD\n"));
+        }
+        content.push_str("    Equity\n");
+        let (ctx, _ledger) = process(arena, &content);
+        let view = BalanceView::with_rows(rows_of(&ctx, names));
+        (ctx, view)
+    }
+
+    /// A tree-backed [`BalanceView`] from ledger `content`, in flat mode.
+    fn tree_view<'ctx>(
+        arena: &'ctx Bump,
+        content: &str,
+    ) -> (ReportContext<'ctx>, BalanceView<'ctx>) {
+        use okane_core::report::BalanceTree;
+        use okane_core::report::query::BalanceQuery;
+
+        let (ctx, mut ledger) = process(arena, content);
+        let balance = ledger
+            .balance(&ctx, &BalanceQuery::default())
+            .unwrap()
+            .into_owned();
+        let tree = BalanceTree::create(&ctx, balance).unwrap().into_nodes();
+        let view = BalanceView::new(tree);
+        (ctx, view)
+    }
+
+    fn selected(view: &BalanceView<'_>) -> Option<usize> {
+        view.nav.table_state.selected()
+    }
+
+    fn full_names(view: &BalanceView<'_>) -> Vec<String> {
+        view.rows.iter().map(|r| r.full_name().to_owned()).collect()
+    }
+
+    fn row_labels(view: &BalanceView<'_>) -> Vec<String> {
+        view.rows.iter().map(|r| r.label.to_owned()).collect()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    // --- search behaviour (BalanceView::update) ---
+
+    #[test]
+    fn start_search_records_origin() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::MoveDown);
+        assert_eq!(selected(&view), Some(2));
+        view.update(BalanceMessage::StartModalSearch);
+        let search = view.search.as_ref().expect("search active");
+        assert_eq!(
+            search.intent.mode,
+            SearchMode::Modal(SearchPhase::Incremental)
+        );
+        assert_eq!(search.intent.origin, 2);
+        assert!(search.intent.input.is_empty());
+        assert!(search.matched_rows().is_empty());
+    }
+
+    #[test]
+    fn incremental_jumps_to_first_match_at_or_after_origin() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        let search = view.search.as_ref().unwrap();
+        assert_eq!(search.matched_rows(), [0, 1]);
+        assert_matches!(search.err(), None);
+        assert_eq!(selected(&view), Some(1));
+    }
+
+    #[test]
+    fn incremental_wraps_when_no_match_after_origin() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        for _ in 0..3 {
+            view.update(BalanceMessage::MoveDown);
+        }
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(view.search.as_ref().unwrap().matched_rows(), [0, 1]);
+        assert_eq!(selected(&view), Some(0));
+    }
+
+    #[test]
+    fn incremental_invalid_regex_sets_error() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        view.update(BalanceMessage::SearchPush('['));
+        let search = view.search.as_ref().unwrap();
+        assert_matches!(search.err(), Some(_));
+        assert!(search.matched_rows().is_empty());
+    }
+
+    #[test]
+    fn backspace_recomputes_matches() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "cash".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(view.search.as_ref().unwrap().matched_rows(), [1]);
+        view.update(BalanceMessage::SearchPop);
+        view.update(BalanceMessage::SearchPop);
+        assert_eq!(view.search.as_ref().unwrap().matched_rows(), [1, 4]);
+    }
+
+    #[test]
+    fn submit_empty_exits_search() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        view.update(BalanceMessage::SearchSubmit);
+        assert!(view.search.is_none());
+    }
+
+    #[test]
+    fn submit_nonempty_enters_fixed_phase() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        view.update(BalanceMessage::SearchPush('a'));
+        view.update(BalanceMessage::SearchSubmit);
+        assert_eq!(
+            view.search.as_ref().unwrap().intent.mode,
+            SearchMode::Modal(SearchPhase::Fixed)
+        );
+    }
+
+    #[test]
+    fn isearch_forward_jumps_and_repeats() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        let search = view.search.as_ref().unwrap();
+        assert_eq!(search.intent.mode, SearchMode::Interactive);
+        assert_eq!(search.intent.dir, SearchDirection::Forward);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(view.search.as_ref().unwrap().matched_rows(), [0, 1]);
+        assert_eq!(selected(&view), Some(0));
+        view.update(BalanceMessage::SearchNext);
+        assert_eq!(selected(&view), Some(1));
+        view.update(BalanceMessage::SearchNext);
+        assert_eq!(selected(&view), Some(0));
+    }
+
+    #[test]
+    fn isearch_backward_jumps_to_last_match() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::SelectLast);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Backward));
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(selected(&view), Some(1));
+        view.update(BalanceMessage::SearchPrev);
+        assert_eq!(selected(&view), Some(0));
+    }
+
+    #[test]
+    fn isearch_repeat_direction_steers_later_input() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(
+            &arena,
+            &["Assets:A", "Bonds:x", "Assets:B", "Bonds:y", "Assets:C"],
+        );
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(selected(&view), Some(0));
+        view.update(BalanceMessage::SearchPrev);
+        assert_eq!(selected(&view), Some(4));
+        view.update(BalanceMessage::SearchPop);
+        assert_eq!(selected(&view), Some(4));
+    }
+
+    #[test]
+    fn isearch_cancel_restores_origin() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::SearchCancel);
+        assert!(view.search.is_none());
+        assert_eq!(selected(&view), Some(2));
+    }
+
+    #[test]
+    fn search_pattern_is_remembered_for_recall() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "salary".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::SearchSubmit);
+        view.update(BalanceMessage::SearchClose);
+        assert_eq!(&view.last_search, "salary");
+
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        view.update(BalanceMessage::SearchNext);
+        let search = view.search.as_ref().unwrap();
+        assert_eq!(search.intent.input, "salary");
+        assert!(!search.intent.no_previous);
+        assert_eq!(search.matched_rows(), [3]);
+        assert_eq!(selected(&view), Some(3));
+    }
+
+    #[test]
+    fn isearch_recall_without_history_shows_notice() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        view.update(BalanceMessage::SearchNext);
+        let search = view.search.as_ref().unwrap();
+        assert!(search.intent.no_previous);
+        assert!(search.intent.input.is_empty());
+        view.update(BalanceMessage::SearchPush('a'));
+        assert!(!view.search.as_ref().unwrap().intent.no_previous);
+    }
+
+    #[test]
+    fn isearch_move_ends_search_and_navigates() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::MoveDown);
+        assert!(view.search.is_none());
+        assert_eq!(selected(&view), Some(1));
+        assert_eq!(&view.last_search, "assets");
+    }
+
+    #[test]
+    fn isearch_open_register_ends_search() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        for c in "salary".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        let action = view.update(BalanceMessage::OpenRegister);
+        assert_matches!(action, Some(BalanceAction::OpenRegister { .. }));
+        assert!(view.search.is_none());
+        assert_eq!(selected(&view), Some(3));
+    }
+
+    #[test]
+    fn modal_fixed_search_survives_navigation() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::SearchSubmit);
+        view.update(BalanceMessage::MoveDown);
+        assert!(view.search.is_some());
+    }
+
+    #[test]
+    fn isearch_recall_backward_sets_direction() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.last_search = "assets".to_owned();
+        view.update(BalanceMessage::SelectLast);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        view.update(BalanceMessage::SearchPrev);
+        let search = view.search.as_ref().unwrap();
+        assert_eq!(search.intent.input, "assets");
+        assert_eq!(search.intent.mode, SearchMode::Interactive);
+        assert_eq!(search.intent.dir, SearchDirection::Backward);
+        assert_eq!(selected(&view), Some(1));
+    }
+
+    #[test]
+    fn cancel_restores_origin() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        assert_eq!(selected(&view), Some(0));
+        view.update(BalanceMessage::SearchCancel);
+        assert!(view.search.is_none());
+        assert_eq!(selected(&view), Some(2));
+    }
+
+    #[test]
+    fn close_keeps_selection() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "salary".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::SearchSubmit);
+        assert_eq!(selected(&view), Some(3));
+        view.update(BalanceMessage::SearchClose);
+        assert!(view.search.is_none());
+        assert_eq!(selected(&view), Some(3));
+    }
+
+    #[test]
+    fn search_next_prev_wrap_over_matches() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        for c in "assets".chars() {
+            view.update(BalanceMessage::SearchPush(c));
+        }
+        view.update(BalanceMessage::SearchSubmit);
+        assert_eq!(selected(&view), Some(0));
+        view.update(BalanceMessage::SearchNext);
+        assert_eq!(selected(&view), Some(1));
+        view.update(BalanceMessage::SearchNext);
+        assert_eq!(selected(&view), Some(0));
+        view.update(BalanceMessage::SearchPrev);
+        assert_eq!(selected(&view), Some(1));
+    }
+
+    // --- amount / restore-index free functions ---
+
+    #[test]
+    fn amount_line_count_zero_amount_is_one() {
+        let amount = Amount::zero();
+        assert_eq!(amount_line_count(&amount), 1);
+    }
+
+    #[test]
+    fn amount_line_count_matches_commodity_count() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodity_store_mut().ensure("USD");
+        let eur = ctx.commodity_store_mut().ensure("EUR");
+        let one = Amount::from_value(usd, dec!(1));
+        let two = Amount::from_value(usd, dec!(1)) + Amount::from_value(eur, dec!(2));
+        assert_eq!(amount_line_count(&one), 1);
+        assert_eq!(amount_line_count(&two), 2);
+    }
+
+    #[test]
+    fn restore_index_prefers_exact_match() {
+        let arena = Bump::new();
+        let (ctx, _view) = view_from_names(&arena, ACCOUNTS);
+        let rows = rows_of(&ctx, ACCOUNTS);
+        assert_eq!(restore_index("Expenses:Food", &rows), Some(2));
+    }
+
+    #[test]
+    fn restore_index_falls_back_to_insertion_point() {
+        let arena = Bump::new();
+        let (ctx, _view) = view_from_names(&arena, ACCOUNTS);
+        let rows = rows_of(&ctx, ACCOUNTS);
+        assert_eq!(restore_index("Assets:Extra", &rows), Some(2));
+        assert_eq!(restore_index("Aaa", &rows), Some(0));
+        assert_eq!(restore_index("Zzz", &rows), Some(4));
+    }
+
+    #[test]
+    fn restore_index_empty_rows_is_none() {
+        let rows: &[BalanceRow<'_>] = &[];
+        assert_eq!(restore_index("Assets:Bank", rows), None);
+    }
+
+    // --- tree / fold (BalanceView::update) ---
+
+    #[test]
+    fn flat_mode_shows_only_posted_accounts() {
+        let arena = Bump::new();
+        let (_ctx, view) = tree_view(&arena, TREE_LEDGER);
+        assert_eq!(
+            full_names(&view),
+            ["Assets:Bank:Checking", "Assets:Cash", "Equity", "Expenses:Food"]
+        );
+    }
+
+    #[test]
+    fn toggle_tree_shows_hierarchy_with_leaf_labels() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        let checking = view.rows[0].amount.clone();
+        let cash = view.rows[1].amount.clone();
+        view.update(BalanceMessage::ToggleTree);
+        assert_eq!(view.mode, DisplayMode::Tree);
+        assert_eq!(
+            full_names(&view),
+            [
+                "Assets",
+                "Assets:Bank",
+                "Assets:Bank:Checking",
+                "Assets:Cash",
+                "Equity",
+                "Expenses",
+                "Expenses:Food",
+            ]
+        );
+        assert_eq!(
+            row_labels(&view),
+            ["Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"]
+        );
+        assert_eq!(view.rows[0].depth, 1);
+        assert!(view.rows[0].has_children);
+        assert_eq!(view.rows[2].depth, 3);
+        assert!(!view.rows[2].has_children);
+        assert_eq!(view.rows[0].amount, checking + cash);
+        view.update(BalanceMessage::ToggleTree);
+        assert_eq!(view.mode, DisplayMode::Flat);
+        assert_eq!(view.rows.len(), 4);
+    }
+
+    #[test]
+    fn toggle_fold_hides_selected_subtree() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.update(BalanceMessage::ToggleTree);
+        view.nav.select(0); // Assets
+        view.update(BalanceMessage::ToggleFold);
+        assert_eq!(
+            full_names(&view),
+            ["Assets", "Equity", "Expenses", "Expenses:Food"]
+        );
+        assert!(view.rows[0].folded);
+        assert_eq!(view.nav.table_state.selected(), Some(0));
+        view.update(BalanceMessage::ToggleFold);
+        assert!(!view.rows[0].folded);
+        assert_eq!(view.rows.len(), 7);
+    }
+
+    #[test]
+    fn toggle_fold_all_collapses_then_expands() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.update(BalanceMessage::ToggleTree);
+        view.update(BalanceMessage::ToggleFoldAll);
+        assert_eq!(full_names(&view), ["Assets", "Equity", "Expenses"]);
+        view.update(BalanceMessage::ToggleFoldAll);
+        assert_eq!(view.rows.len(), 7);
+    }
+
+    #[test]
+    fn tree_open_register_drills_into_subtree() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.update(BalanceMessage::ToggleTree);
+        view.nav.select(0); // Assets
+        let action = view.update(BalanceMessage::OpenRegister);
+        assert_matches!(
+            action,
+            Some(BalanceAction::OpenRegister { scope: RegisterScope::Subtree(agg) }) if agg.as_str() == "Assets"
+        );
+    }
+
+    #[test]
+    fn flat_open_register_drills_into_single_account() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.nav.select(1); // Assets:Cash
+        let action = view.update(BalanceMessage::OpenRegister);
+        assert_matches!(
+            action,
+            Some(BalanceAction::OpenRegister { scope: RegisterScope::Single(account) }) if account.as_str() == "Assets:Cash"
+        );
+    }
+
+    #[test]
+    fn open_register_with_no_selection_is_none() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, &[]);
+        assert_matches!(view.update(BalanceMessage::OpenRegister), None);
+    }
+
+    #[test]
+    fn tree_state_survives_snapshot_restore() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.update(BalanceMessage::ToggleTree);
+        view.nav.select(0); // Assets
+        view.update(BalanceMessage::ToggleFold); // fold Assets
+        let snapshot = view.snapshot();
+
+        let (_ctx2, mut view2) = tree_view(&arena, TREE_LEDGER);
+        view2.restore(&snapshot);
+        assert_eq!(view2.mode, DisplayMode::Tree);
+        assert_eq!(
+            full_names(&view2),
+            ["Assets", "Equity", "Expenses", "Expenses:Food"]
+        );
+        assert!(view2.rows[0].folded);
+    }
+
+    // --- key mapping (BalanceView::key_to_message) ---
+
+    #[test]
+    fn key_maps_nav_keys() {
+        let arena = Bump::new();
+        let (_ctx, view) = view_from_names(&arena, ACCOUNTS);
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Down)),
+            Some(BalanceMessage::MoveDown)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('k'))),
+            Some(BalanceMessage::MoveUp)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('n')),
+            Some(BalanceMessage::MoveDown)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('p')),
+            Some(BalanceMessage::MoveUp)
+        );
+    }
+
+    #[test]
+    fn key_maps_balance_actions() {
+        let arena = Bump::new();
+        let (_ctx, view) = view_from_names(&arena, ACCOUNTS);
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Enter)),
+            Some(BalanceMessage::OpenRegister)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('/'))),
+            Some(BalanceMessage::StartModalSearch)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('t'))),
+            Some(BalanceMessage::ToggleTree)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('s')),
+            Some(BalanceMessage::StartISearch(SearchDirection::Forward))
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('r')),
+            Some(BalanceMessage::StartISearch(SearchDirection::Backward))
+        );
+    }
+
+    #[test]
+    fn key_leaves_quit_and_reload_unmapped() {
+        let arena = Bump::new();
+        let (_ctx, view) = view_from_names(&arena, ACCOUNTS);
+        // q/Esc and r/F5 are global; the event layer handles them.
+        assert_eq!(view.key_to_message(key(KeyCode::Char('q'))), None);
+        assert_eq!(view.key_to_message(key(KeyCode::Esc)), None);
+        assert_eq!(view.key_to_message(key(KeyCode::Char('r'))), None);
+        assert_eq!(view.key_to_message(key(KeyCode::F(5))), None);
+    }
+
+    #[test]
+    fn key_incremental_search_captures_editing_keys() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('j'))),
+            Some(BalanceMessage::SearchPush('j'))
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Backspace)),
+            Some(BalanceMessage::SearchPop)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Enter)),
+            Some(BalanceMessage::SearchSubmit)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Esc)),
+            Some(BalanceMessage::SearchCancel)
+        );
+        // 'r' during editing is input, not reload.
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('r'))),
+            Some(BalanceMessage::SearchPush('r'))
+        );
+    }
+
+    #[test]
+    fn key_fixed_search_intercepts_only_its_controls() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartModalSearch);
+        view.update(BalanceMessage::SearchPush('a'));
+        view.update(BalanceMessage::SearchSubmit); // fixed
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('n'))),
+            Some(BalanceMessage::SearchNext)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('N'))),
+            Some(BalanceMessage::SearchPrev)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Esc)),
+            Some(BalanceMessage::SearchClose)
+        );
+        // Everything else falls through to normal navigation / drill-in.
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('j'))),
+            Some(BalanceMessage::MoveDown)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Enter)),
+            Some(BalanceMessage::OpenRegister)
+        );
+        // 'r' in fixed search is unmapped (event layer reloads).
+        assert_eq!(view.key_to_message(key(KeyCode::Char('r'))), None);
+    }
+
+    #[test]
+    fn key_interactive_search_captures_keys() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
+        view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Char('j'))),
+            Some(BalanceMessage::SearchPush('j'))
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Backspace)),
+            Some(BalanceMessage::SearchPop)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('s')),
+            Some(BalanceMessage::SearchNext)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('r')),
+            Some(BalanceMessage::SearchPrev)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('g')),
+            Some(BalanceMessage::SearchCancel)
+        );
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Esc)),
+            Some(BalanceMessage::SearchCancel)
+        );
+        // RET drills in; C-n/C-p move — all end the search at update time.
+        assert_eq!(
+            view.key_to_message(key(KeyCode::Enter)),
+            Some(BalanceMessage::OpenRegister)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('n')),
+            Some(BalanceMessage::MoveDown)
+        );
+        assert_eq!(
+            view.key_to_message(ctrl_key('p')),
+            Some(BalanceMessage::MoveUp)
+        );
+    }
 }

--- a/cli/src/ui/report/balance.rs
+++ b/cli/src/ui/report/balance.rs
@@ -17,12 +17,10 @@ use okane_core::report::Account;
 use okane_core::report::{AccountAggregate, AccountTreeKey, Amount, BalanceTreeNode};
 
 use crate::ui::keys::is_ctrl;
-use crate::ui::table::TableNav;
+use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
 use super::register::{OwnedRegisterScope, RegisterScope};
-use super::search::{
-    Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase,
-};
+use super::search::{Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase};
 
 /// Whether the balance screen shows a flat account list or the account tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,12 +131,8 @@ pub struct BalanceSnapshot {
 /// Messages handled by the balance screen.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BalanceMessage {
-    MoveUp,
-    MoveDown,
-    PageUp,
-    PageDown,
-    SelectFirst,
-    SelectLast,
+    /// Move the selection within the balance table.
+    Nav(NavCommand),
     /// Toggle between the flat list and the account tree (`t`).
     ToggleTree,
     /// Fold/unfold the selected tree node (`space`).
@@ -255,28 +249,13 @@ impl<'ctx> BalanceView<'ctx> {
     /// cross-screen transitions the view cannot perform itself.
     pub(super) fn update(&mut self, msg: BalanceMessage) -> Option<BalanceAction<'ctx>> {
         match msg {
-            BalanceMessage::MoveUp => {
+            BalanceMessage::Nav(cmd) => {
                 self.end_interactive_search();
-                self.nav.move_selection(-1);
+                self.nav.apply(cmd);
             }
-            BalanceMessage::MoveDown => {
-                self.end_interactive_search();
-                self.nav.move_selection(1);
-            }
-            BalanceMessage::PageUp => {
-                let delta = -(self.nav.page_size() as isize);
-                self.nav.move_selection(delta);
-            }
-            BalanceMessage::PageDown => {
-                let delta = self.nav.page_size() as isize;
-                self.nav.move_selection(delta);
-            }
-            BalanceMessage::SelectFirst => self.nav.select_first(),
-            BalanceMessage::SelectLast => self.nav.select_last(),
             BalanceMessage::OpenRegister => {
                 if let Some(scope) = self.selected_scope() {
-                    // An interactive search drills in like the normal view:
-                    // end the search, keeping the cursor on the chosen account.
+                    // An interactive search terminates on the register view transition.
                     self.end_interactive_search();
                     return Some(BalanceAction::OpenRegister { scope });
                 }
@@ -340,22 +319,9 @@ impl<'ctx> BalanceView<'ctx> {
             }
         }
 
-        // Navigation.
-        let nav = match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(BalanceMessage::MoveUp),
-            KeyCode::Char('p') if ctrl => Some(BalanceMessage::MoveUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(BalanceMessage::MoveDown),
-            KeyCode::Char('n') if ctrl => Some(BalanceMessage::MoveDown),
-            KeyCode::PageUp => Some(BalanceMessage::PageUp),
-            KeyCode::Char('b') if ctrl => Some(BalanceMessage::PageUp),
-            KeyCode::PageDown => Some(BalanceMessage::PageDown),
-            KeyCode::Char('f') if ctrl => Some(BalanceMessage::PageDown),
-            KeyCode::Home | KeyCode::Char('g') => Some(BalanceMessage::SelectFirst),
-            KeyCode::End | KeyCode::Char('G') => Some(BalanceMessage::SelectLast),
-            _ => None,
-        };
-        if nav.is_some() {
-            return nav;
+        // Shared table navigation.
+        if let Some(cmd) = key_to_nav(key) {
+            return Some(BalanceMessage::Nav(cmd));
         }
 
         // Balance-specific actions.
@@ -928,8 +894,8 @@ mod tests {
     fn start_search_records_origin() {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
-        view.update(BalanceMessage::MoveDown);
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         assert_eq!(selected(&view), Some(2));
         view.update(BalanceMessage::StartModalSearch);
         let search = view.search.as_ref().expect("search active");
@@ -946,7 +912,7 @@ mod tests {
     fn incremental_jumps_to_first_match_at_or_after_origin() {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         view.update(BalanceMessage::StartModalSearch);
         for c in "assets".chars() {
             view.update(BalanceMessage::SearchPush(c));
@@ -962,7 +928,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
         for _ in 0..3 {
-            view.update(BalanceMessage::MoveDown);
+            view.update(BalanceMessage::Nav(NavCommand::Down));
         }
         view.update(BalanceMessage::StartModalSearch);
         for c in "assets".chars() {
@@ -1042,7 +1008,7 @@ mod tests {
     fn isearch_backward_jumps_to_last_match() {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
-        view.update(BalanceMessage::SelectLast);
+        view.update(BalanceMessage::Nav(NavCommand::Last));
         view.update(BalanceMessage::StartISearch(SearchDirection::Backward));
         for c in "assets".chars() {
             view.update(BalanceMessage::SearchPush(c));
@@ -1074,8 +1040,8 @@ mod tests {
     fn isearch_cancel_restores_origin() {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
-        view.update(BalanceMessage::MoveDown);
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
         for c in "assets".chars() {
             view.update(BalanceMessage::SearchPush(c));
@@ -1127,7 +1093,7 @@ mod tests {
         for c in "assets".chars() {
             view.update(BalanceMessage::SearchPush(c));
         }
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         assert!(view.search.is_none());
         assert_eq!(selected(&view), Some(1));
         assert_eq!(&view.last_search, "assets");
@@ -1156,7 +1122,7 @@ mod tests {
             view.update(BalanceMessage::SearchPush(c));
         }
         view.update(BalanceMessage::SearchSubmit);
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         assert!(view.search.is_some());
     }
 
@@ -1165,7 +1131,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
         view.last_search = "assets".to_owned();
-        view.update(BalanceMessage::SelectLast);
+        view.update(BalanceMessage::Nav(NavCommand::Last));
         view.update(BalanceMessage::StartISearch(SearchDirection::Forward));
         view.update(BalanceMessage::SearchPrev);
         let search = view.search.as_ref().unwrap();
@@ -1179,8 +1145,8 @@ mod tests {
     fn cancel_restores_origin() {
         let arena = Bump::new();
         let (_ctx, mut view) = view_from_names(&arena, ACCOUNTS);
-        view.update(BalanceMessage::MoveDown);
-        view.update(BalanceMessage::MoveDown);
+        view.update(BalanceMessage::Nav(NavCommand::Down));
+        view.update(BalanceMessage::Nav(NavCommand::Down));
         view.update(BalanceMessage::StartModalSearch);
         for c in "assets".chars() {
             view.update(BalanceMessage::SearchPush(c));
@@ -1276,7 +1242,12 @@ mod tests {
         let (_ctx, view) = tree_view(&arena, TREE_LEDGER);
         assert_eq!(
             full_names(&view),
-            ["Assets:Bank:Checking", "Assets:Cash", "Equity", "Expenses:Food"]
+            [
+                "Assets:Bank:Checking",
+                "Assets:Cash",
+                "Equity",
+                "Expenses:Food"
+            ]
         );
     }
 
@@ -1302,7 +1273,9 @@ mod tests {
         );
         assert_eq!(
             row_labels(&view),
-            ["Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"]
+            [
+                "Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"
+            ]
         );
         assert_eq!(view.rows[0].depth, 1);
         assert!(view.rows[0].has_children);
@@ -1402,19 +1375,19 @@ mod tests {
         let (_ctx, view) = view_from_names(&arena, ACCOUNTS);
         assert_eq!(
             view.key_to_message(key(KeyCode::Down)),
-            Some(BalanceMessage::MoveDown)
+            Some(BalanceMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             view.key_to_message(key(KeyCode::Char('k'))),
-            Some(BalanceMessage::MoveUp)
+            Some(BalanceMessage::Nav(NavCommand::Up))
         );
         assert_eq!(
             view.key_to_message(ctrl_key('n')),
-            Some(BalanceMessage::MoveDown)
+            Some(BalanceMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             view.key_to_message(ctrl_key('p')),
-            Some(BalanceMessage::MoveUp)
+            Some(BalanceMessage::Nav(NavCommand::Up))
         );
     }
 
@@ -1505,7 +1478,7 @@ mod tests {
         // Everything else falls through to normal navigation / drill-in.
         assert_eq!(
             view.key_to_message(key(KeyCode::Char('j'))),
-            Some(BalanceMessage::MoveDown)
+            Some(BalanceMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             view.key_to_message(key(KeyCode::Enter)),
@@ -1551,11 +1524,11 @@ mod tests {
         );
         assert_eq!(
             view.key_to_message(ctrl_key('n')),
-            Some(BalanceMessage::MoveDown)
+            Some(BalanceMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             view.key_to_message(ctrl_key('p')),
-            Some(BalanceMessage::MoveUp)
+            Some(BalanceMessage::Nav(NavCommand::Up))
         );
     }
 }

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -18,17 +18,14 @@ use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
 use ratatui::DefaultTerminal;
 
 use crate::ui::keys::is_ctrl;
+use crate::ui::table::key_to_nav;
 
 use super::app::{App, Command, Message};
-use super::overlay::{Overlay, ScrollDelta};
+use super::overlay::Overlay;
 use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView, Screen};
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);
-
-fn scroll(delta: ScrollDelta) -> Option<Message> {
-    Some(Message::OverlayScroll(delta))
-}
 
 /// Why the event loop returned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,23 +93,16 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
                 _ => None,
             };
         }
-        // Scrolling mirrors the common navigation block below so the modal
-        // needs no new muscle memory. `r`/`F5` retry the load without a
-        // dismiss step; `q` goes straight to the quit prompt.
+        // Scrolling mirrors the table navigation keys so the modal needs no new
+        // muscle memory. `r`/`F5` retry the load without a dismiss step; `q`
+        // goes straight to the quit prompt.
         Some(Overlay::Error(_)) => {
+            if let Some(cmd) = key_to_nav(key) {
+                return Some(Message::OverlayScroll(cmd.into()));
+            }
             return match key.code {
                 KeyCode::Esc | KeyCode::Enter => Some(Message::DismissOverlay),
                 KeyCode::Char('q') => Some(Message::RequestQuit),
-                KeyCode::Up | KeyCode::Char('k') => scroll(ScrollDelta::Lines(-1)),
-                KeyCode::Char('p') if ctrl => scroll(ScrollDelta::Lines(-1)),
-                KeyCode::Down | KeyCode::Char('j') => scroll(ScrollDelta::Lines(1)),
-                KeyCode::Char('n') if ctrl => scroll(ScrollDelta::Lines(1)),
-                KeyCode::PageUp => scroll(ScrollDelta::Pages(-1)),
-                KeyCode::Char('b') if ctrl => scroll(ScrollDelta::Pages(-1)),
-                KeyCode::PageDown => scroll(ScrollDelta::Pages(1)),
-                KeyCode::Char('f') if ctrl => scroll(ScrollDelta::Pages(1)),
-                KeyCode::Home | KeyCode::Char('g') => scroll(ScrollDelta::Top),
-                KeyCode::End | KeyCode::Char('G') => scroll(ScrollDelta::Bottom),
                 KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
                 _ => None,
             };
@@ -180,10 +170,10 @@ mod tests {
 
     use okane_core::report::Account;
 
-    use crate::ui::table::TableNav;
+    use crate::ui::table::{NavCommand, TableNav};
 
     use super::super::balance::BalanceMessage;
-    use super::super::overlay::ErrorPopup;
+    use super::super::overlay::{ErrorPopup, ScrollDelta};
     use super::super::register::{RegisterMessage, RegisterView};
     use super::super::search::{
         Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase,
@@ -217,11 +207,11 @@ mod tests {
         let app = app();
         assert_eq!(
             key_to_message(&app, key(KeyCode::Down)),
-            Some(Message::Balance(BalanceMessage::MoveDown))
+            Some(Message::Balance(BalanceMessage::Nav(NavCommand::Down)))
         );
         assert_eq!(
             key_to_message(&app, key(KeyCode::Char('k'))),
-            Some(Message::Balance(BalanceMessage::MoveUp))
+            Some(Message::Balance(BalanceMessage::Nav(NavCommand::Up)))
         );
         assert_eq!(
             key_to_message(&app, key(KeyCode::Enter)),
@@ -237,7 +227,7 @@ mod tests {
         app.screen = register_screen(account);
         assert_eq!(
             key_to_message(&app, key(KeyCode::Down)),
-            Some(Message::Register(RegisterMessage::MoveDown))
+            Some(Message::Register(RegisterMessage::Nav(NavCommand::Down)))
         );
     }
 

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -22,7 +22,6 @@ use crate::ui::keys::is_ctrl;
 use super::app::{App, Command, Message};
 use super::overlay::{Overlay, ScrollDelta};
 use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView, Screen};
-use super::search::{SearchDirection, SearchMode, SearchPhase};
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);
@@ -121,94 +120,22 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         None => {}
     }
 
-    // The register screen owns its keys; global keys (reload) fall through.
-    if let Screen::Register(_) = &app.screen {
-        if let Some(msg) = RegisterView::key_to_message(key) {
-            return Some(Message::Register(msg));
-        }
-        return match key.code {
-            KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
-            _ => None,
-        };
-    }
-
-    // Balance account-search capture. The editing phases (modal incremental,
-    // interactive i-search) own every key; the modal fixed phase intercepts
-    // only its own controls and lets the rest fall through so full navigation
-    // (and Enter-to-register) keep working.
-    if let Some(search) = &app.balance.search {
-        match search.intent.mode {
-            SearchMode::Modal(SearchPhase::Incremental) => {
-                return match key.code {
-                    KeyCode::Esc => Some(Message::SearchCancel),
-                    KeyCode::Enter => Some(Message::SearchSubmit),
-                    KeyCode::Backspace => Some(Message::SearchPop),
-                    // TODO: now we're pushing char also with modifier,
-                    // which isn't good. probably let widget hold the text,
-                    // and pass them entirely.
-                    KeyCode::Char(c) if !ctrl => Some(Message::SearchPush(c)),
-                    _ => None,
-                };
-            }
-            SearchMode::Modal(SearchPhase::Fixed) => match key.code {
-                KeyCode::Esc => return Some(Message::SearchClose),
-                KeyCode::Char('n') => return Some(Message::SearchNext),
-                KeyCode::Char('N') => return Some(Message::SearchPrev),
-                _ => {} // fallback to normal UI
-            },
-            SearchMode::Interactive => {
-                // Canonical i-search: editing is always live;
-                // C-g/Esc aborts to the origin. RET drills into the
-                // register and C-n/C-p move the selection — these three end
-                // the search (keeping the cursor), behaving like normal view.
-                match key.code {
-                    KeyCode::Char('s') if ctrl => return Some(Message::SearchNext),
-                    KeyCode::Char('r') if ctrl => return Some(Message::SearchPrev),
-                    KeyCode::Char('g') if ctrl => return Some(Message::SearchCancel),
-                    KeyCode::Esc => return Some(Message::SearchCancel),
-                    KeyCode::Backspace => return Some(Message::SearchPop),
-                    KeyCode::Char(c) if !ctrl => return Some(Message::SearchPush(c)),
-                    _ => {} // fallback to normal UI
-                };
-            }
-        }
-    }
-
-    // Common navigation keys, regardless of screen.
-    let nav = match key.code {
-        KeyCode::Up | KeyCode::Char('k') => Some(Message::MoveUp),
-        KeyCode::Char('p') if ctrl => Some(Message::MoveUp),
-        KeyCode::Down | KeyCode::Char('j') => Some(Message::MoveDown),
-        KeyCode::Char('n') if ctrl => Some(Message::MoveDown),
-        KeyCode::PageUp => Some(Message::PageUp),
-        KeyCode::Char('b') if ctrl => Some(Message::PageUp),
-        KeyCode::PageDown => Some(Message::PageDown),
-        KeyCode::Char('f') if ctrl => Some(Message::PageDown),
-        KeyCode::Home | KeyCode::Char('g') => Some(Message::SelectFirst),
-        KeyCode::End | KeyCode::Char('G') => Some(Message::SelectLast),
-        KeyCode::F(5) => Some(Message::Reload),
-        _ => None,
+    // Each screen owns its own keys; the focused component maps them to its
+    // message type. Keys it doesn't consume fall through to the global keys
+    // below (quit, reload), which is how e.g. `q` on balance reaches the quit
+    // prompt while `q` on register leaves the screen.
+    let routed = match &app.screen {
+        Screen::Balance => app.balance.key_to_message(key).map(Message::Balance),
+        Screen::Register(_) => RegisterView::key_to_message(key).map(Message::Register),
     };
-    if nav.is_some() {
-        return nav;
+    if let Some(msg) = routed {
+        return Some(msg);
     }
 
-    // Screen-specific keys.
-    match (&app.screen, key.code) {
-        (Screen::Balance, KeyCode::Char('/')) => Some(Message::StartModalSearch),
-        (Screen::Balance, KeyCode::Char('s')) if ctrl => {
-            Some(Message::StartISearch(SearchDirection::Forward))
-        }
-        (Screen::Balance, KeyCode::Char('r')) if ctrl => {
-            Some(Message::StartISearch(SearchDirection::Backward))
-        }
-        (Screen::Balance, KeyCode::Char('t')) => Some(Message::ToggleTree),
-        (Screen::Balance, KeyCode::Char(' ')) => Some(Message::ToggleFold),
-        (Screen::Balance, KeyCode::Char('x')) => Some(Message::ToggleFoldAll),
-        (Screen::Balance, KeyCode::Enter) => Some(Message::OpenRegister),
-        (Screen::Balance, KeyCode::Char('q') | KeyCode::Esc) => Some(Message::RequestQuit),
-        // this needs to come here, as it should come after Ctrl-r search backward.
-        (_, KeyCode::Char('r')) => Some(Message::Reload),
+    // Global keys, for whatever the focused component left unmapped.
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => Some(Message::RequestQuit),
+        KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
         _ => None,
     }
 }
@@ -255,9 +182,12 @@ mod tests {
 
     use crate::ui::table::TableNav;
 
+    use super::super::balance::BalanceMessage;
     use super::super::overlay::ErrorPopup;
     use super::super::register::{RegisterMessage, RegisterView};
-    use super::super::search::{Search, SearchIntent, SearchMatch};
+    use super::super::search::{
+        Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase,
+    };
     use super::super::testing::{make_account, template};
 
     /// A single-account register screen for `account`, empty rows.
@@ -283,24 +213,31 @@ mod tests {
     }
 
     #[test]
-    fn balance_arrow_keys_map_to_nav() {
+    fn balance_keys_route_to_the_balance_component() {
         let app = app();
         assert_eq!(
             key_to_message(&app, key(KeyCode::Down)),
-            Some(Message::MoveDown)
+            Some(Message::Balance(BalanceMessage::MoveDown))
         );
         assert_eq!(
             key_to_message(&app, key(KeyCode::Char('k'))),
-            Some(Message::MoveUp)
+            Some(Message::Balance(BalanceMessage::MoveUp))
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Enter)),
+            Some(Message::Balance(BalanceMessage::OpenRegister))
         );
     }
 
     #[test]
-    fn balance_enter_opens_register() {
-        let app = app();
+    fn register_keys_route_to_the_register_component() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let mut app = app();
+        app.screen = register_screen(account);
         assert_eq!(
-            key_to_message(&app, key(KeyCode::Enter)),
-            Some(Message::OpenRegister)
+            key_to_message(&app, key(KeyCode::Down)),
+            Some(Message::Register(RegisterMessage::MoveDown))
         );
     }
 
@@ -494,137 +431,6 @@ mod tests {
         }
     }
 
-    fn interactive_search() -> Search {
-        Search {
-            intent: SearchIntent {
-                mode: SearchMode::Interactive,
-                dir: SearchDirection::Forward,
-                input: "a".to_owned(),
-                no_previous: false,
-                origin: 0,
-            },
-            matches: Some(Ok(SearchMatch::from(vec![0]))),
-        }
-    }
-
-    #[test]
-    fn balance_slash_starts_search() {
-        let app = app();
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('/'))),
-            Some(Message::StartModalSearch)
-        );
-    }
-
-    #[test]
-    fn incremental_search_captures_editing_keys() {
-        let mut app = app();
-        app.update(Message::StartModalSearch);
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('j'))),
-            Some(Message::SearchPush('j'))
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Backspace)),
-            Some(Message::SearchPop)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Enter)),
-            Some(Message::SearchSubmit)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Esc)),
-            Some(Message::SearchCancel)
-        );
-    }
-
-    #[test]
-    fn fixed_search_intercepts_only_its_controls() {
-        let mut app = app();
-        app.balance.search = Some(fixed_search());
-        // Own controls.
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('n'))),
-            Some(Message::SearchNext)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('N'))),
-            Some(Message::SearchPrev)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Esc)),
-            Some(Message::SearchClose)
-        );
-        // Everything else falls through to normal navigation / drill-in.
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('j'))),
-            Some(Message::MoveDown)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Enter)),
-            Some(Message::OpenRegister)
-        );
-    }
-
-    #[test]
-    fn balance_ctrl_s_and_r_start_isearch() {
-        let app = app();
-        assert_eq!(
-            key_to_message(&app, ctrl_key('s')),
-            Some(Message::StartISearch(SearchDirection::Forward))
-        );
-        assert_eq!(
-            key_to_message(&app, ctrl_key('r')),
-            Some(Message::StartISearch(SearchDirection::Backward))
-        );
-    }
-
-    #[test]
-    fn interactive_search_captures_keys() {
-        let mut app = app();
-        app.balance.search = Some(interactive_search());
-        // Plain characters refine the pattern.
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Char('j'))),
-            Some(Message::SearchPush('j'))
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Backspace)),
-            Some(Message::SearchPop)
-        );
-        // C-s / C-r repeat; C-g and Esc abort.
-        assert_eq!(
-            key_to_message(&app, ctrl_key('s')),
-            Some(Message::SearchNext)
-        );
-        assert_eq!(
-            key_to_message(&app, ctrl_key('r')),
-            Some(Message::SearchPrev)
-        );
-        assert_eq!(
-            key_to_message(&app, ctrl_key('g')),
-            Some(Message::SearchCancel)
-        );
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Esc)),
-            Some(Message::SearchCancel)
-        );
-        // RET drills into the register; C-n/C-p move — all end the search.
-        assert_eq!(
-            key_to_message(&app, key(KeyCode::Enter)),
-            Some(Message::OpenRegister)
-        );
-        assert_eq!(key_to_message(&app, ctrl_key('n')), Some(Message::MoveDown));
-        assert_eq!(key_to_message(&app, ctrl_key('p')), Some(Message::MoveUp));
-    }
-
-    #[test]
-    fn ctrl_n_and_p_navigate_like_j_k() {
-        let app = app();
-        assert_eq!(key_to_message(&app, ctrl_key('n')), Some(Message::MoveDown));
-        assert_eq!(key_to_message(&app, ctrl_key('p')), Some(Message::MoveUp));
-    }
-
     #[test]
     fn key_release_is_ignored() {
         let app = app();
@@ -654,24 +460,6 @@ mod tests {
         assert_eq!(
             key_to_message(&app, key(KeyCode::F(5))),
             Some(Message::Reload)
-        );
-    }
-
-    #[test]
-    fn r_during_search_editing_is_captured_as_input() {
-        // Modal incremental: every character belongs to the pattern.
-        let mut modal_app = app();
-        modal_app.update(Message::StartModalSearch);
-        assert_eq!(
-            key_to_message(&modal_app, key(KeyCode::Char('r'))),
-            Some(Message::SearchPush('r'))
-        );
-        // Interactive i-search: same.
-        let mut isearch_app = app();
-        isearch_app.balance.search = Some(interactive_search());
-        assert_eq!(
-            key_to_message(&isearch_app, key(KeyCode::Char('r'))),
-            Some(Message::SearchPush('r'))
         );
     }
 

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -21,7 +21,7 @@ use crate::ui::keys::is_ctrl;
 
 use super::app::{App, Command, Message};
 use super::overlay::{Overlay, ScrollDelta};
-use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, Screen};
+use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView, Screen};
 use super::search::{SearchDirection, SearchMode, SearchPhase};
 use super::render;
 
@@ -121,6 +121,17 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         None => {}
     }
 
+    // The register screen owns its keys; global keys (reload) fall through.
+    if let Screen::Register(_) = &app.screen {
+        if let Some(msg) = RegisterView::key_to_message(key) {
+            return Some(Message::Register(msg));
+        }
+        return match key.code {
+            KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
+            _ => None,
+        };
+    }
+
     // Balance account-search capture. The editing phases (modal incremental,
     // interactive i-search) own every key; the modal fixed phase intercepts
     // only its own controls and lets the rest fall through so full navigation
@@ -196,7 +207,6 @@ fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         (Screen::Balance, KeyCode::Char('x')) => Some(Message::ToggleFoldAll),
         (Screen::Balance, KeyCode::Enter) => Some(Message::OpenRegister),
         (Screen::Balance, KeyCode::Char('q') | KeyCode::Esc) => Some(Message::RequestQuit),
-        (Screen::Register(_), KeyCode::Char('q') | KeyCode::Esc) => Some(Message::LeaveRegister),
         // this needs to come here, as it should come after Ctrl-r search backward.
         (_, KeyCode::Char('r')) => Some(Message::Reload),
         _ => None,
@@ -246,7 +256,7 @@ mod tests {
     use crate::ui::table::TableNav;
 
     use super::super::overlay::ErrorPopup;
-    use super::super::register::RegisterView;
+    use super::super::register::{RegisterMessage, RegisterView};
     use super::super::search::{Search, SearchIntent, SearchMatch};
     use super::super::testing::{make_account, template};
 
@@ -308,18 +318,18 @@ mod tests {
     }
 
     #[test]
-    fn register_q_leaves_register() {
+    fn register_q_routes_to_leave() {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut app = app();
         app.screen = register_screen(account);
         assert_eq!(
             key_to_message(&app, key(KeyCode::Char('q'))),
-            Some(Message::LeaveRegister)
+            Some(Message::Register(RegisterMessage::Leave))
         );
         assert_eq!(
             key_to_message(&app, key(KeyCode::Esc)),
-            Some(Message::LeaveRegister)
+            Some(Message::Register(RegisterMessage::Leave))
         );
     }
 

--- a/cli/src/ui/report/overlay.rs
+++ b/cli/src/ui/report/overlay.rs
@@ -5,6 +5,8 @@
 
 use std::cmp::{max, min};
 
+use crate::ui::table::NavCommand;
+
 /// A scroll request against a scrollable overlay body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScrollDelta {
@@ -12,6 +14,22 @@ pub enum ScrollDelta {
     Pages(i16),
     Top,
     Bottom,
+}
+
+/// The error popup reuses the table navigation keys for scrolling: a row step
+/// scrolls one line, a page step scrolls a page, and first/last jump to the
+/// ends.
+impl From<NavCommand> for ScrollDelta {
+    fn from(cmd: NavCommand) -> Self {
+        match cmd {
+            NavCommand::Up => ScrollDelta::Lines(-1),
+            NavCommand::Down => ScrollDelta::Lines(1),
+            NavCommand::PageUp => ScrollDelta::Pages(-1),
+            NavCommand::PageDown => ScrollDelta::Pages(1),
+            NavCommand::First => ScrollDelta::Top,
+            NavCommand::Last => ScrollDelta::Bottom,
+        }
+    }
 }
 
 /// Body of the error modal: a full error report the user scrolls through.

--- a/cli/src/ui/report/register.rs
+++ b/cli/src/ui/report/register.rs
@@ -8,8 +8,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use okane_core::report::query::{Conversion, DateRange};
 use okane_core::report::{Account, AccountAggregate, Amount};
 
-use crate::ui::keys::is_ctrl;
-use crate::ui::table::TableNav;
+use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
 use super::balance::amount_line_count;
 
@@ -131,18 +130,7 @@ impl<'ctx> RegisterView<'ctx> {
     /// cross-screen transitions the view cannot perform itself.
     pub(super) fn update(&mut self, msg: RegisterMessage) -> Option<RegisterAction> {
         match msg {
-            RegisterMessage::MoveUp => self.nav.move_selection(-1),
-            RegisterMessage::MoveDown => self.nav.move_selection(1),
-            RegisterMessage::PageUp => {
-                let delta = -(self.nav.page_size() as isize);
-                self.nav.move_selection(delta);
-            }
-            RegisterMessage::PageDown => {
-                let delta = self.nav.page_size() as isize;
-                self.nav.move_selection(delta);
-            }
-            RegisterMessage::SelectFirst => self.nav.select_first(),
-            RegisterMessage::SelectLast => self.nav.select_last(),
+            RegisterMessage::Nav(cmd) => self.nav.apply(cmd),
             RegisterMessage::Leave => return Some(RegisterAction::Leave),
         }
         None
@@ -151,18 +139,10 @@ impl<'ctx> RegisterView<'ctx> {
     /// Translates a key event into a [`RegisterMessage`]. Global keys (`Ctrl-C`,
     /// reload) are left for [`super::event`], so `None` lets them fall through.
     pub(super) fn key_to_message(key: KeyEvent) -> Option<RegisterMessage> {
-        let ctrl = is_ctrl(key.modifiers);
+        if let Some(cmd) = key_to_nav(key) {
+            return Some(RegisterMessage::Nav(cmd));
+        }
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => Some(RegisterMessage::MoveUp),
-            KeyCode::Char('p') if ctrl => Some(RegisterMessage::MoveUp),
-            KeyCode::Down | KeyCode::Char('j') => Some(RegisterMessage::MoveDown),
-            KeyCode::Char('n') if ctrl => Some(RegisterMessage::MoveDown),
-            KeyCode::PageUp => Some(RegisterMessage::PageUp),
-            KeyCode::Char('b') if ctrl => Some(RegisterMessage::PageUp),
-            KeyCode::PageDown => Some(RegisterMessage::PageDown),
-            KeyCode::Char('f') if ctrl => Some(RegisterMessage::PageDown),
-            KeyCode::Home | KeyCode::Char('g') => Some(RegisterMessage::SelectFirst),
-            KeyCode::End | KeyCode::Char('G') => Some(RegisterMessage::SelectLast),
             KeyCode::Char('q') | KeyCode::Esc => Some(RegisterMessage::Leave),
             _ => None,
         }
@@ -179,12 +159,8 @@ pub enum Screen<'ctx> {
 /// Messages handled by the register drill-down screen.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegisterMessage {
-    MoveUp,
-    MoveDown,
-    PageUp,
-    PageDown,
-    SelectFirst,
-    SelectLast,
+    /// Move the selection within the register table.
+    Nav(NavCommand),
     /// Leave the register and return to the balance screen.
     Leave,
 }
@@ -269,13 +245,13 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut view = register_view(account, 3);
-        view.update(RegisterMessage::SelectFirst);
+        view.update(RegisterMessage::Nav(NavCommand::First));
         assert_eq!(view.nav.table_state.selected(), Some(0));
-        assert_eq!(view.update(RegisterMessage::MoveUp), None);
+        assert_eq!(view.update(RegisterMessage::Nav(NavCommand::Up)), None);
         assert_eq!(view.nav.table_state.selected(), Some(0));
-        view.update(RegisterMessage::MoveDown);
+        view.update(RegisterMessage::Nav(NavCommand::Down));
         assert_eq!(view.nav.table_state.selected(), Some(1));
-        view.update(RegisterMessage::SelectLast);
+        view.update(RegisterMessage::Nav(NavCommand::Last));
         assert_eq!(view.nav.table_state.selected(), Some(2));
     }
 
@@ -291,15 +267,15 @@ mod tests {
     fn key_to_message_maps_nav_and_leave() {
         assert_eq!(
             RegisterView::key_to_message(key(KeyCode::Down)),
-            Some(RegisterMessage::MoveDown)
+            Some(RegisterMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             RegisterView::key_to_message(key(KeyCode::Char('k'))),
-            Some(RegisterMessage::MoveUp)
+            Some(RegisterMessage::Nav(NavCommand::Up))
         );
         assert_eq!(
             RegisterView::key_to_message(ctrl_key('n')),
-            Some(RegisterMessage::MoveDown)
+            Some(RegisterMessage::Nav(NavCommand::Down))
         );
         assert_eq!(
             RegisterView::key_to_message(key(KeyCode::Char('q'))),

--- a/cli/src/ui/report/register.rs
+++ b/cli/src/ui/report/register.rs
@@ -4,9 +4,11 @@
 use std::cmp::max;
 
 use chrono::NaiveDate;
+use crossterm::event::{KeyCode, KeyEvent};
 use okane_core::report::query::{Conversion, DateRange};
 use okane_core::report::{Account, AccountAggregate, Amount};
 
+use crate::ui::keys::is_ctrl;
 use crate::ui::table::TableNav;
 
 use super::balance::amount_line_count;
@@ -124,6 +126,47 @@ impl<'ctx> RegisterView<'ctx> {
     pub fn title(&self) -> &'ctx str {
         self.scope.display_name()
     }
+
+    /// Applies a [`RegisterMessage`], returning a [`RegisterAction`] for the
+    /// cross-screen transitions the view cannot perform itself.
+    pub(super) fn update(&mut self, msg: RegisterMessage) -> Option<RegisterAction> {
+        match msg {
+            RegisterMessage::MoveUp => self.nav.move_selection(-1),
+            RegisterMessage::MoveDown => self.nav.move_selection(1),
+            RegisterMessage::PageUp => {
+                let delta = -(self.nav.page_size() as isize);
+                self.nav.move_selection(delta);
+            }
+            RegisterMessage::PageDown => {
+                let delta = self.nav.page_size() as isize;
+                self.nav.move_selection(delta);
+            }
+            RegisterMessage::SelectFirst => self.nav.select_first(),
+            RegisterMessage::SelectLast => self.nav.select_last(),
+            RegisterMessage::Leave => return Some(RegisterAction::Leave),
+        }
+        None
+    }
+
+    /// Translates a key event into a [`RegisterMessage`]. Global keys (`Ctrl-C`,
+    /// reload) are left for [`super::event`], so `None` lets them fall through.
+    pub(super) fn key_to_message(key: KeyEvent) -> Option<RegisterMessage> {
+        let ctrl = is_ctrl(key.modifiers);
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => Some(RegisterMessage::MoveUp),
+            KeyCode::Char('p') if ctrl => Some(RegisterMessage::MoveUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(RegisterMessage::MoveDown),
+            KeyCode::Char('n') if ctrl => Some(RegisterMessage::MoveDown),
+            KeyCode::PageUp => Some(RegisterMessage::PageUp),
+            KeyCode::Char('b') if ctrl => Some(RegisterMessage::PageUp),
+            KeyCode::PageDown => Some(RegisterMessage::PageDown),
+            KeyCode::Char('f') if ctrl => Some(RegisterMessage::PageDown),
+            KeyCode::Home | KeyCode::Char('g') => Some(RegisterMessage::SelectFirst),
+            KeyCode::End | KeyCode::Char('G') => Some(RegisterMessage::SelectLast),
+            KeyCode::Char('q') | KeyCode::Esc => Some(RegisterMessage::Leave),
+            _ => None,
+        }
+    }
 }
 
 /// Top-level screen the user is currently looking at.
@@ -131,6 +174,27 @@ impl<'ctx> RegisterView<'ctx> {
 pub enum Screen<'ctx> {
     Balance,
     Register(RegisterView<'ctx>),
+}
+
+/// Messages handled by the register drill-down screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterMessage {
+    MoveUp,
+    MoveDown,
+    PageUp,
+    PageDown,
+    SelectFirst,
+    SelectLast,
+    /// Leave the register and return to the balance screen.
+    Leave,
+}
+
+/// Effect a [`RegisterView`] asks the [`App`](super::app::App) to perform;
+/// everything else is handled inside the view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterAction {
+    /// Return to the balance screen.
+    Leave,
 }
 
 /// Snapshot of register view that survives a reload, as part of
@@ -159,5 +223,99 @@ impl RegisterSnapshot {
 
     pub(super) fn cursor(&self) -> usize {
         self.cursor
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bumpalo::Bump;
+    use crossterm::event::KeyModifiers;
+
+    use super::super::testing::make_account;
+
+    /// A register view for `account` with `n` one-line rows, cursor on the last.
+    fn register_view<'ctx>(account: Account<'ctx>, n: usize) -> RegisterView<'ctx> {
+        let rows: Vec<RegisterRow<'ctx>> = (0..n)
+            .map(|i| RegisterRow {
+                date: NaiveDate::from_ymd_opt(2024, 1, (i + 1) as u32).unwrap(),
+                payee: "payee".to_owned(),
+                amount: Amount::zero(),
+                total: Amount::zero(),
+            })
+            .collect();
+        RegisterView::new(RegisterScope::Single(account), rows)
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn new_selects_last_row() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let view = register_view(account, 3);
+        assert_eq!(view.nav.table_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn nav_moves_and_clamps_selection() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let mut view = register_view(account, 3);
+        view.update(RegisterMessage::SelectFirst);
+        assert_eq!(view.nav.table_state.selected(), Some(0));
+        assert_eq!(view.update(RegisterMessage::MoveUp), None);
+        assert_eq!(view.nav.table_state.selected(), Some(0));
+        view.update(RegisterMessage::MoveDown);
+        assert_eq!(view.nav.table_state.selected(), Some(1));
+        view.update(RegisterMessage::SelectLast);
+        assert_eq!(view.nav.table_state.selected(), Some(2));
+    }
+
+    #[test]
+    fn leave_returns_action() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let mut view = register_view(account, 1);
+        assert_eq!(view.update(RegisterMessage::Leave), Some(RegisterAction::Leave));
+    }
+
+    #[test]
+    fn key_to_message_maps_nav_and_leave() {
+        assert_eq!(
+            RegisterView::key_to_message(key(KeyCode::Down)),
+            Some(RegisterMessage::MoveDown)
+        );
+        assert_eq!(
+            RegisterView::key_to_message(key(KeyCode::Char('k'))),
+            Some(RegisterMessage::MoveUp)
+        );
+        assert_eq!(
+            RegisterView::key_to_message(ctrl_key('n')),
+            Some(RegisterMessage::MoveDown)
+        );
+        assert_eq!(
+            RegisterView::key_to_message(key(KeyCode::Char('q'))),
+            Some(RegisterMessage::Leave)
+        );
+        assert_eq!(
+            RegisterView::key_to_message(key(KeyCode::Esc)),
+            Some(RegisterMessage::Leave)
+        );
+    }
+
+    #[test]
+    fn key_to_message_leaves_global_keys_unmapped() {
+        // Enter and reload keys fall through to the event layer.
+        assert_eq!(RegisterView::key_to_message(key(KeyCode::Enter)), None);
+        assert_eq!(RegisterView::key_to_message(key(KeyCode::Char('r'))), None);
+        assert_eq!(RegisterView::key_to_message(key(KeyCode::F(5))), None);
     }
 }

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -503,8 +503,9 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::super::app::Message;
+    use super::super::balance::BalanceMessage;
     use super::super::overlay::ScrollDelta;
-    use super::super::register::RegisterQueryTemplate;
+    use super::super::register::{RegisterMessage, RegisterQueryTemplate};
     use super::super::testing::template;
     use super::*;
 
@@ -818,7 +819,7 @@ mod tests {
         let tree = BalanceTree::create(&ctx, balance).unwrap().into_nodes();
         let mut app = App::new(source_display(input), tree, template());
         // Tree view is what turns balance rows into `RegisterScope::Subtree`.
-        app.update(Message::ToggleTree);
+        app.update(Message::Balance(BalanceMessage::ToggleTree));
         // The first parent row (a real ancestor) exercises `descendants_of`
         // with more than one underlying account.
         let scope = app
@@ -858,7 +859,7 @@ mod tests {
     ) {
         let arena = Bump::new();
         let (ctx, mut app) = balance_app(&arena, &input);
-        app.update(Message::ToggleTree); // Flat -> Tree
+        app.update(Message::Balance(BalanceMessage::ToggleTree)); // Flat -> Tree
         golden(&golden_name(&input, "balance-tree")).assert(&render(&mut app, &ctx));
     }
 
@@ -872,8 +873,8 @@ mod tests {
     ) {
         let arena = Bump::new();
         let (ctx, mut app) = balance_app(&arena, &input);
-        app.update(Message::ToggleTree); // Flat -> Tree
-        app.update(Message::ToggleFoldAll); // collapse every node
+        app.update(Message::Balance(BalanceMessage::ToggleTree)); // Flat -> Tree
+        app.update(Message::Balance(BalanceMessage::ToggleFoldAll)); // collapse every node
         golden(&golden_name(&input, "balance-tree-all-folded")).assert(&render(&mut app, &ctx));
     }
 
@@ -986,7 +987,7 @@ mod tests {
         );
 
         // Jump to the top: now the first entries show and the last are gone.
-        app.update(Message::SelectFirst);
+        app.update(Message::Register(RegisterMessage::SelectFirst));
         let top = render_sized(&mut app, &ctx, 80, 10);
         assert!(top.contains("Payee00"), "first entry should be visible");
         assert!(

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -508,6 +508,7 @@ mod tests {
     use super::super::register::{RegisterMessage, RegisterQueryTemplate};
     use super::super::testing::template;
     use super::*;
+    use crate::ui::table::NavCommand;
 
     #[test]
     fn amount_width_has_minimum() {
@@ -987,7 +988,7 @@ mod tests {
         );
 
         // Jump to the top: now the first entries show and the last are gone.
-        app.update(Message::Register(RegisterMessage::SelectFirst));
+        app.update(Message::Register(RegisterMessage::Nav(NavCommand::First)));
         let top = render_sized(&mut app, &ctx, 80, 10);
         assert!(top.contains("Payee00"), "first entry should be visible");
         assert!(

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -1,6 +1,43 @@
 use std::cmp::max;
 
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::TableState;
+
+use crate::ui::keys::is_ctrl;
+
+/// A navigation command over a table — the vocabulary shared by every table
+/// screen. Keeps the key bindings and the [`TableNav`] mutations in one place
+/// so each screen wraps [`NavCommand`] in its own message rather than
+/// re-deriving `move_selection`/`select_first` from scratch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NavCommand {
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    First,
+    Last,
+}
+
+/// Maps a key event to a [`NavCommand`], the navigation bindings shared by the
+/// balance and register tables (and mirrored by the error-popup scroll).
+/// Returns `None` for keys that aren't navigation.
+pub fn key_to_nav(key: KeyEvent) -> Option<NavCommand> {
+    let ctrl = is_ctrl(key.modifiers);
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => Some(NavCommand::Up),
+        KeyCode::Char('p') if ctrl => Some(NavCommand::Up),
+        KeyCode::Down | KeyCode::Char('j') => Some(NavCommand::Down),
+        KeyCode::Char('n') if ctrl => Some(NavCommand::Down),
+        KeyCode::PageUp => Some(NavCommand::PageUp),
+        KeyCode::Char('b') if ctrl => Some(NavCommand::PageUp),
+        KeyCode::PageDown => Some(NavCommand::PageDown),
+        KeyCode::Char('f') if ctrl => Some(NavCommand::PageDown),
+        KeyCode::Home | KeyCode::Char('g') => Some(NavCommand::First),
+        KeyCode::End | KeyCode::Char('G') => Some(NavCommand::Last),
+        _ => None,
+    }
+}
 
 /// Pure scroll/selection state for a table.
 ///
@@ -78,6 +115,24 @@ impl TableNav {
     pub fn select(&mut self, index: usize) {
         if index < self.row_count {
             self.table_state.select(Some(index));
+        }
+    }
+
+    /// Applies a [`NavCommand`].
+    pub fn apply(&mut self, cmd: NavCommand) {
+        match cmd {
+            NavCommand::Up => self.move_selection(-1),
+            NavCommand::Down => self.move_selection(1),
+            NavCommand::PageUp => {
+                let delta = -(self.page_size() as isize);
+                self.move_selection(delta);
+            }
+            NavCommand::PageDown => {
+                let delta = self.page_size() as isize;
+                self.move_selection(delta);
+            }
+            NavCommand::First => self.select_first(),
+            NavCommand::Last => self.select_last(),
         }
     }
 
@@ -175,13 +230,60 @@ fn fill_from(
 mod tests {
     use super::*;
 
+    use crossterm::event::KeyModifiers;
     use pretty_assertions::assert_eq;
 
     fn nav(n: usize) -> TableNav {
         TableNav::new(n)
     }
 
-    
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn key_to_nav_maps_the_shared_bindings() {
+        assert_eq!(key_to_nav(key(KeyCode::Down)), Some(NavCommand::Down));
+        assert_eq!(key_to_nav(key(KeyCode::Char('j'))), Some(NavCommand::Down));
+        assert_eq!(key_to_nav(ctrl('n')), Some(NavCommand::Down));
+        assert_eq!(key_to_nav(key(KeyCode::Up)), Some(NavCommand::Up));
+        assert_eq!(key_to_nav(ctrl('p')), Some(NavCommand::Up));
+        assert_eq!(key_to_nav(key(KeyCode::PageDown)), Some(NavCommand::PageDown));
+        assert_eq!(key_to_nav(ctrl('f')), Some(NavCommand::PageDown));
+        assert_eq!(key_to_nav(ctrl('b')), Some(NavCommand::PageUp));
+        assert_eq!(key_to_nav(key(KeyCode::Home)), Some(NavCommand::First));
+        assert_eq!(key_to_nav(key(KeyCode::Char('g'))), Some(NavCommand::First));
+        assert_eq!(key_to_nav(key(KeyCode::Char('G'))), Some(NavCommand::Last));
+        // Non-navigation keys are left for the caller.
+        assert_eq!(key_to_nav(key(KeyCode::Char('q'))), None);
+        assert_eq!(key_to_nav(key(KeyCode::Enter)), None);
+        assert_eq!(key_to_nav(key(KeyCode::Char('f'))), None); // f without ctrl
+    }
+
+    #[test]
+    fn apply_moves_and_jumps() {
+        let mut n = nav(5);
+        n.viewport_height = 2;
+        assert_eq!(n.table_state.selected(), Some(0));
+        n.apply(NavCommand::Down);
+        assert_eq!(n.table_state.selected(), Some(1));
+        n.apply(NavCommand::PageDown); // +2
+        assert_eq!(n.table_state.selected(), Some(3));
+        n.apply(NavCommand::Last);
+        assert_eq!(n.table_state.selected(), Some(4));
+        n.apply(NavCommand::PageUp); // -2
+        assert_eq!(n.table_state.selected(), Some(2));
+        n.apply(NavCommand::First);
+        assert_eq!(n.table_state.selected(), Some(0));
+        n.apply(NavCommand::Up); // clamps at top
+        assert_eq!(n.table_state.selected(), Some(0));
+    }
+
+
     #[test]
     fn empty_nav_has_no_selection() {
         let n = nav(0);


### PR DESCRIPTION
## What

Follow-up to the report-UI split, pushing toward the ratatui Component
pattern (#425). Each screen now owns its own **message, update, and key
handling**, and `App` becomes genuine glue.

| Layer | Owns |
|---|---|
| `BalanceView` | `BalanceMessage`, `update() -> Option<BalanceAction>`, `key_to_message()` — nav, tree/fold, and the whole account-search state machine |
| `RegisterView` | `RegisterMessage`, `update() -> Option<RegisterAction>`, `key_to_message()` — nav + leave |
| `App::update` | routes `Message::Balance` / `Message::Register` to the focused component and translates its action (`OpenRegister` → `Command::LoadRegister`, `Leave` → screen switch); owns only quit / overlay / reload |
| `event::key_to_message` | Ctrl-C, the overlays, and the global quit/reload fallthrough; delegates the rest to the focused component |

`Message` collapses from ~24 flat variants to `Balance(_)`, `Register(_)`,
plus the six cross-screen ones. Behavior is unchanged.

## Tests move into the components

The update- and key-driven tests move out of `app.rs` and drive the
components directly:

- **app.rs: 1178 → 636 lines**, 48 → **23 tests** — now only App-glue:
  routing, overlays, quit, reload, register open/leave, snapshot/restore.
- **balance.rs: 39 tests** — search/tree/fold behavior via `BalanceView::update`,
  plus balance key mapping via `BalanceView::key_to_message`.
- **register.rs: 5 tests**; **event.rs: 16** — Ctrl-C, overlays, global
  fallback, and two delegation-smoke tests.

## Commits
- `cli: give RegisterView its own message, update, and key handling`
- `cli: give BalanceView its own message, update, and key handling`

## Testing
- `cargo test` (whole workspace) — green
- `cargo clippy --all-targets` — no warnings
- `cargo build` — clean

Rendering stays centralized in `render.rs` (the TEA view layer reads
component state); per-component rendering is a natural follow-up but a
larger churn, left out here.

Refs #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)