### PR TITLE
bench: pin codegen-units in the bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,10 @@ lto = "thin"
 
 [profile.bench]
 debug = "limited"
+# `cargo bench` builds with this profile, which inherits `lto = "thin"` from
+# release. With the default 16 codegen units the measurements become a function
+# of CGU partitioning: an edit in one module can repartition the units and
+# change whether a hot loop in an unrelated module still gets its callees
+# inlined. Pinning to 1 removes that variable, so a CI alert means a real
+# change. See #537.
+codegen-units = 1


### PR DESCRIPTION
Towards #537.

## Context

`cargo bench` builds with `[profile.bench]`, which inherits `lto = "thin"` from release and uses the default 16 codegen units. That makes the numbers a function of CGU partitioning: an edit in one module can repartition the units and change whether a hot loop in an unrelated module still gets its callees inlined.

#537 is an instance of exactly that. The whole `query::register` group moved +60–80% at `4a9d7fe` and returned to baseline at `fbe8c75`:

| commit | default/small | account-filter/small | date-range-first10/small |
|---|---|---|---|
| `617b227` | 380,090 | 53,326 | 53,894 |
| `69850de` | 361,935 | 54,806 | 49,682 |
| `4a9d7fe` | **726,684** | **72,134** | **86,243** |
| `fbe8c75` | 377,947 | 50,296 | 51,571 |

`4a9d7fe` touched one file, `syntax::display`, which is not reachable from `RegisterEntries::next` — that loop is `advance_to_next_posting` plus `Amount::add_assign`. `process/*`, the bench that *does* exercise the eval path, stayed flat across the same four runs. And the error bars were tight (726,684 ± 5,155), so it was a real property of that binary rather than runner noise.

## What this changes

`codegen-units = 1` on `[profile.bench]`, with a comment explaining why.

## Effect

This is not a performance PR — it's a measurement-stability one. On the affected commit rebuilt locally with `codegen-units = 1`, the cheap register benches improve ~4–6% and nothing gets worse (paired alternating rounds, `date-range-first10`: baseline 78,110 / 77,474 / 77,556 vs 74,191 / 72,734 / 68,587). The point is not the 5%; it's that the number stops depending on where the partitioner happens to draw lines.

Cost is a longer bench build. The job already runs ~15m and `Swatinem/rust-cache` is in place.

## Open question

With this on `bench` only, the benchmark stops matching the profile users actually install (`[profile.release]`, default 16 CGUs). The alternative is putting `codegen-units = 1` on `[profile.release]` so `bench` inherits it and the two agree, at the cost of slower `cargo install`. I didn't want to make that call unilaterally — happy to move it if you'd rather the two profiles agree.

## Testing

`cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` all clean. Profile settings cannot change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
