### PR TITLE
cli: move Screen out of register.rs into app.rs

### DIFF
--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -275,7 +275,8 @@ mod tests {
     use indoc::indoc;
     use okane_core::load::FakeFileSystem;
 
-    use register::{RegisterScope, Screen};
+    use app::Screen;
+    use register::RegisterScope;
     use testing::fake_loader;
 
     const V1: &str = indoc! {"

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -20,8 +20,15 @@ use super::balance::{BalanceAction, BalanceMessage, BalanceSnapshot, BalanceView
 use super::overlay::{Overlay, ScrollDelta};
 use super::register::{
     RegisterAction, RegisterMessage, RegisterQueryTemplate, RegisterRow, RegisterScope,
-    RegisterSnapshot, RegisterView, Screen,
+    RegisterSnapshot, RegisterView,
 };
+
+/// Top-level screen the user is currently looking at.
+#[derive(Debug)]
+pub enum Screen<'ctx> {
+    Balance,
+    Register(RegisterView<'ctx>),
+}
 
 /// Messages that drive state transitions (Elm-style).
 ///

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -20,9 +20,9 @@ use ratatui::DefaultTerminal;
 use crate::ui::keys::is_ctrl;
 use crate::ui::table::key_to_nav;
 
-use super::app::{App, Command, Message};
+use super::app::{App, Command, Message, Screen};
 use super::overlay::Overlay;
-use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView, Screen};
+use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView};
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);

--- a/cli/src/ui/report/register.rs
+++ b/cli/src/ui/report/register.rs
@@ -1,5 +1,4 @@
-//! Register drill-down screen: its rows, the scope it is filtered to, and the
-//! [`Screen`] focus enum that selects between the balance and register views.
+//! Register drill-down screen: its rows and the scope it is filtered to.
 
 use std::cmp::max;
 
@@ -149,13 +148,6 @@ impl<'ctx> RegisterView<'ctx> {
     }
 }
 
-/// Top-level screen the user is currently looking at.
-#[derive(Debug)]
-pub enum Screen<'ctx> {
-    Balance,
-    Register(RegisterView<'ctx>),
-}
-
 /// Messages handled by the register drill-down screen.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegisterMessage {
@@ -260,7 +252,10 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut view = register_view(account, 1);
-        assert_eq!(view.update(RegisterMessage::Leave), Some(RegisterAction::Leave));
+        assert_eq!(
+            view.update(RegisterMessage::Leave),
+            Some(RegisterAction::Leave)
+        );
     }
 
     #[test]

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -16,10 +16,10 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
 use unicode_width::UnicodeWidthStr;
 
-use super::app::App;
+use super::app::{App, Screen};
 use super::balance::{BalanceRow, DisplayMode};
 use super::overlay::{ErrorPopup, Overlay};
-use super::register::{RegisterRow, RegisterView, Screen};
+use super::register::{RegisterRow, RegisterView};
 use super::search::{Search, SearchDirection, SearchMatch, SearchMode, SearchPhase};
 use crate::ui::table::TableNav;
 
@@ -491,6 +491,8 @@ fn display_width(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::path::{Path, PathBuf};
 
     use bumpalo::Bump;
@@ -507,7 +509,6 @@ mod tests {
     use super::super::overlay::ScrollDelta;
     use super::super::register::{RegisterMessage, RegisterQueryTemplate};
     use super::super::testing::template;
-    use super::*;
     use crate::ui::table::NavCommand;
 
     #[test]
@@ -963,8 +964,7 @@ mod tests {
             date_range: DateRange::default(),
         };
         let scope = super::super::register::RegisterScope::Single(account);
-        let rows =
-            super::super::event::load_register(&mut ledger, &ctx, &template, scope).unwrap();
+        let rows = super::super::event::load_register(&mut ledger, &ctx, &template, scope).unwrap();
         assert_eq!(rows.len(), n);
         let mut app = App::new("test.ledger".to_owned(), Vec::new(), template);
         app.show_register(scope, rows);


### PR DESCRIPTION
`Screen` is the top-level focus enum that picks between the balance and register views. It lived in `register.rs`, but it is not a register concept — `app.rs` already describes itself as a thin dispatcher over the two screen states, and `App` is its only owner.

Moves the enum to `app.rs` next to `Message` and `Command`, drops it from `register.rs`'s module doc, and points `event.rs`, `render.rs` and `report.rs` at the new location.

Also hoists `use super::*;` to the top of `render.rs`'s test module, matching the other test modules in this tree.

No behavior change.
