### PR TITLE
syntax: make LedgerEntry a struct carrying blank-line separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 ### Changed
 
 * CLI: `ui` reload errors are now shown in color instead of plain text (https://github.com/xkikeg/okane/issues/489).
+* Core: `syntax::LedgerEntry` is now a struct pairing a `syntax::Separation` with the new
+  `syntax::LedgerStatement` enum, which holds the variants `LedgerEntry` used to have.
+  `Separation` records whether a blank line preceded the entry in the source
+  (https://github.com/xkikeg/okane/pull/525).
+* Core/CLI: formatting now reproduces the blank lines of the source instead of putting one between
+  every entry. A comment written directly above a transaction stays attached to it, runs of
+  `apply tag` / `include` directives stay grouped, and the spurious blank line at end of file is gone.
 * CLI: import config is now parsed with [`ya`](https://crates.io/crates/ya) instead of the
   unmaintained `serde_yaml`, dropping the `unsafe-libyaml` dependency. Config errors now point at
   the offending source line, and config files must be valid UTF-8 (a leading BOM is still

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ For import: external formats (CSV, ISO Camt053, Viseca) → `cli/src/import/` �
 
 ### `core/src/syntax/`
 
-The AST. Top-level type is `LedgerEntry<'i, Deco>`, parameterized over a lifetime `'i` (zero-copy string slices into the original file) and a `Decoration` type.
+The AST. Top-level type is `LedgerEntry<'i, Deco>`, parameterized over a lifetime `'i` (zero-copy string slices into the original file) and a `Decoration` type. It is a thin struct pairing a `LedgerStatement` (the enum of transactions, directives and standalone comments) with a `Separation`, which records whether a blank line preceded the entry in the source so formatting can reproduce the author's grouping.
 
 - **`decoration.rs`** — `Decoration` trait controls what extra data is attached to each AST node. Two implementations exist: `plain` (bare identity, used for most processing) and `tracked` (carries source span info, used during parsing when location is needed).
 - **`expr.rs`** — Numeric expression types (`Amount`, `ValueExpr`).

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -9,6 +9,7 @@ use clap::{Args, Subcommand};
 
 use lender::FallibleLender;
 use okane_core::report::query;
+use okane_core::syntax::Separation;
 use okane_core::syntax::display::DisplayContext;
 use okane_core::syntax::plain::LedgerEntry;
 use okane_core::{load, report};
@@ -93,7 +94,7 @@ impl Command {
 #[derive(Args, Debug)]
 pub struct ImportCmd {
     #[arg(short, long, value_name = "FILE")]
-    pub config: std::path::PathBuf,
+    pub config: PathBuf,
 
     /// Review the imported transactions in an interactive TUI before writing.
     #[arg(long)]
@@ -101,13 +102,13 @@ pub struct ImportCmd {
 
     /// Ledger file whose accounts feed the autocomplete (interactive only).
     #[arg(long, value_name = "FILE", requires = "interactive")]
-    pub ledger: Option<std::path::PathBuf>,
+    pub ledger: Option<PathBuf>,
 
     /// Ledger file the reviewed transactions are appended to (interactive only).
     #[arg(short = 'o', long, value_name = "FILE", requires = "interactive")]
-    pub output: Option<std::path::PathBuf>,
+    pub output: Option<PathBuf>,
 
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 }
 
 impl ImportCmd {
@@ -198,7 +199,7 @@ impl ImportCmd {
 
 #[derive(Args, Debug)]
 pub struct FormatCmd {
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 }
 
 impl FormatCmd {
@@ -255,7 +256,7 @@ impl PrimitiveCmd {
 
 #[derive(Args, Debug)]
 struct FlattenCmd {
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 }
 
 impl FlattenCmd {
@@ -276,9 +277,19 @@ impl FlattenCmd {
 
         // TODO: Pick DisplayContext from load results.
         let ctx = DisplayContext::default();
+        let mut prev_path: Option<PathBuf> = None;
         load::new_loader(self.source).load(
-            |_path, _ctx, entry: &LedgerEntry| -> Result<(), FlattenError> {
-                writeln!(w, "{}", ctx.as_display(entry))?;
+            |path, _ctx, entry: &LedgerEntry| -> Result<(), FlattenError> {
+                let file_changed = prev_path.as_deref().is_some_and(|prev| prev != path);
+                if file_changed {
+                    prev_path = Some(path.to_owned());
+                    // The first entry of every file is `Separation::Immediate`, so without this
+                    // the last entry of one file would run into the first entry of the next.
+                    if entry.separation == Separation::Immediate {
+                        writeln!(w)?;
+                    }
+                }
+                write!(w, "{}", ctx.as_display(entry))?;
                 Ok(())
             },
         )?;
@@ -297,7 +308,7 @@ struct EvalCmd {
 
     /// source of the Ledger file.
     #[arg(short = 'f', long = "file")]
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 
     /// expression to evaluate.
     pub expression: Vec<String>,
@@ -336,7 +347,7 @@ impl EvalCmd {
 
 #[derive(Args, Debug)]
 pub struct AccountsCmd {
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 }
 
 impl AccountsCmd {
@@ -357,7 +368,7 @@ impl AccountsCmd {
 #[derive(Args, Debug)]
 pub struct TagsCmd {
     /// Path to the Ledger file.
-    pub source: std::path::PathBuf,
+    pub source: PathBuf,
 
     /// Print each tag as `key: value`, instead of the key alone.
     ///
@@ -394,7 +405,7 @@ pub struct BalanceCmd {
     eval_options: EvalOptions,
 
     /// Path to the Ledger file.
-    source: std::path::PathBuf,
+    source: PathBuf,
 
     /// [Optional] Accounts to report the balance.
     ///
@@ -450,7 +461,7 @@ pub struct UiCmd {
     eval_options: EvalOptions,
 
     /// Path to the Ledger file.
-    source: std::path::PathBuf,
+    source: PathBuf,
 }
 
 impl UiCmd {
@@ -507,7 +518,7 @@ pub struct RegisterCmd {
     sort: SortKey,
 
     /// Path to the Ledger file.
-    source: std::path::PathBuf,
+    source: PathBuf,
 
     /// [Optional] Accounts to get register.
     ///

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -55,7 +55,7 @@ impl FormatOptions {
         let ctx = DisplayContext::default();
         for parsed in parse_ledger(&ParseOptions::default(), &buf) {
             let (_, entry): (_, syntax::plain::LedgerEntry) = parsed?;
-            writeln!(w, "{}", ctx.as_display(&entry))?;
+            write!(w, "{}", ctx.as_display(&entry))?;
         }
         Ok(())
     }
@@ -67,6 +67,72 @@ mod tests {
 
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+
+    fn format_str(input: &str) -> String {
+        let mut output = Vec::new();
+        FormatOptions::new()
+            .format(&mut input.as_bytes(), &mut output)
+            .expect("format() should succeeds");
+        String::from_utf8(output).expect("output should be valid UTF-8")
+    }
+
+    #[test]
+    fn format_keeps_comment_attached_to_the_next_entry() {
+        let input = indoc! {"
+            ; Explains the transaction below.
+            2021/03/12 Opening Balance
+                Assets:Bank                                          = 1000 CHF
+                Equity
+            ; Explains the transaction above.
+
+            ; Standalone comment, separated by blank lines.
+
+            2021/03/13 Grocery
+                Expenses:Grocery                              10 CHF
+                Assets:Bank
+        "};
+
+        assert_eq!(input, format_str(input));
+    }
+
+    #[test]
+    fn format_collapses_consecutive_blank_lines() {
+        let input = indoc! {"
+            include a.ledger
+
+
+
+            include b.ledger
+        "};
+        let want = indoc! {"
+            include a.ledger
+
+            include b.ledger
+        "};
+
+        assert_eq!(want, format_str(input));
+    }
+
+    #[test]
+    fn format_is_idempotent() {
+        let input = indoc! {"
+            ; Top
+            #comment
+
+            account  Foo\t
+             alias Bar
+
+            apply    tag   foo
+            end  apply   tag
+
+            2021/05/14 !(#txn-1) My Grocery
+                Expenses:Grocery\t10 CHF
+                Assets:Bank  -10 CHF
+        "};
+
+        let once = format_str(input);
+        assert_eq!(once, format_str(&once));
+    }
 
     #[test]
     fn format_succeeds_transaction_without_lot_price() {
@@ -90,10 +156,12 @@ mod tests {
              \talias $\t
 
             apply    tag   foo
+
             apply tag key: value
             apply tag key:: 10 USD
 
             end  apply   tag
+            ; key:: 10 USD
 
             end apply tag
             end apply tag
@@ -139,13 +207,12 @@ mod tests {
             apply tag foo
 
             apply tag key: value
-
             apply tag key:: 10 USD
 
             end apply tag
+            ; key:: 10 USD
 
             end apply tag
-
             end apply tag
 
             include path/to/other.ledger
@@ -166,7 +233,6 @@ mod tests {
                 Assets:Complex                        (-10 * 2.1 $) @ (1 $ + 1 $) = 2.5 $
                 Assets:Broker                                 -2 SPINX {100 USD} [2010/12/23] (bought before Xmas) @ 10000 USD
                 Liabilities:Comma                       5,678.00 CHF @ 1,000,000 JPYRIN = -123,456.12 CHF
-
         "};
         let mut output = Vec::new();
         let mut r = input.as_bytes();

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -109,8 +109,8 @@ impl<F: FileSystem> Loader<F> {
         for parsed in parse::parse_ledger(parse_options, &content) {
             let (ctx, entry) =
                 parsed.map_err(|e| LoadError::Parse(e, path.clone().into_owned()))?;
-            match entry {
-                syntax::LedgerEntry::Include(p) => {
+            match &entry.statement {
+                syntax::LedgerStatement::Include(p) => {
                     let include_path: PathBuf = p.0.as_ref().into();
                     let target: String = path
                         .as_ref()
@@ -274,15 +274,29 @@ mod tests {
     use maplit::hashmap;
     use pretty_assertions::assert_eq;
 
+    /// Parses the expected entries, given as a fragment per contiguous run of
+    /// entries the loader reports from one file.
+    ///
+    /// A fragment starts wherever the preceding `include` directive was, so its
+    /// first entry's [`syntax::Separation`] cannot be derived from the fragment
+    /// itself and is given explicitly.
     fn parse_static_ledger_entry(
-        input: &[(&Path, &'static str)],
+        input: &[(&Path, syntax::Separation, &'static str)],
     ) -> Result<Vec<(PathBuf, syntax::plain::LedgerEntry<'static>)>, parse::ParseError> {
         let opts = parse::ParseOptions::default();
         input
             .iter()
-            .flat_map(|(p, content)| {
+            .flat_map(|(p, first_separation, content)| {
                 parse::parse_ledger(&opts, content)
-                    .map(|elem| elem.map(|(_ctx, entry)| (p.to_path_buf(), entry)))
+                    .enumerate()
+                    .map(|(i, elem)| {
+                        elem.map(|(_ctx, mut entry)| {
+                            if i == 0 {
+                                entry.separation = *first_separation;
+                            }
+                            (p.to_path_buf(), entry)
+                        })
+                    })
             })
             .collect()
     }
@@ -320,6 +334,7 @@ mod tests {
         let want = parse_static_ledger_entry(&[
             (
                 &root,
+                syntax::Separation::Immediate,
                 indoc! {"
             ; Demonstrates include feature including glob, parent dir, ...
 
@@ -335,6 +350,7 @@ mod tests {
             ),
             (
                 &child2,
+                syntax::Separation::Immediate,
                 indoc! {"
             2024/01/01 * Complicated salary
                 Income:Salary                          -3,000.00 CHF
@@ -346,6 +362,7 @@ mod tests {
             ),
             (
                 &child3,
+                syntax::Separation::Immediate,
                 indoc! {"
             2024/03/01 * SBB CFF FFS
                 Assets:Bank:ZKB                            -5.60 CHF
@@ -354,6 +371,8 @@ mod tests {
             ),
             (
                 &child2,
+                // Follows a blank line after `include ../child3.ledger`.
+                syntax::Separation::BlankLine,
                 indoc! {"
             2024/01/25 ! RSU
                 ; TODO: FMV not determined
@@ -364,6 +383,7 @@ mod tests {
             ),
             (
                 &child4,
+                syntax::Separation::Immediate,
                 indoc! {"
             2024/7/1 * Send money
                 Assets:Bank:ZKB                         -1000.00 CHF
@@ -372,6 +392,8 @@ mod tests {
             ),
             (
                 &child1,
+                // Follows a blank line after `include sub/child*.ledger`.
+                syntax::Separation::BlankLine,
                 indoc! {"
             2024/05/01 * Migros
                 Expenses:Grocery                          -10.00 CHF
@@ -404,6 +426,7 @@ mod tests {
 
         let want = parse_static_ledger_entry(&[(
             Path::new("path/to/sub/child3.ledger"),
+            syntax::Separation::Immediate,
             indoc! {"
             ; comment here
             "},

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -35,11 +35,33 @@ pub fn parse_ledger<'i, Deco: 'i + Decoration>(
     options: &ParseOptions,
     input: &'i str,
 ) -> impl Iterator<Item = Result<(ParsedContext<'i>, syntax::LedgerEntry<'i, Deco>), ParseError>> {
-    options.parse_repeated(parse_ledger_entry, character::newlines.void(), input)
+    options
+        .parse_repeated(parse_ledger_statement, character::newlines.void(), input)
+        .enumerate()
+        .map(|(i, parsed)| {
+            parsed.map(|(ctx, statement)| {
+                // The first entry never gets a blank line before it, regardless
+                // of the leading newlines the file may have.
+                let separation = if i > 0 && ctx.has_blank_line_before() {
+                    syntax::Separation::BlankLine
+                } else {
+                    syntax::Separation::Immediate
+                };
+                (
+                    ctx,
+                    syntax::LedgerEntry {
+                        separation,
+                        statement,
+                    },
+                )
+            })
+        })
 }
 
-/// Parses given `input` into [syntax::LedgerEntry].
-fn parse_ledger_entry<'i, I, Deco>(input: &mut I) -> ModalResult<syntax::LedgerEntry<'i, Deco>>
+/// Parses given `input` into [syntax::LedgerStatement].
+fn parse_ledger_statement<'i, I, Deco>(
+    input: &mut I,
+) -> ModalResult<syntax::LedgerStatement<'i, Deco>>
 where
     I: Stream<Token = char, Slice = &'i str>
         + StreamIsPartial
@@ -50,25 +72,25 @@ where
     Deco: Decoration + 'static,
 {
     trace(
-        "parse_ledger_entry",
+        "parse_ledger_statement",
         dispatch! {peek(any);
             'a' => alt((
                 preceded(
                     peek(literal("account")),
-                    cut_err(directive::account_declaration.map(syntax::LedgerEntry::Account)),
+                    cut_err(directive::account_declaration.map(syntax::LedgerStatement::Account)),
                 ),
                 preceded(
                     peek(literal("apply")),
-                    cut_err(directive::apply_tag.map(syntax::LedgerEntry::ApplyTag)),
+                    cut_err(directive::apply_tag.map(syntax::LedgerStatement::ApplyTag)),
                 ),
             )),
-            'c' => directive::commodity_declaration.map(syntax::LedgerEntry::Commodity),
-            'e' => directive::end_apply_tag.map(|_| syntax::LedgerEntry::EndApplyTag),
-            'i' => directive::include.map(syntax::LedgerEntry::Include),
+            'c' => directive::commodity_declaration.map(syntax::LedgerStatement::Commodity),
+            'e' => directive::end_apply_tag.map(|_| syntax::LedgerStatement::EndApplyTag),
+            'i' => directive::include.map(syntax::LedgerStatement::Include),
             c if directive::is_comment_prefix(c) => {
-                directive::top_comment.map(syntax::LedgerEntry::Comment)
+                directive::top_comment.map(syntax::LedgerStatement::Comment)
             },
-            c if c.is_ascii_digit() => transaction::transaction.map(syntax::LedgerEntry::Txn),
+            c if c.is_ascii_digit() => transaction::transaction.map(syntax::LedgerStatement::Txn),
             _ => fail.context(StrContext::Label("no matching syntax")),
         },
     )
@@ -84,6 +106,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use syntax::plain::LedgerEntry;
+    use syntax::{LedgerStatement, Separation};
 
     fn parse_ledger_into(input: &'_ str) -> Vec<(ParsedContext<'_>, LedgerEntry<'_>)> {
         let r: Result<Vec<(ParsedContext, LedgerEntry)>, ParseError> =
@@ -92,6 +115,14 @@ mod tests {
             Ok(x) => x,
             Err(e) => panic!("failed to parse:\n{}", e),
         }
+    }
+
+    /// Returns the [`Separation`] of every parsed entry.
+    fn parse_ledger_separations(input: &str) -> Vec<Separation> {
+        parse_ledger_into(input)
+            .iter()
+            .map(|(_, entry)| entry.separation)
+            .collect()
     }
 
     #[test]
@@ -103,12 +134,17 @@ mod tests {
             vec![(
                 ParsedContext {
                     initial: input,
-                    span: 2..13
+                    span: 2..13,
+                    separator: 0..2,
                 },
-                syntax::LedgerEntry::Txn(syntax::Transaction::new(
-                    NaiveDate::from_ymd_opt(2022, 1, 23).unwrap(),
-                    ""
-                ))
+                LedgerEntry {
+                    // Leading newlines must not turn into a leading blank line.
+                    separation: Separation::Immediate,
+                    statement: LedgerStatement::Txn(syntax::Transaction::new(
+                        NaiveDate::from_ymd_opt(2022, 1, 23).unwrap(),
+                        ""
+                    )),
+                }
             )]
         );
     }
@@ -128,30 +164,69 @@ mod tests {
                 (
                     ParsedContext {
                         initial: input,
-                        span: 0..38
+                        span: 0..38,
+                        separator: 0..0,
                     },
-                    syntax::LedgerEntry::Txn(syntax::Transaction {
-                        posts: vec![syntax::Posting::new_untracked("Expenses:Grocery")],
-                        ..syntax::Transaction::new(
-                            NaiveDate::from_ymd_opt(2024, 4, 10).unwrap(),
-                            "Migros",
-                        )
-                    })
+                    LedgerEntry {
+                        separation: Separation::Immediate,
+                        statement: LedgerStatement::Txn(syntax::Transaction {
+                            posts: vec![syntax::Posting::new_untracked("Expenses:Grocery")],
+                            ..syntax::Transaction::new(
+                                NaiveDate::from_ymd_opt(2024, 4, 10).unwrap(),
+                                "Migros",
+                            )
+                        }),
+                    }
                 ),
                 (
                     ParsedContext {
                         initial: input,
-                        span: 38..74
+                        span: 38..74,
+                        separator: 38..38,
                     },
-                    syntax::LedgerEntry::Txn(syntax::Transaction {
-                        posts: vec![syntax::Posting::new_untracked("Expenses:Grocery")],
-                        ..syntax::Transaction::new(
-                            NaiveDate::from_ymd_opt(2024, 4, 20).unwrap(),
-                            "Coop"
-                        )
-                    })
+                    LedgerEntry {
+                        separation: Separation::Immediate,
+                        statement: LedgerStatement::Txn(syntax::Transaction {
+                            posts: vec![syntax::Posting::new_untracked("Expenses:Grocery")],
+                            ..syntax::Transaction::new(
+                                NaiveDate::from_ymd_opt(2024, 4, 20).unwrap(),
+                                "Coop"
+                            )
+                        }),
+                    }
                 )
             ]
         )
+    }
+
+    #[test]
+    fn parse_ledger_tracks_separation() {
+        let input = indoc! {"
+            ; comment right above the transaction
+            2024/4/10 Migros
+                Expenses:Grocery
+
+            include other.ledger
+            include another.ledger
+
+
+
+            end apply tag
+        "};
+
+        assert_eq!(
+            parse_ledger_separations(input),
+            vec![
+                // Leading comment, first entry of the file.
+                Separation::Immediate,
+                // Transaction glued to the comment above it.
+                Separation::Immediate,
+                Separation::BlankLine,
+                // Consecutive include directives stay grouped.
+                Separation::Immediate,
+                // Several blank lines are still just one separation.
+                Separation::BlankLine,
+            ]
+        );
     }
 }

--- a/core/src/parse/adaptor.rs
+++ b/core/src/parse/adaptor.rs
@@ -50,7 +50,14 @@ impl ParseOptions {
                 start,
                 e.into_inner(),
             )),
-            Ok((entry, span)) => Ok((ParsedContext { initial, span }, entry)),
+            Ok((entry, span)) => Ok((
+                ParsedContext {
+                    initial,
+                    span,
+                    separator: 0..0,
+                },
+                entry,
+            )),
         }
     }
 
@@ -82,11 +89,23 @@ impl ParseOptions {
 /// Context information carrying the metadata of the entry.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParsedContext<'i> {
+    /// Initial input.
     pub(super) initial: &'i str,
+    /// Span of the separator consumed right before the entry, may be empty.
+    pub(super) separator: Range<usize>,
+    /// Span of the parsed [`LedgerStatement`].
     pub(super) span: Range<usize>,
 }
 
 impl ParsedContext<'_> {
+    /// Returns `true` if a blank line preceded the entry.
+    ///
+    /// Every statement parser consumes its own trailing line ending, so any
+    /// separator left to consume in between means at least one blank line.
+    pub(super) fn has_blank_line_before(&self) -> bool {
+        !self.separator.is_empty()
+    }
+
     /// Computes the starting line number from this context.
     /// Note this function is O(N), not a cheap function.
     pub fn compute_line_start(&self) -> usize {
@@ -168,7 +187,7 @@ where
     E: winnow::error::ParserError<&'i str> + 'i,
 {
     fn next_impl(&mut self) -> Result<Option<(ParsedContext<'i>, Out)>, E> {
-        self.separator.parse_next(&mut self.input)?;
+        let separator = self.separator.by_ref().span().parse_next(&mut self.input)?;
         if self.input.is_empty() {
             return Ok(None);
         }
@@ -181,6 +200,7 @@ where
             ParsedContext {
                 initial: self.initial,
                 span,
+                separator,
             },
             entry,
         )))

--- a/core/src/report.rs
+++ b/core/src/report.rs
@@ -29,7 +29,7 @@ pub use process::{ProcessOptions, process};
 pub use tags::{Tag, TagQuery, TagValue, tags};
 pub use transaction::{Posting, Transaction};
 
-use crate::{load, syntax::plain::LedgerEntry};
+use crate::{load, syntax::plain::LedgerStatement};
 
 /// Returns all accounts for the given LedgerEntry.
 /// Returned accounts should be sorted as `str`.
@@ -43,8 +43,8 @@ where
     F: load::FileSystem,
 {
     loader.borrow().load(|path, pctx, entry| {
-        match entry {
-            LedgerEntry::Account(account) => {
+        match &entry.statement {
+            LedgerStatement::Account(account) => {
                 process::process_account(ctx, account).map_err(|berr| {
                     ReportError::BookKeep(
                         berr,
@@ -56,7 +56,7 @@ where
                     )
                 })?
             }
-            LedgerEntry::Txn(txn) => {
+            LedgerStatement::Txn(txn) => {
                 for posting in &txn.posts {
                     ctx.accounts.ensure(&posting.account);
                 }

--- a/core/src/report/process.rs
+++ b/core/src/report/process.rs
@@ -79,8 +79,8 @@ impl<'ctx> ProcessAccumulator<'ctx> {
         ctx: &mut ReportContext<'ctx>,
         entry: &syntax::tracked::LedgerEntry,
     ) -> Result<(), BookKeepError> {
-        match entry {
-            syntax::LedgerEntry::Txn(txn) => {
+        match &entry.statement {
+            syntax::LedgerStatement::Txn(txn) => {
                 self.txns.push(book_keeping::add_transaction(
                     ctx,
                     &mut self.price_repos,
@@ -89,8 +89,8 @@ impl<'ctx> ProcessAccumulator<'ctx> {
                 )?);
                 Ok(())
             }
-            syntax::LedgerEntry::Account(account) => process_account(ctx, account),
-            syntax::LedgerEntry::Commodity(commodity) => process_commodity(ctx, commodity),
+            syntax::LedgerStatement::Account(account) => process_account(ctx, account),
+            syntax::LedgerStatement::Commodity(commodity) => process_commodity(ctx, commodity),
             _ => Ok(()),
         }
     }

--- a/core/src/report/tags.rs
+++ b/core/src/report/tags.rs
@@ -4,7 +4,7 @@ use std::borrow::Borrow;
 use std::collections::BTreeSet;
 
 use crate::load;
-use crate::syntax::{self, plain::LedgerEntry};
+use crate::syntax::{self, plain::LedgerStatement};
 
 use super::error::ReportError;
 
@@ -58,11 +58,11 @@ where
 {
     let mut collected: BTreeSet<Tag> = BTreeSet::new();
     loader.borrow().load(|_path, _pctx, entry| {
-        match entry {
-            LedgerEntry::ApplyTag(apply) => {
+        match &entry.statement {
+            LedgerStatement::ApplyTag(apply) => {
                 insert(&mut collected, query, &apply.key, apply.value.as_ref())
             }
-            LedgerEntry::Txn(txn) => {
+            LedgerStatement::Txn(txn) => {
                 for metadata in &txn.metadata {
                     collect_metadata(&mut collected, query, metadata);
                 }

--- a/core/src/syntax.rs
+++ b/core/src/syntax.rs
@@ -17,9 +17,56 @@ use bounded_static::ToBoundedStatic;
 
 use decoration::Decoration;
 
-/// Top-level entry of the LedgerFile.
+/// How an entry is separated from the preceding entry.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Separation {
+    /// The entry immediately follows the previous entry, without a blank line.
+    Immediate,
+    /// The entry is separated from the previous entry by a blank line.
+    BlankLine,
+}
+
+/// Top-level entry of the LedgerFile, a [`LedgerStatement`] with its layout context.
 #[derive_where(Debug, PartialEq, Eq)]
-pub enum LedgerEntry<'i, Deco: Decoration> {
+pub struct LedgerEntry<'i, Deco: Decoration> {
+    /// How the entry is separated from the previous entry.
+    pub separation: Separation,
+    /// The statement itself.
+    pub statement: LedgerStatement<'i, Deco>,
+}
+
+impl<'i, Deco: Decoration> LedgerEntry<'i, Deco> {
+    /// Creates an entry separated from the previous entry by a blank line,
+    /// which is the usual way to write a Ledger file.
+    pub fn new(statement: LedgerStatement<'i, Deco>) -> Self {
+        Self {
+            separation: Separation::BlankLine,
+            statement,
+        }
+    }
+
+    /// Marks the entry as immediately following the previous entry.
+    pub fn immediate(self) -> Self {
+        Self {
+            separation: Separation::Immediate,
+            ..self
+        }
+    }
+}
+
+impl LedgerEntry<'_, plain::Ident> {
+    #[cfg(test)]
+    pub(crate) fn to_static(&self) -> LedgerEntry<'static, plain::Ident> {
+        LedgerEntry {
+            separation: self.separation,
+            statement: self.statement.to_static(),
+        }
+    }
+}
+
+/// Top-level statement of the LedgerFile.
+#[derive_where(Debug, PartialEq, Eq)]
+pub enum LedgerStatement<'i, Deco: Decoration> {
     /// Transaction
     Txn(Transaction<'i, Deco>),
     /// Comment, not limited to one-line oppose to `Metadata`.
@@ -36,17 +83,17 @@ pub enum LedgerEntry<'i, Deco: Decoration> {
     Commodity(CommodityDeclaration<'i>),
 }
 
-impl LedgerEntry<'_, plain::Ident> {
+impl LedgerStatement<'_, plain::Ident> {
     #[cfg(test)]
-    pub(crate) fn to_static(&self) -> LedgerEntry<'static, plain::Ident> {
+    pub(crate) fn to_static(&self) -> LedgerStatement<'static, plain::Ident> {
         match self {
-            LedgerEntry::Txn(v) => LedgerEntry::Txn(v.to_static()),
-            LedgerEntry::Comment(v) => LedgerEntry::Comment(v.to_static()),
-            LedgerEntry::ApplyTag(v) => LedgerEntry::ApplyTag(v.to_static()),
-            LedgerEntry::EndApplyTag => LedgerEntry::EndApplyTag,
-            LedgerEntry::Include(v) => LedgerEntry::Include(v.to_static()),
-            LedgerEntry::Account(v) => LedgerEntry::Account(v.to_static()),
-            LedgerEntry::Commodity(v) => LedgerEntry::Commodity(v.to_static()),
+            LedgerStatement::Txn(v) => LedgerStatement::Txn(v.to_static()),
+            LedgerStatement::Comment(v) => LedgerStatement::Comment(v.to_static()),
+            LedgerStatement::ApplyTag(v) => LedgerStatement::ApplyTag(v.to_static()),
+            LedgerStatement::EndApplyTag => LedgerStatement::EndApplyTag,
+            LedgerStatement::Include(v) => LedgerStatement::Include(v.to_static()),
+            LedgerStatement::Account(v) => LedgerStatement::Account(v.to_static()),
+            LedgerStatement::Commodity(v) => LedgerStatement::Commodity(v.to_static()),
         }
     }
 }

--- a/core/src/syntax/decoration.rs
+++ b/core/src/syntax/decoration.rs
@@ -38,6 +38,7 @@ macro_rules! define_as_undecorated {
 define_as_undecorated!(['i], Cow<'i, str>);
 define_as_undecorated!(['i], &'i str);
 define_as_undecorated!(['i, Deco: Decoration], super::LedgerEntry<'i, Deco>);
+define_as_undecorated!(['i, Deco: Decoration], super::LedgerStatement<'i, Deco>);
 define_as_undecorated!(['i, Deco: Decoration], super::Transaction<'i, Deco>);
 define_as_undecorated!(['i, Deco: Decoration], super::Posting<'i, Deco>);
 define_as_undecorated!(['i, Deco: Decoration], super::PostingAmount<'i, Deco>);

--- a/core/src/syntax/display.rs
+++ b/core/src/syntax/display.rs
@@ -61,14 +61,23 @@ impl<'a, T> WithContext<'a, T> {
 
 impl<Deco: Decoration> fmt::Display for WithContext<'_, LedgerEntry<'_, Deco>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.value.separation == Separation::BlankLine {
+            writeln!(f)?;
+        }
+        self.pass_context(&self.value.statement).fmt(f)
+    }
+}
+
+impl<Deco: Decoration> fmt::Display for WithContext<'_, LedgerStatement<'_, Deco>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.value {
-            LedgerEntry::Txn(txn) => self.pass_context(txn).fmt(f),
-            LedgerEntry::Comment(v) => v.fmt(f),
-            LedgerEntry::ApplyTag(v) => v.fmt(f),
-            LedgerEntry::EndApplyTag => writeln!(f, "end apply tag"),
-            LedgerEntry::Include(v) => v.fmt(f),
-            LedgerEntry::Account(v) => v.fmt(f),
-            LedgerEntry::Commodity(v) => self.pass_context(v).fmt(f),
+            LedgerStatement::Txn(txn) => self.pass_context(txn).fmt(f),
+            LedgerStatement::Comment(v) => v.fmt(f),
+            LedgerStatement::ApplyTag(v) => v.fmt(f),
+            LedgerStatement::EndApplyTag => writeln!(f, "end apply tag"),
+            LedgerStatement::Include(v) => v.fmt(f),
+            LedgerStatement::Account(v) => v.fmt(f),
+            LedgerStatement::Commodity(v) => self.pass_context(v).fmt(f),
         }
     }
 }
@@ -449,7 +458,7 @@ mod tests {
             concat!(";this\n", ";is\n", ";a pen pineapple apple pen.\n"),
             format!(
                 "{}",
-                ctx.as_display(&plain::LedgerEntry::Comment(TopLevelComment(
+                ctx.as_display(&plain::LedgerStatement::Comment(TopLevelComment(
                     Cow::Borrowed("this\nis\na pen pineapple apple pen."),
                 )))
             )
@@ -458,7 +467,7 @@ mod tests {
             "apply tag foo\n",
             format!(
                 "{}",
-                ctx.as_display(&tracked::LedgerEntry::ApplyTag(ApplyTag {
+                ctx.as_display(&tracked::LedgerStatement::ApplyTag(ApplyTag {
                     key: Cow::Borrowed("foo"),
                     value: None
                 })),
@@ -468,7 +477,7 @@ mod tests {
             "apply tag foo: bar\n",
             format!(
                 "{}",
-                ctx.as_display(&plain::LedgerEntry::ApplyTag(ApplyTag {
+                ctx.as_display(&plain::LedgerStatement::ApplyTag(ApplyTag {
                     key: Cow::Borrowed("foo"),
                     value: Some(MetadataValue::Text(Cow::Borrowed("bar")))
                 }))
@@ -478,7 +487,7 @@ mod tests {
             "apply tag foo:: 100\n",
             format!(
                 "{}",
-                ctx.as_display(&tracked::LedgerEntry::ApplyTag(ApplyTag {
+                ctx.as_display(&tracked::LedgerStatement::ApplyTag(ApplyTag {
                     key: Cow::Borrowed("foo"),
                     value: Some(MetadataValue::Expr(Cow::Borrowed("100")))
                 }))
@@ -486,7 +495,24 @@ mod tests {
         );
         assert_eq!(
             "end apply tag\n",
-            format!("{}", ctx.as_display(&plain::LedgerEntry::EndApplyTag))
+            format!("{}", ctx.as_display(&plain::LedgerStatement::EndApplyTag))
+        );
+    }
+
+    #[test]
+    fn display_ledger_entry_emits_blank_line_on_separation() {
+        let ctx = DisplayContext::default();
+        let entry = |separation| plain::LedgerEntry {
+            separation,
+            statement: plain::LedgerStatement::EndApplyTag,
+        };
+        assert_eq!(
+            "end apply tag\n",
+            format!("{}", ctx.as_display(&entry(Separation::Immediate)))
+        );
+        assert_eq!(
+            "\nend apply tag\n",
+            format!("{}", ctx.as_display(&entry(Separation::BlankLine)))
         );
     }
 
@@ -494,7 +520,7 @@ mod tests {
     fn display_txn() {
         let got = format!(
             "{}",
-            DisplayContext::default().as_display(&LedgerEntry::Txn(plain::Transaction {
+            DisplayContext::default().as_display(&LedgerStatement::Txn(plain::Transaction {
                 date: NaiveDate::from_ymd_opt(2022, 12, 23).unwrap(),
                 effective_date: None,
                 clear_state: ClearState::Uncleared,

--- a/core/src/syntax/plain.rs
+++ b/core/src/syntax/plain.rs
@@ -26,6 +26,7 @@ impl Decoration for Ident {
 }
 
 pub type LedgerEntry<'i> = super::LedgerEntry<'i, Ident>;
+pub type LedgerStatement<'i> = super::LedgerStatement<'i, Ident>;
 pub type Transaction<'i> = super::Transaction<'i, Ident>;
 pub type Posting<'i> = super::Posting<'i, Ident>;
 pub type PostingAmount<'i> = super::PostingAmount<'i, Ident>;

--- a/core/src/syntax/tracked.rs
+++ b/core/src/syntax/tracked.rs
@@ -29,6 +29,7 @@ impl Decoration for Tracking {
 }
 
 pub type LedgerEntry<'i> = super::LedgerEntry<'i, Tracking>;
+pub type LedgerStatement<'i> = super::LedgerStatement<'i, Tracking>;
 pub type Transaction<'i> = super::Transaction<'i, Tracking>;
 pub type Posting<'i> = super::Posting<'i, Tracking>;
 pub type PostingAmount<'i> = super::PostingAmount<'i, Tracking>;


### PR DESCRIPTION
## Motivation

Formatting put a blank line between *every* entry, because `format.rs` used `writeln!` on output
that is already newline-terminated. That meant a comment block written directly above a transaction
got pushed away from it, runs of `apply tag` / `include` directives got exploded, and every file
gained a stray blank line at EOF. That makes in-place formatting destructive and non-idempotent,
which blocks the recursive `okane format` command.

## Change

`syntax::LedgerEntry` becomes a thin struct pairing the new `syntax::Separation` with
`syntax::LedgerStatement` — the enum holding the seven variants `LedgerEntry` used to have:

```rust
pub enum Separation { Immediate, BlankLine }

pub struct LedgerEntry<'i, Deco: Decoration> {
    pub separation: Separation,
    pub statement: LedgerStatement<'i, Deco>,
}
```

`ParsedIter::next_impl` already parsed the entry separator and threw it away; it now records the
separator span on `ParsedContext`, and `parse_ledger` stamps `separation` from it. Every top-level
statement parser consumes its own trailing line ending, so an empty separator is an exact test for
"immediately follows the previous entry"; any non-empty run means a blank line, collapsed to one.
The first entry of a file is always `Immediate`, so leading newlines never become a leading blank
line.

`Display for LedgerEntry` emits the blank line itself, and the two callers
(`format::FormatOptions::format`, `primitive flatten`) switch from `writeln!` to `write!`.
`primitive flatten` additionally emits a blank line at file boundaries, since the first entry of
each included file is `Immediate`.

## Result

Formatting now reproduces the author's grouping:

```
; Explains the transaction below.
2021/03/12 Opening Balance
    Assets:Bank                                          = 1000 CHF
    Equity
; Explains the transaction above.

; Standalone comment, separated by blank lines.

2021/03/13 Grocery
    Expenses:Grocery                              10 CHF
    Assets:Bank
```

This is a **breaking change** to the public `okane-core` API.

## Tests

- New: `parse_ledger_tracks_separation`, `display_ledger_entry_emits_blank_line_on_separation`,
  `format_keeps_comment_attached_to_the_next_entry`, `format_collapses_consecutive_blank_lines`,
  `format_is_idempotent`.
- Updated `format_succeeds_transaction_without_lot_price` expectations, and `load.rs` test fragments
  now state the separation of their first entry explicitly (a fragment starts wherever the preceding
  `include` was, so it cannot be derived from the fragment alone).
- `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)