### PR TITLE
release: build with codegen-units = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,13 @@ rust_decimal_macros = "1.40"
 
 [profile.release]
 lto = "thin"
+# Released binaries are built once and run many times, so trade build time for
+# codegen quality. This also makes `cargo bench` reproducible: `[profile.bench]`
+# inherits from here, and with the default 16 codegen units the benchmark
+# numbers become a function of CGU partitioning — an edit in one module can
+# repartition the units and change whether a hot loop in an unrelated module
+# still gets its callees inlined. See #537.
+codegen-units = 1
 
 [profile.bench]
 debug = "limited"


### PR DESCRIPTION
Towards #537. Overlaps with #538 — see "Relationship to #538" below.

## Context

Two reasons to pin codegen units on the release profile.

**Released binaries are built once and run many times**, so the build-time / codegen-quality trade is worth taking. The workspace already opts into `lto = "thin"` for the same reason.

**It makes the benchmark reproducible**, which is what #537 is about. `[profile.bench]` inherits from `[profile.release]` — verified with `cargo bench --bench report_bench --no-run -v`, the bench binary is compiled with `-C lto=thin` even though `lto` is only ever set under `[profile.release]`. So with the default 16 codegen units the bench numbers are a function of CGU partitioning: an edit in one module can repartition the units and change whether a hot loop in an unrelated module still gets its callees inlined.

#537 is an instance. The `query::register` group moved +60–80% at `4a9d7fe` and returned to baseline at `fbe8c75`:

| commit | default/small | account-filter/small | date-range-first10/small |
|---|---|---|---|
| `617b227` | 380,090 | 53,326 | 53,894 |
| `69850de` | 361,935 | 54,806 | 49,682 |
| `4a9d7fe` | **726,684** | **72,134** | **86,243** |
| `fbe8c75` | 377,947 | 50,296 | 51,571 |

`4a9d7fe` touched one file, `syntax::display`, which is not reachable from `RegisterEntries::next` — that loop is `advance_to_next_posting` plus `Amount::add_assign`. `process/*`, the bench that *does* exercise the eval path, stayed flat across the same four runs. The error bars were tight (726,684 ± 5,155), so it was a real property of that binary rather than runner noise.

## Build-time cost

Negligible — clean workspace release build, same machine, back to back:

| | wall clock |
|---|---|
| default (16 CGUs) | 3m 23s |
| `codegen-units = 1` | 3m 25s |

`lto = "thin"` already serializes the expensive part, so dropping codegen parallelism costs about 1% here. I have not measured the runtime effect on the shipped binary — the argument for this PR is reproducibility plus the standard release-profile trade, not a claimed speedup.

## Relationship to #538

#538 sets `codegen-units = 1` on `[profile.bench]` only, which fixes the benchmark but leaves it measuring a different configuration from the one users install. This PR sets it on `[profile.release]` so `bench` inherits it and the two agree.

**They are alternatives.** If you take this one, #538 can be closed — or keep both, since the explicit line under `[profile.bench]` is a harmless restatement. Your call; happy to close whichever you don't want.

## Testing

`cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` all clean. Profile settings cannot change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
