### PR TITLE
Generalize report::eval::Evaluable into an expression visitor

### DIFF
--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -17,84 +17,90 @@ pub use evaluated::Evaluated;
 pub(super) use posting_amount::PostingAmount;
 pub use single_amount::SingleAmount;
 
+use std::marker::PhantomData;
+
 use super::context::ReportContext;
-use crate::syntax::expr;
+use crate::syntax::expr::{self, ExprVisitor, Visitable};
 
-/// Provides syntax tree evaluation.
-pub(crate) trait Evaluable {
-    /// Visitor for AST.
-    /// Argument `evaluator` is a call operator to evaluate the given syntax amount to [`Evaluated`].
-    fn eval_visit<'ctx, F: FnMut(&expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>>(
-        &self,
-        evaluator: &mut F,
-    ) -> Result<Evaluated<'ctx>, EvalError<'ctx>>;
-
+/// Provides syntax tree evaluation, on top of [`EvalExpr`].
+pub(crate) trait Evaluable<'i>: Visitable<'i> {
     /// Evaluate the self with mutable `ctx`, which allows unknown commodities in the expressions to be registered.
     fn eval_mut<'ctx>(
         &self,
         ctx: &mut ReportContext<'ctx>,
     ) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        self.eval_visit(&mut |amount| Ok(Evaluated::from_expr_amount_mut(ctx, amount)))
+        self.accept(&mut EvalExpr::new(RegisterCommodity(ctx)))
     }
 
     /// Evaluate the self with immutable `ctx`, which raises error on unknown commodities.
     fn eval<'ctx>(&self, ctx: &ReportContext<'ctx>) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        self.eval_visit(&mut |amount| Evaluated::from_expr_amount(ctx, amount))
+        self.accept(&mut EvalExpr::new(ResolveCommodity(ctx)))
     }
 }
 
-impl Evaluable for expr::ValueExpr<'_> {
-    fn eval_visit<'ctx, F: FnMut(&expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>>(
-        &self,
-        evaluator: &mut F,
-    ) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        match self {
-            expr::ValueExpr::Paren(x) => x.eval_visit(evaluator),
-            expr::ValueExpr::Amount(x) => evaluator(x),
-        }
+impl<'i, T: Visitable<'i> + ?Sized> Evaluable<'i> for T {}
+
+/// [`ExprVisitor`] evaluating an expression into [`Evaluated`].
+///
+/// Handling of the leaf is delegated to `A`, which decides whether an unknown commodity gets
+/// registered ([`Evaluable::eval_mut`]) or rejected ([`Evaluable::eval`]).
+struct EvalExpr<'ctx, A>(A, PhantomData<ReportContext<'ctx>>);
+
+impl<'ctx, A: EvalAmount<'ctx>> EvalExpr<'ctx, A> {
+    fn new(eval_amount: A) -> Self {
+        EvalExpr(eval_amount, PhantomData)
     }
 }
 
-impl Evaluable for expr::Expr<'_> {
-    fn eval_visit<'ctx, F: FnMut(&expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>>(
-        &self,
-        evaluator: &mut F,
-    ) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        match self {
-            expr::Expr::Unary(e) => e.eval_visit(evaluator),
-            expr::Expr::Binary(e) => e.eval_visit(evaluator),
-            expr::Expr::Value(e) => e.eval_visit(evaluator),
-        }
-    }
-}
+impl<'i, 'ctx, A: EvalAmount<'ctx>> ExprVisitor<'i> for EvalExpr<'ctx, A> {
+    type Output = Evaluated<'ctx>;
+    type Error = EvalError<'ctx>;
 
-impl Evaluable for expr::UnaryOpExpr<'_> {
-    fn eval_visit<'ctx, F: FnMut(&expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>>(
-        &self,
-        evaluator: &mut F,
-    ) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        match self.op {
+    fn visit_amount(&mut self, amount: &expr::Amount<'i>) -> Result<Self::Output, Self::Error> {
+        self.0.eval_amount(amount)
+    }
+
+    fn visit_unary(&mut self, expr: &expr::UnaryOpExpr<'i>) -> Result<Self::Output, Self::Error> {
+        match expr.op {
             expr::UnaryOp::Negate => {
-                let val = self.expr.eval_visit(evaluator)?;
+                let val = self.visit_expr(&expr.expr)?;
                 Ok(val.negate())
             }
         }
     }
-}
 
