### PR TITLE
chore: apply cargo fmt

### DIFF
--- a/cli/src/ui/report/testing.rs
+++ b/cli/src/ui/report/testing.rs
@@ -40,8 +40,12 @@ pub(super) fn process<'ctx>(
     content: &str,
 ) -> (ReportContext<'ctx>, Ledger<'ctx>) {
     let mut ctx = ReportContext::new(arena);
-    let ledger = report::process(&mut ctx, fake_loader(content), &report::ProcessOptions::default())
-        .expect("test ledger should process");
+    let ledger = report::process(
+        &mut ctx,
+        fake_loader(content),
+        &report::ProcessOptions::default(),
+    )
+    .expect("test ledger should process");
     (ctx, ledger)
 }
 

--- a/core/src/report/account.rs
+++ b/core/src/report/account.rs
@@ -322,7 +322,7 @@ mod tests {
         let grocery = accounts.ensure("Expenses:Grocery");
         tree.construct(&accounts);
         let expenses = tree.resolve_ancestor("Expenses").unwrap();
-        
+
         assert_eq!("Grocery", AccountAggregate::from(grocery).last_segment());
         assert_eq!("Expenses", AccountAggregate::from(expenses).last_segment());
     }

--- a/core/src/report/balance_tree.rs
+++ b/core/src/report/balance_tree.rs
@@ -216,11 +216,11 @@ impl From<NodeRange> for std::ops::Range<usize> {
 mod tests {
     use super::*;
 
+    use assert_matches::assert_matches;
     use bumpalo::Bump;
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
     use rust_decimal::Decimal;
-    use assert_matches::assert_matches;
     use rust_decimal_macros::dec;
 
     #[test]

--- a/core/src/report/process.rs
+++ b/core/src/report/process.rs
@@ -142,7 +142,7 @@ mod tests {
     use assert_matches::assert_matches;
     use bumpalo::Bump;
 
-    use super::super::account::{AccountAggregate,AccountTreeKey};
+    use super::super::account::{AccountAggregate, AccountTreeKey};
 
     #[test]
     fn process_constructs_account_tree() {
@@ -167,6 +167,9 @@ mod tests {
         let children: &[_] = &[child1, child2];
 
         assert_eq!(Some(children), ctx.account_tree.children(parent));
-        assert_eq!(Some(AccountTreeKey::Descendant(parent)), ctx.account_tree.parent(child1));
+        assert_eq!(
+            Some(AccountTreeKey::Descendant(parent)),
+            ctx.account_tree.parent(child1)
+        );
     }
 }


### PR DESCRIPTION
`cargo fmt` leftovers in `core/src/report/{account,balance_tree,process}.rs` and `cli/src/ui/report/testing.rs`: a stray trailing-whitespace line, an out-of-order `use`, and three call sites that needed wrapping.

Formatting only — no behavior change.
