### PR TITLE
report: inline the small cross-module calls on the register hot loop

### DIFF
--- a/core/src/report/eval.rs
+++ b/core/src/report/eval.rs
@@ -56,6 +56,7 @@ impl<'i, 'ctx, A: EvalAmount<'ctx>> ExprVisitor<'i> for EvalExpr<'ctx, A> {
     type Output = Evaluated<'ctx>;
     type Error = EvalError<'ctx>;
 
+    #[inline]
     fn visit_amount(&mut self, amount: &expr::Amount<'i>) -> Result<Self::Output, Self::Error> {
         self.0.eval_amount(amount)
     }
@@ -90,6 +91,7 @@ trait EvalAmount<'ctx> {
 struct RegisterCommodity<'a, 'ctx>(&'a mut ReportContext<'ctx>);
 
 impl<'ctx> EvalAmount<'ctx> for RegisterCommodity<'_, 'ctx> {
+    #[inline]
     fn eval_amount(&mut self, amount: &expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
         Ok(Evaluated::from_expr_amount_mut(self.0, amount))
     }
@@ -99,6 +101,7 @@ impl<'ctx> EvalAmount<'ctx> for RegisterCommodity<'_, 'ctx> {
 struct ResolveCommodity<'a, 'ctx>(&'a ReportContext<'ctx>);
 
 impl<'ctx> EvalAmount<'ctx> for ResolveCommodity<'_, 'ctx> {
+    #[inline]
     fn eval_amount(&mut self, amount: &expr::Amount) -> Result<Evaluated<'ctx>, EvalError<'ctx>> {
         Evaluated::from_expr_amount(self.0, amount)
     }

--- a/core/src/report/eval/amount.rs
+++ b/core/src/report/eval/amount.rs
@@ -342,6 +342,7 @@ impl Add for Amount<'_> {
 }
 
 impl<'ctx> AddAssign<&'_ Amount<'ctx>> for Amount<'ctx> {
+    #[inline]
     fn add_assign(&mut self, rhs: &Amount<'ctx>) {
         for (&c, &v2) in &rhs.values {
             *self.values.entry(c).or_insert(Decimal::ZERO) += v2;

--- a/core/src/report/query.rs
+++ b/core/src/report/query.rs
@@ -148,6 +148,7 @@ impl DateRange {
         self.start.is_none() && self.end.is_none()
     }
 
+    #[inline]
     fn contains(&self, date: NaiveDate) -> bool {
         match (self.start, self.end) {
             (Some(start), _) if date < start => false,
@@ -699,6 +700,7 @@ impl<'ctx> AccountFilter<'ctx> {
     }
 
     /// Returns `true` if the given account matches this filter.
+    #[inline]
     fn is_match(&self, account: &Account<'ctx>) -> bool {
         match self {
             AccountFilter::All => true,

--- a/core/src/syntax/expr.rs
+++ b/core/src/syntax/expr.rs
@@ -120,6 +120,7 @@ pub(crate) trait ExprVisitor<'i> {
     fn visit_binary(&mut self, expr: &BinaryOpExpr<'i>) -> Result<Self::Output, Self::Error>;
 
     /// Visits a value expression, dispatching to [`Self::visit_expr`] or [`Self::visit_amount`].
+    #[inline]
     fn visit_value_expr(&mut self, expr: &ValueExpr<'i>) -> Result<Self::Output, Self::Error> {
         match expr {
             ValueExpr::Paren(x) => self.visit_expr(x),
@@ -128,6 +129,7 @@ pub(crate) trait ExprVisitor<'i> {
     }
 
     /// Visits a generic expression, dispatching on the node kind.
+    #[inline]
     fn visit_expr(&mut self, expr: &Expr<'i>) -> Result<Self::Output, Self::Error> {
         match expr {
             Expr::Unary(e) => self.visit_unary(e),
@@ -144,30 +146,35 @@ pub(crate) trait Visitable<'i> {
 }
 
 impl<'i> Visitable<'i> for Amount<'i> {
+    #[inline]
     fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
         visitor.visit_amount(self)
     }
 }
 
 impl<'i> Visitable<'i> for ValueExpr<'i> {
+    #[inline]
     fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
         visitor.visit_value_expr(self)
     }
 }
 
 impl<'i> Visitable<'i> for Expr<'i> {
+    #[inline]
     fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
         visitor.visit_expr(self)
     }
 }
 
 impl<'i> Visitable<'i> for UnaryOpExpr<'i> {
+    #[inline]
     fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
         visitor.visit_unary(self)
     }
 }
 
 impl<'i> Visitable<'i> for BinaryOpExpr<'i> {
+    #[inline]
     fn accept<V: ExprVisitor<'i> + ?Sized>(&self, visitor: &mut V) -> Result<V::Output, V::Error> {
         visitor.visit_binary(self)
     }


### PR DESCRIPTION
Towards #537. Independent of the `codegen-units` PR — either can land alone.

## Context

`RegisterEntries::next` is `advance_to_next_posting` plus `self.total += amount`. Three of the functions it calls per posting live in other modules:

- `AccountFilter::is_match` — a three-arm match, once per posting
- `DateRange::contains` — once per transaction
- `AddAssign<&Amount> for Amount` — the dominant per-posting work

Whether those get inlined is decided by codegen-unit partitioning, which is how an edit to an unrelated module can move `query::register` by a large factor. In #537 the group went +60–80% at `4a9d7fe` and back to baseline at `fbe8c75`, with nothing in the loop's reachable set having changed in either commit.

## What this changes

`#[inline]` on those three, plus the same class of one-line cross-module forwarders on the two `ExprVisitor` consumers added in #530 / #531 — the `visit_value_expr` / `visit_expr` dispatch defaults, the five `Visitable::accept` impls, and the `EvalAmount` leaf forwarders. Those are pure dispatch, nothing but a `match`.

`TxnIter::next` in the same loop already carries `#[inline]` for exactly this reason, as do the accessors in `report::account`, `report::commodity` and `report::context`.

13 lines, all attributes.

## Measurements

Honest summary: **the #537 regression does not reproduce on my machine at all.** Windows/x86-64, small dataset — `4a9d7fe` and `fbe8c75` are identical within noise on every register bench (default 1,029,092 vs 1,001,790; account-filter 85,227 vs 84,804; date-range-first10 81,820 vs 82,269). That's consistent with a CGU-layout effect, which is toolchain- and target-specific.

What I can measure is the patch's own effect, applied to `4a9d7fe` and compared against it in paired alternating rounds:

`date-range-first10/small` (ns/iter)

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| baseline | 78,110 | 77,474 | 77,556 |
| this patch | 75,108 | 72,497 | 71,955 |

`account-filter/small` (ns/iter)

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| baseline | 75,688 | — | 75,683 |
| this patch | 72,030 | 71,514 | 71,536 |

So ~5%, consistent, never worse. `default` and the conversion benches are bimodal on this laptop (baseline swung 1,126,780 → 667,918 between rounds) and one `account-filter` baseline sample came in at 127,244 — I've left both out rather than dress them up. The CI bench run on this PR is the better data point, and I'd treat it as the deciding one.

## Testing

`cargo test` (567 tests) green, golden tests pass **without** `UPDATE_GOLDEN=1`. `cargo clippy --all-targets` and `cargo fmt --check` clean. `#[inline]` cannot change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