-impl Evaluable for expr::BinaryOpExpr<'_> {
-    fn eval_visit<'ctx, F: FnMut(&expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>>(
-        &self,
-        evaluator: &mut F,
-    ) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
-        let lhs = self.lhs.eval_visit(evaluator)?;
-        let rhs = self.rhs.eval_visit(evaluator)?;
-        match self.op {
+    fn visit_binary(&mut self, expr: &expr::BinaryOpExpr<'i>) -> Result<Self::Output, Self::Error> {
+        let lhs = self.visit_expr(&expr.lhs)?;
+        let rhs = self.visit_expr(&expr.rhs)?;
+        match expr.op {
             expr::BinaryOp::Add => lhs.check_add(rhs),
             expr::BinaryOp::Sub => lhs.check_sub(rhs),
             expr::BinaryOp::Mul => lhs.check_mul(rhs),
             expr::BinaryOp::Div => lhs.check_div(rhs),
         }
+    }
+}
+
+/// Evaluation of the leaf amount, which is the only part [`EvalExpr`] varies on.
+trait EvalAmount<'ctx> {
+    fn eval_amount(&mut self, amount: &expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>>;
+}
+
+/// [`EvalAmount`] registering the unknown commodities into the context.
+struct RegisterCommodity<'a, 'ctx>(&'a mut ReportContext<'ctx>);
+
+impl<'ctx> EvalAmount<'ctx> for RegisterCommodity<'_, 'ctx> {
+    fn eval_amount(&mut self, amount: &expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
+        Ok(Evaluated::from_expr_amount_mut(self.0, amount))
+    }
+}
+
+/// [`EvalAmount`] raising an error on the unknown commodities.
+struct ResolveCommodity<'a, 'ctx>(&'a ReportContext<'ctx>);
+
+impl<'ctx> EvalAmount<'ctx> for ResolveCommodity<'_, 'ctx> {
+    fn eval_amount(&mut self, amount: &expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
+        Evaluated::from_expr_amount(self.0, amount)
     }
 }
 

--- a/core/src/syntax/expr.rs
+++ b/core/src/syntax/expr.rs
@@ -92,3 +92,169 @@ pub struct BinaryOpExpr<'i> {
     pub lhs: Box<Expr<'i>>,
     pub rhs: Box<Expr<'i>>,
 }
+
+/// Visitor over the value expression AST.
+///
+/// Every `visit_*` method is responsible for recursing into its own children, usually by
+/// calling [`ExprVisitor::visit_expr`]. That leaves the visitor free to run code before,
+/// between and after the children, which a plain fold over already-computed child values
+/// could not express.
+///
+/// [`ExprVisitor::visit_value_expr`] and [`ExprVisitor::visit_expr`] only dispatch on the node
+/// kind, so they come with default implementations. Implementors normally provide just
+/// [`ExprVisitor::visit_amount`], [`ExprVisitor::visit_unary`] and [`ExprVisitor::visit_binary`].
+pub(crate) trait ExprVisitor<'i> {
+    /// Value produced for every expression node.
+    type Output;
+
+    /// Error aborting the traversal.
+    type Error;
+
+    /// Visits an amount literal, the only leaf of the tree.
+    fn visit_amount(&mut self, amount: &Amount<'i>) -> Result<Self::Output, Self::Error>;
+
+    /// Visits a unary operator expression, recursing into `expr.expr`.
+    fn visit_unary(&mut self, expr: &UnaryOpExpr<'i>) -> Result<Self::Output, Self::Error>;
+
+    /// Visits a binary operator expression, recursing into `expr.lhs` and `expr.rhs`.
+    fn visit_binary(&mut self, expr: &BinaryOpExpr<'i>) -> Result<Self::Output, Self::Error>;
+
+    /// Visits a value expression, dispatching to [`Self::visit_expr`] or [`Self::visit_amount`].
+    fn visit_value_expr(&mut self, expr: &ValueExpr<'i>) -> Result<Self::Output, Self::Error> {
+        match expr {
+            ValueExpr::Paren(x) => self.visit_expr(x),
+            ValueExpr::Amount(x) => self.visit_amount(x),
+        }
+    }
+
+    /// Visits a generic expression, dispatching on the node kind.
+    fn visit_expr(&mut self, expr: &Expr<'i>) -> Result<Self::Output, Self::Error> {
+        match expr {
+            Expr::Unary(e) => self.visit_unary(e),
+            Expr::Binary(e) => self.visit_binary(e),
+            Expr::Value(e) => self.visit_value_expr(e),
+        }
+    }
+}
+
+/// Node of the expression AST an [`ExprVisitor`] can be applied to.
+pub(crate) trait Visitable<'i> {
+    /// Invokes the `visitor` method corresponding to `Self`.
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error>;
+}
+
+impl<'i> Visitable<'i> for Amount<'i> {
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
+        visitor.visit_amount(self)
+    }
+}
+
+impl<'i> Visitable<'i> for ValueExpr<'i> {
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
+        visitor.visit_value_expr(self)
+    }
+}
+
+impl<'i> Visitable<'i> for Expr<'i> {
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
+        visitor.visit_expr(self)
+    }
+}
+
+impl<'i> Visitable<'i> for UnaryOpExpr<'i> {
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
+        visitor.visit_unary(self)
+    }
+}
+
+impl<'i> Visitable<'i> for BinaryOpExpr<'i> {
+    fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
+        visitor.visit_binary(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::convert::Infallible;
+
+    use pretty_assertions::assert_eq;
+
+    /// [`ExprVisitor`] recording every node it reaches, relying on the default dispatch.
+    #[derive(Default)]
+    struct TraceVisitor(Vec<String>);
+
+    impl<'i> ExprVisitor<'i> for TraceVisitor {
+        type Output = ();
+        type Error = Infallible;
+
+        fn visit_amount(&mut self, amount: &Amount<'i>) -> Result<(), Infallible> {
+            self.0.push(format!("amount({})", amount.commodity));
+            Ok(())
+        }
+
+        fn visit_unary(&mut self, expr: &UnaryOpExpr<'i>) -> Result<(), Infallible> {
+            self.0.push(format!("unary({})", expr.op));
+            self.visit_expr(&expr.expr)
+        }
+
+        fn visit_binary(&mut self, expr: &BinaryOpExpr<'i>) -> Result<(), Infallible> {
+            self.0.push(format!("binary({})", expr.op));
+            self.visit_expr(&expr.lhs)?;
+            self.visit_expr(&expr.rhs)
+        }
+    }
+
+    #[test]
+    fn visitor_reaches_all_nodes_in_pre_order() {
+        let input: ValueExpr = "(1 USD * (-2 + 3 EUR))".try_into().expect("must parse");
+        let mut visitor = TraceVisitor::default();
+        input.accept(&mut visitor).expect("must not fail");
+        assert_eq!(
+            vec![
+                "binary(*)",
+                "amount(USD)",
+                "binary(+)",
+                "unary(-)",
+                "amount()",
+                "amount(EUR)",
+            ],
+            visitor.0
+        );
+    }
+
+    #[test]
+    fn visitor_aborts_on_error() {
+        /// [`ExprVisitor`] failing on the first amount without a commodity.
+        struct FailingVisitor(usize);
+
+        impl<'i> ExprVisitor<'i> for FailingVisitor {
+            type Output = ();
+            type Error = ();
+
+            fn visit_amount(&mut self, amount: &Amount<'i>) -> Result<(), ()> {
+                self.0 += 1;
+                if amount.commodity.is_empty() {
+                    return Err(());
+                }
+                Ok(())
+            }
+
+            fn visit_unary(&mut self, expr: &UnaryOpExpr<'i>) -> Result<(), ()> {
+                self.visit_expr(&expr.expr)
+            }
+
+            fn visit_binary(&mut self, expr: &BinaryOpExpr<'i>) -> Result<(), ()> {
+                self.visit_expr(&expr.lhs)?;
+                self.visit_expr(&expr.rhs)
+            }
+        }
+
+        let input: ValueExpr = "(1 USD + 2 + 3 EUR)".try_into().expect("must parse");
+        let mut visitor = FailingVisitor(0);
+        assert_eq!(Err(()), input.accept(&mut visitor));
+        // Stopped right at the bare `2`, without reaching `3 EUR`.
+        assert_eq!(2, visitor.0);
+    }
+}


