### PR TITLE
Add tags command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* CLI: Added `tags` command, listing all tags in the file, sorted and deduped (https://github.com/xkikeg/okane/pull/523). Pass `--values` to print `key: value` pairs instead of the keys alone.
+
 ### Changed
 
 * CLI: `ui` reload errors are now shown in color instead of plain text (https://github.com/xkikeg/okane/issues/489).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This tool supports various commands:
 * `balance` to get the current balance of the accounts.
 * `register` to get the history of the accounts.
 * `accounts` to list all accounts in the file.
+* `tags` to list all tags in the file.
 * `format` to format given Ledger file into organized format.
 * `import` to convert various source including CSV, ISO Camt053 XML into Ledger format.
 * `primitive` to hold commands that are not so useful but good for debugging.
@@ -41,6 +42,7 @@ Similar to [Ledger][ledger document], you can use similar commands.
 
 ```shell
 $ okane accounts /path/to/file.ledger
+$ okane tags /path/to/file.ledger [--values]
 $ okane balance /path/to/file.ledger
 $ okane registry /path/to/file.ledger [optional account]
 ```

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -51,6 +51,8 @@ pub enum Command {
     Format(FormatCmd),
     /// List all accounts in the file.
     Accounts(AccountsCmd),
+    /// List all tags in the file.
+    Tags(TagsCmd),
     /// Gives balance report.
     Balance(BalanceCmd),
     /// Gives register report.
@@ -79,6 +81,7 @@ impl Command {
             Command::Import(cmd) => cmd.run(w),
             Command::Format(cmd) => cmd.run(w),
             Command::Accounts(cmd) => cmd.run(w),
+            Command::Tags(cmd) => cmd.run(w),
             Command::Balance(cmd) => cmd.run(w),
             Command::Register(cmd) => cmd.run(w),
             Command::Ui(cmd) => cmd.run(),
@@ -346,6 +349,40 @@ impl AccountsCmd {
         let accounts = report::accounts(&mut ctx, load::new_loader(self.source))?;
         for acc in accounts.iter() {
             writeln!(w, "{}", acc.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct TagsCmd {
+    /// Path to the Ledger file.
+    pub source: std::path::PathBuf,
+
+    /// Print each tag as `key: value`, instead of the key alone.
+    ///
+    /// Tags without a value, such as `; :tag1:tag2:`, are still printed as the bare key.
+    #[arg(long)]
+    pub values: bool,
+}
+
+impl TagsCmd {
+    pub fn run<W>(self, w: &mut W) -> anyhow::Result<()>
+    where
+        W: std::io::Write,
+    {
+        let query = if self.values {
+            report::TagQuery::WithValues
+        } else {
+            report::TagQuery::KeysOnly
+        };
+        let tags = report::tags(load::new_loader(self.source), query)?;
+        for tag in tags {
+            match tag.value {
+                None => writeln!(w, "{}", tag.key),
+                Some(report::TagValue::Expr(expr)) => writeln!(w, "{}:: {}", tag.key, expr),
+                Some(report::TagValue::Text(text)) => writeln!(w, "{}: {}", tag.key, text),
+            }?;
         }
         Ok(())
     }

--- a/cli/tests/test_tags.rs
+++ b/cli/tests/test_tags.rs
@@ -1,0 +1,67 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use rstest::rstest;
+
+pub mod testing;
+
+#[ctor::ctor(unsafe)]
+fn init() {
+    env_logger::init();
+}
+
+#[rstest]
+fn tags_default(
+    #[base_dir = "../testdata/tags"]
+    #[files("*.ledger")]
+    input: PathBuf,
+) {
+    println!("test input file path: {}", input.display());
+    let golden = golden_of(&input, "golden.tags.default.txt");
+
+    let result = assert_cmd::Command::new(&*testing::BIN_PATH)
+        .args(["tags".as_ref(), input.as_os_str()])
+        .assert()
+        .success();
+
+    assert_golden(golden, result);
+}
+
+#[rstest]
+fn tags_with_values(
+    #[base_dir = "../testdata/tags"]
+    #[files("*.ledger")]
+    input: PathBuf,
+) {
+    println!("test input file path: {}", input.display());
+    let golden = golden_of(&input, "golden.tags.values.txt");
+
+    let result = assert_cmd::Command::new(&*testing::BIN_PATH)
+        .args(["tags".as_ref(), input.as_os_str(), "--values".as_ref()])
+        .assert()
+        .success();
+
+    assert_golden(golden, result);
+}
+
+fn golden_of(input: &Path, extension: &str) -> okane_golden::Golden {
+    let mut golden_path = input.to_path_buf();
+    let filename = golden_path.file_name().unwrap().to_owned();
+    assert!(golden_path.pop());
+    golden_path.push("golden");
+    golden_path.push(filename);
+    assert!(
+        golden_path.set_extension(extension),
+        "failed to set extension .ledger to input {}",
+        input.display()
+    );
+    log::info!("golden_path: {}", golden_path.display());
+    okane_golden::Golden::new(golden_path).unwrap()
+}
+
+fn assert_golden(golden: okane_golden::Golden, result: assert_cmd::assert::Assert) {
+    let output = result.get_output();
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    golden.assert(stdout);
+}

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -12,6 +12,7 @@ mod eval;
 mod price_db;
 mod process;
 pub mod query;
+mod tags;
 mod transaction;
 
 use std::borrow::Borrow;
@@ -25,6 +26,7 @@ pub use error::ReportError;
 pub use eval::{Amount, SingleAmount};
 pub use price_db::LoadError;
 pub use process::{ProcessOptions, process};
+pub use tags::{Tag, TagQuery, TagValue, tags};
 pub use transaction::{Posting, Transaction};
 
 use crate::{load, syntax::plain::LedgerEntry};

--- a/core/src/report/tags.rs
+++ b/core/src/report/tags.rs
@@ -1,0 +1,250 @@
+//! Collects all tags declared in the given Ledger file.
+
+use std::borrow::Borrow;
+use std::collections::BTreeSet;
+
+use crate::load;
+use crate::syntax::{self, plain::LedgerEntry};
+
+use super::error::ReportError;
+
+/// Controls whether [`tags`] reports tag keys only, or key-value pairs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagQuery {
+    /// Report the tag key only, regardless of the value.
+    KeysOnly,
+    /// Report the tag as `key: value`, or the key alone if it has no value.
+    WithValues,
+}
+
+/// Result of the [`tags()`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Tag {
+    /// Tag value itself. For key-value metadata, this is the key part.
+    pub key: String,
+    /// Associated value for key-value metadata.
+    /// Note that the value will be always empty if the query is [`TagQuery::KeysOnly`].
+    pub value: Option<TagValue>,
+}
+
+/// Value of the [`Tag`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TagValue {
+    /// Expression tag value. Currently we treat it as just text.
+    Expr(String),
+    /// Plain text value.
+    Text(String),
+}
+
+impl From<&syntax::MetadataValue<'_>> for TagValue {
+    fn from(value: &syntax::MetadataValue<'_>) -> Self {
+        match value {
+            syntax::MetadataValue::Expr(expr) => Self::Expr(expr.clone().into_owned()),
+            syntax::MetadataValue::Text(text) => Self::Text(text.clone().into_owned()),
+        }
+    }
+}
+
+/// Returns all tags in the given Ledger file, sorted and deduped.
+///
+/// Tags are collected from `apply tag` directives, transaction level metadata
+/// and posting level metadata. Note `apply tag` is reported as-is, and not
+/// propagated into the transactions it encloses.
+/// WARNING: interface are subject to change.
+pub fn tags<L, F>(loader: L, query: TagQuery) -> Result<BTreeSet<Tag>, ReportError>
+where
+    L: Borrow<load::Loader<F>>,
+    F: load::FileSystem,
+{
+    let mut collected: BTreeSet<Tag> = BTreeSet::new();
+    loader.borrow().load(|_path, _pctx, entry| {
+        match entry {
+            LedgerEntry::ApplyTag(apply) => {
+                insert(&mut collected, query, &apply.key, apply.value.as_ref())
+            }
+            LedgerEntry::Txn(txn) => {
+                for metadata in &txn.metadata {
+                    collect_metadata(&mut collected, query, metadata);
+                }
+                for posting in &txn.posts {
+                    for metadata in &posting.metadata {
+                        collect_metadata(&mut collected, query, metadata);
+                    }
+                }
+            }
+            _ => (),
+        }
+        Ok::<(), ReportError>(())
+    })?;
+    Ok(collected)
+}
+
+fn collect_metadata(collected: &mut BTreeSet<Tag>, query: TagQuery, metadata: &syntax::Metadata) {
+    match metadata {
+        syntax::Metadata::WordTags(word_tags) => {
+            for tag in word_tags {
+                insert(collected, query, tag, None);
+            }
+        }
+        syntax::Metadata::KeyValueTag { key, value } => {
+            insert(collected, query, key, Some(value));
+        }
+        syntax::Metadata::Comment(_) => (),
+    }
+}
+
+fn insert(
+    collected: &mut BTreeSet<Tag>,
+    query: TagQuery,
+    key: &str,
+    value: Option<&syntax::MetadataValue>,
+) {
+    match (query, value) {
+        (TagQuery::WithValues, Some(value)) => collected.insert(Tag {
+            key: key.to_owned(),
+            value: Some(value.into()),
+        }),
+        _ => collected.insert(Tag {
+            key: key.to_owned(),
+            value: None,
+        }),
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use indoc::indoc;
+    use maplit::{btreeset, hashmap};
+    use pretty_assertions::assert_eq;
+
+    fn ko(key: &str) -> Tag {
+        Tag {
+            key: key.to_owned(),
+            value: None,
+        }
+    }
+
+    fn kv(key: &str, value: &str) -> Tag {
+        Tag {
+            key: key.to_owned(),
+            value: Some(TagValue::Text(value.to_owned())),
+        }
+    }
+
+    fn kve(key: &str, value: &str) -> Tag {
+        Tag {
+            key: key.to_owned(),
+            value: Some(TagValue::Expr(value.to_owned())),
+        }
+    }
+
+    fn loader(
+        files: std::collections::HashMap<PathBuf, Vec<u8>>,
+    ) -> load::Loader<load::FakeFileSystem> {
+        load::Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            load::FakeFileSystem::from(files),
+        )
+    }
+
+    fn all_tags_fixture() -> load::Loader<load::FakeFileSystem> {
+        loader(hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                apply tag Workflow
+                apply tag trip: kyoto
+
+                2026/01/01 lunch
+                   ; :food:trip:
+                   ; type: reimbursable
+                   ; just a comment, not a tag
+                   Expenses:Food     10 CHF
+                     ; trip: hokkaido-2026
+                   Assets:Bank:X
+                end apply tag
+            "}.as_bytes().to_vec(),
+        })
+    }
+
+    #[test]
+    fn tags_keys_only() {
+        let got = tags(all_tags_fixture(), TagQuery::KeysOnly).unwrap();
+
+        assert_eq!(
+            btreeset![ko("Workflow"), ko("food"), ko("trip"), ko("type")],
+            got
+        );
+    }
+
+    #[test]
+    fn tags_with_values() {
+        let got = tags(all_tags_fixture(), TagQuery::WithValues).unwrap();
+
+        assert_eq!(
+            btreeset![
+                ko("Workflow"),
+                ko("food"),
+                ko("trip"),
+                kv("trip", "hokkaido-2026"),
+                kv("trip", "kyoto"),
+                kv("type", "reimbursable"),
+            ],
+            got,
+        );
+    }
+
+    #[test]
+    fn tags_with_expr_value() {
+        let loader = loader(hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                2026/01/01 lunch
+                   Expenses:Food     10 CHF
+                     ; total:: 1 + 2
+                   Assets:Bank:X
+            "}.as_bytes().to_vec(),
+        });
+
+        assert_eq!(
+            btreeset![ko("total")],
+            tags(&loader, TagQuery::KeysOnly).unwrap()
+        );
+        assert_eq!(
+            btreeset![kve("total", "1 + 2")],
+            tags(&loader, TagQuery::WithValues).unwrap(),
+        );
+    }
+
+    #[test]
+    fn tags_dedups_across_includes() {
+        let loader = loader(hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                include child.ledger
+
+                2026/01/01 lunch
+                   ; :food:
+                   ; trip: kyoto
+                   Expenses:Food     10 CHF
+                   Assets:Bank:X
+            "}.as_bytes().to_vec(),
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                2026/01/02 dinner
+                   ; :food:
+                   ; trip: kyoto
+                   Expenses:Food     20 CHF
+                   Assets:Bank:X
+            "}.as_bytes().to_vec(),
+        });
+
+        assert_eq!(
+            btreeset![ko("food"), ko("trip")],
+            tags(&loader, TagQuery::KeysOnly).unwrap()
+        );
+        assert_eq!(
+            btreeset![ko("food"), kv("trip", "kyoto")],
+            tags(&loader, TagQuery::WithValues).unwrap(),
+        );
+    }
+}

--- a/testdata/tags/basic.ledger
+++ b/testdata/tags/basic.ledger
@@ -1,0 +1,20 @@
+include include/tagged.ledger
+
+apply tag Workflow
+apply tag trip: kyoto
+
+2026/01/01 lunch
+    ; :food:trip:
+    ; type: reimbursable
+    ; just a comment, not a tag
+    Expenses:Food                              10.00 CHF
+      ; trip: hokkaido-2026
+    Assets:Banks:Main
+
+end apply tag
+
+2026/01/02 dinner
+    ; :food:
+    ; total:: 20.00 CHF + 5.00 CHF
+    Expenses:Food                              25.00 CHF
+    Assets:Banks:Main

--- a/testdata/tags/golden/basic.golden.tags.default.txt
+++ b/testdata/tags/golden/basic.golden.tags.default.txt
@@ -1,0 +1,6 @@
+Workflow
+food
+project
+total
+trip
+type

--- a/testdata/tags/golden/basic.golden.tags.values.txt
+++ b/testdata/tags/golden/basic.golden.tags.values.txt
@@ -1,0 +1,8 @@
+Workflow
+food
+project: okane
+total:: 20.00 CHF + 5.00 CHF
+trip
+trip: hokkaido-2026
+trip: kyoto
+type: reimbursable

--- a/testdata/tags/include/tagged.ledger
+++ b/testdata/tags/include/tagged.ledger
@@ -1,0 +1,7 @@
+2026/01/03 breakfast
+    ; :food:
+    ; trip: kyoto
+    ; project: okane
+    Expenses:Food                               5.00 CHF
+      ; type: reimbursable
+    Assets:Banks:Main


### PR DESCRIPTION
Adds an `okane tags` command, the tag-side counterpart of `okane accounts`.

It lists every distinct tag in a Ledger file — sorted and deduped — collected from
`apply tag` directives, transaction level metadata, and posting level metadata.
Comments are skipped.

```console
$ okane tags testdata/tags/basic.ledger
Workflow
food
project
total
trip
type
```

With `--values`, each distinct key/value pair is printed as `key: value` instead:

```console
$ okane tags --values testdata/tags/basic.ledger
Workflow
food
project: okane
total:: 20.00 CHF + 5.00 CHF
trip
trip: hokkaido-2026
trip: kyoto
type: reimbursable
```

## Notes on the design

* **`--values` prints pairs, not bare values.** Keeping the key makes the output
  self-describing, and the composed string sorts so that a key groups with its own
  values (`trip` < `trip: hokkaido-2026` < `trip: kyoto`).
* **Valueless tags stay visible under `--values`.** Word tags (`; :food:`) and
  `apply tag foo` have no value, so they print as the bare key. `--values` output is
  therefore a superset of the default — the flag never drops a tag.
* **Returning fully owned `Tag`.** This choice might be revised later, especially
  once the query implements the tag filtering.
* **`apply tag` is reported literally, not propagated.** For now it just runs through the value.
* **Reads the syntax AST, not processed report data.** `report::Transaction` /
  `report::Posting` carry no metadata at all, so `report::tags` walks
  `load::Loader::load()` directly — the same cheap path `report::accounts` takes, and
  the only one available.
* No `EvalOptions` (date range, conversion, account filter) on this command, matching
  `accounts`.

## Tests

* `core/src/report/tags.rs` unit tests over `FakeFileSystem`: both query modes, word
  tags vs. key/value tags, comments ignored, `::` expression values, and dedup across
  `include` recursion.
* `cli/tests/test_tags.rs` golden tests against the new `testdata/tags/` fixture, for
  the default and `--values` output.

Full suite passes (564 tests); `cargo clippy --all-targets` and `cargo fmt --check` are
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