### PR DESCRIPTION
## Context

`report::eval::Evaluable` was *shaped* like a visitor but wasn't one. Its `eval_visit` exposed a single `FnMut(&expr::Amount)` closure for the leaf, while `Paren`, `UnaryOpExpr` and `BinaryOpExpr` were hardcoded to `Evaluated::negate` / `check_add` / `check_sub` / `check_mul` / `check_div`. Nothing that wanted to traverse an expression for another purpose could reuse it.

The cost is already visible elsewhere in the tree: `syntax::display`'s `DisplayWithAlignment` is a second, independent hand-rolled traversal of the same five-variant AST, and `DisplayContextBuilder` on the `recursive-format` branch is a third.

## What changed

**`ExprVisitor` in `syntax::expr`** (`pub(crate)`) — a walk-style visitor where each `visit_*` method drives its own recursion:

- `visit_amount` / `visit_unary` / `visit_binary` are required.
- `visit_value_expr` / `visit_expr` only dispatch on the node kind, so they're defaulted.
- `Visitable` gives each node an `accept()` entry point.

Walk-style rather than fold-style (visitor receives already-computed child values) specifically so it can express in-order side effects — a formatter has to write `(` *before* recursing and the operator *between* the operands. #531 is what exercises that.

**`Evaluable` becomes a wrapper.** An `Evaluator` visitor holds the arithmetic; the leaf strategy moves into a small `EvalAmount` trait with `RegisterCommodity` (registers unknown commodities, backs `eval_mut`) and `ResolveCommodity` (rejects them, backs `eval`). A trait rather than the previous closures because wrapping a closure in a struct loses the higher-ranked signature that inference needs.

## Behavior

None. Same results, same errors. The six call sites in `report::query` and `report::book_keeping` are untouched.

## Testing

- `cargo test` green; the three eval unit tests are unchanged and act as the regression net.
- Golden tests pass **without** `UPDATE_GOLDEN=1`; no golden file regenerated.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Two new tests in `syntax::expr` use visitors that are neither eval nor display — one traces traversal order to pin the default dispatch, one checks that an error aborts the walk early.

## Stack

- **#530 (this)** — add `ExprVisitor`, rebuild `Evaluable` on it → `main`
- #531 — port the expression formatter onto it → `expr-visitor`
- #526 — recursive `okane format`, which also adopts the visitor → stacked on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)