### PR TITLE
ui: draw the report tables one row per amount line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 ### Changed
 
 * CLI: `ui` reload errors are now shown in color instead of plain text (https://github.com/xkikeg/okane/issues/489).
+* CLI: `ui` balance and register tables now draw one table row per amount line, so a
+  multi-commodity account is never clipped and every one of its lines can be scrolled to
+  (https://github.com/xkikeg/okane/issues/513). `↑`/`↓` walk lines and the new `J`/`K` jump a whole
+  account or register entry. An account whose name has scrolled off the top of the body has it
+  redrawn on the top line in color, and one cut by either edge says how much is hidden with
+  `+N above` / `+N more`. A terminal too short to hold a single row now says so instead of showing
+  an empty table.
 * Core: `syntax::LedgerEntry` is now a struct pairing a `syntax::Separation` with the new
   `syntax::LedgerStatement` enum, which holds the variants `LedgerEntry` used to have.
   `Separation` records whether a blank line preceded the entry in the source

--- a/cli/src/ui/import/app.rs
+++ b/cli/src/ui/import/app.rs
@@ -261,18 +261,18 @@ impl ReviewApp {
         }
 
         match msg {
-            Message::MoveUp => self.nav.move_selection(-1),
-            Message::MoveDown => self.nav.move_selection(1),
+            Message::MoveUp => self.nav.move_rows(-1),
+            Message::MoveDown => self.nav.move_rows(1),
             Message::PageUp => {
                 let delta = -(self.nav.page_size() as isize);
-                self.nav.move_selection(delta);
+                self.nav.move_rows(delta);
             }
             Message::PageDown => {
                 let delta = self.nav.page_size() as isize;
-                self.nav.move_selection(delta);
+                self.nav.move_rows(delta);
             }
-            Message::SelectFirst => self.nav.select_first(),
-            Message::SelectLast => self.nav.select_last(),
+            Message::SelectFirst => self.nav.select_first_row(),
+            Message::SelectLast => self.nav.select_last_row(),
             Message::Accept => {
                 if let Some(index) = self.selected_index() {
                     match self.items[index].kind {
@@ -282,7 +282,7 @@ impl ReviewApp {
                         // Re-accepting (e.g. after a skip) needs no mutation.
                         ReviewKind::Auto => {
                             self.items[index].status = Status::Accepted;
-                            self.nav.move_selection(1);
+                            self.nav.move_rows(1);
                         }
                         // An unknown transaction needs an account first.
                         ReviewKind::Unknown => {}
@@ -297,7 +297,7 @@ impl ReviewApp {
             Message::Skip => {
                 if let Some(index) = self.selected_index() {
                     self.items[index].status = Status::Skipped;
-                    self.nav.move_selection(1);
+                    self.nav.move_rows(1);
                 }
             }
             Message::RequestWrite => {
@@ -370,7 +370,7 @@ impl ReviewApp {
         item.status = Status::Accepted;
         item.preview = preview;
         if self.nav.table_state.selected() == Some(index) {
-            self.nav.move_selection(1);
+            self.nav.move_rows(1);
         }
     }
 }

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -348,7 +348,7 @@ mod tests {
                 account_names(&app),
                 ["Assets:Bank", "Assets:Cash", "Equity", "Expenses:Food"]
             );
-            app.balance.nav.select(3); // Expenses:Food
+            app.balance.nav.select_item(3); // Expenses:Food
             app.snapshot()
         };
         arena.reset();
@@ -368,7 +368,7 @@ mod tests {
             ]
         );
         // The selection followed Expenses:Food to its new index.
-        assert_eq!(app.balance.nav.table_state.selected(), Some(4));
+        assert_eq!(app.balance.nav.selected_item(), Some(4));
     }
 
     /// The reason reload rebuilds from scratch: interned entries of the
@@ -416,7 +416,7 @@ mod tests {
         };
         assert_eq!(view.title(), "Assets:Bank");
         assert_eq!(view.rows.len(), 1);
-        assert_eq!(view.nav.table_state.selected(), Some(0));
+        assert_eq!(view.nav.selected_item(), Some(0));
     }
 
     #[test]

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -216,8 +216,8 @@ impl<'ctx> App<'ctx> {
     }
 
     /// Like [`Self::show_register`], but restores a previous cursor position
-    /// (clamped to the new row count) instead of jumping to the last entry.
-    /// Used when re-entering the register after a reload.
+    /// (an entry index, clamped to the new entry count) instead of jumping to
+    /// the last entry. Used when re-entering the register after a reload.
     pub fn show_register_at(
         &mut self,
         scope: RegisterScope<'ctx>,
@@ -225,8 +225,8 @@ impl<'ctx> App<'ctx> {
         index: usize,
     ) {
         let mut view = RegisterView::new(scope, rows);
-        if let Some(last) = view.nav.row_count.checked_sub(1) {
-            view.nav.select(min(index, last));
+        if let Some(last) = view.nav.item_count().checked_sub(1) {
+            view.nav.select_item(min(index, last));
         }
         self.screen = Screen::Register(view);
     }
@@ -321,8 +321,11 @@ mod tests {
         "Liabilities:Card", // 4
     ];
 
+    /// The selected *account* (an index into `app.balance.rows`), which is
+    /// what every test below means — the table itself has one row per
+    /// commodity line.
     fn selected(app: &App<'_>) -> Option<usize> {
-        app.balance.nav.table_state.selected()
+        app.balance.nav.selected_item()
     }
 
     #[test]
@@ -376,7 +379,7 @@ mod tests {
         app.balance.nav = TableNav::new(3);
         app.update(Message::RequestQuit);
         app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
-        assert_eq!(app.balance.nav.table_state.selected(), Some(0));
+        assert_eq!(app.balance.nav.selected_row(), 0);
     }
 
     fn popup(lines: usize, viewport_height: u16) -> ErrorPopup {
@@ -496,7 +499,7 @@ mod tests {
     fn restore_follows_selected_account() {
         let arena = Bump::new();
         let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.balance.nav.select(2); // Expenses:Food
+        app.balance.nav.select_item(2); // Expenses:Food
         let snapshot = app.snapshot();
 
         let mut app = next_app(
@@ -517,7 +520,7 @@ mod tests {
     fn restore_vanished_account_selects_closest() {
         let arena = Bump::new();
         let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
-        app.balance.nav.select(2); // Expenses:Food
+        app.balance.nav.select_item(2); // Expenses:Food
         let snapshot = app.snapshot();
 
         let mut app = next_app(
@@ -575,7 +578,7 @@ mod tests {
         let (ctx, mut app) = make_balance_app(&arena, ACCOUNTS);
         let account = ctx.account("Assets:Cash").unwrap();
         let mut nav = TableNav::new(5);
-        nav.select(3);
+        nav.select_item(3);
         app.screen = register_screen(account, nav);
         let snapshot = app.snapshot();
 
@@ -622,13 +625,13 @@ mod tests {
         let Screen::Register(view) = &app.screen else {
             panic!("expected register screen");
         };
-        assert_eq!(view.nav.table_state.selected(), Some(2));
+        assert_eq!(view.nav.selected_item(), Some(2));
 
         app.show_register_at(scope, rows, 1);
         let Screen::Register(view) = &app.screen else {
             panic!("expected register screen");
         };
-        assert_eq!(view.nav.table_state.selected(), Some(1));
+        assert_eq!(view.nav.selected_item(), Some(1));
     }
 
     #[test]

--- a/cli/src/ui/report/balance.rs
+++ b/cli/src/ui/report/balance.rs
@@ -20,6 +20,7 @@ use crate::ui::keys::is_ctrl;
 use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
 use super::register::{OwnedRegisterScope, RegisterScope};
+use super::render::amount_line_count;
 use super::search::{Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase};
 
 /// Whether the balance screen shows a flat account list or the account tree.
@@ -102,12 +103,6 @@ pub fn account_full_label<'ctx>(account: &AccountTreeKey<'ctx>) -> &'ctx str {
     }
 }
 
-/// Number of lines an [`Amount`] would render as in a table.
-pub(super) fn amount_line_count(amount: &Amount<'_>) -> u16 {
-    let n = amount.iter().count();
-    n.clamp(1, u16::MAX as usize) as u16
-}
-
 /// Balance-screen state that survives a reload, captured by
 /// [`BalanceView::snapshot`] and re-applied by [`BalanceView::restore`].
 /// Everything is plain owned data — arena references would dangle across the
@@ -186,6 +181,12 @@ pub struct BalanceView<'ctx> {
     /// [`Self::rebuild_rows`].
     pub rows: Vec<BalanceRow<'ctx>>,
     pub nav: TableNav,
+    /// Width of the Amount column, cached because deciding it means formatting
+    /// every row's amount — the one thing a frame cannot do per viewport, and
+    /// the event loop redraws on a timer as well as on every key. Cleared by
+    /// [`Self::rebuild_rows`], the only thing that changes what is measured;
+    /// the display context it is measured against outlives the whole view.
+    pub amount_width: Option<u16>,
     /// Active account search on the balance screen, if any.
     pub search: Option<Search>,
     /// Most recently used search pattern, recalled by an empty interactive
@@ -205,6 +206,7 @@ impl<'ctx> BalanceView<'ctx> {
             folded: HashSet::new(),
             rows: Vec::new(),
             nav: TableNav::new(0),
+            amount_width: None,
             search: None,
             last_search: String::new(),
         };
@@ -217,13 +219,14 @@ impl<'ctx> BalanceView<'ctx> {
     /// goes through [`Self::new`] with a real tree.
     #[cfg(test)]
     pub fn with_rows(rows: Vec<BalanceRow<'ctx>>) -> Self {
-        let nav = TableNav::new(rows.len());
+        let nav = TableNav::with_lines(rows.iter().map(BalanceRow::line_count));
         Self {
             tree: Vec::new(),
             mode: DisplayMode::Flat,
             folded: HashSet::new(),
             rows,
             nav,
+            amount_width: None,
             search: None,
             last_search: String::new(),
         }
@@ -231,8 +234,7 @@ impl<'ctx> BalanceView<'ctx> {
 
     /// The currently-selected balance row, if any.
     fn selected_row(&self) -> Option<&BalanceRow<'ctx>> {
-        let idx = self.nav.table_state.selected()?;
-        self.rows.get(idx)
+        self.rows.get(self.nav.selected_item()?)
     }
 
     /// Full name of the currently-selected account, if any.
@@ -361,8 +363,10 @@ impl<'ctx> BalanceView<'ctx> {
             DisplayMode::Flat => self.build_flat_rows(),
             DisplayMode::Tree => self.build_tree_rows(),
         };
-        self.nav = TableNav::new(self.rows.len());
+        self.nav = TableNav::with_lines(self.rows.iter().map(BalanceRow::line_count));
         self.nav.viewport_height = viewport_height;
+        // Different rows, so a different widest amount.
+        self.amount_width = None;
         if let Some(name) = prev {
             self.select_by_name(name);
         }
@@ -435,7 +439,7 @@ impl<'ctx> BalanceView<'ctx> {
     /// exists.
     fn select_by_name(&mut self, name: &str) {
         if let Some(idx) = self.rows.iter().position(|r| r.full_name() == name) {
-            self.nav.select(idx);
+            self.nav.select_item(idx);
             return;
         }
         let mut best: Option<usize> = None;
@@ -451,7 +455,7 @@ impl<'ctx> BalanceView<'ctx> {
             }
         }
         if let Some(idx) = best {
-            self.nav.select(idx);
+            self.nav.select_item(idx);
         }
     }
 
@@ -602,7 +606,7 @@ impl<'ctx> BalanceView<'ctx> {
         if let Some(prev) = &snapshot.selected_account
             && let Some(idx) = restore_index(prev, &self.rows)
         {
-            self.nav.select(idx);
+            self.nav.select_item(idx);
         }
 
         self.last_search = snapshot.last_search.clone();
@@ -617,7 +621,7 @@ impl<'ctx> BalanceView<'ctx> {
     /// Opens a search of the given style, recording the current selection as
     /// the origin.
     fn start_search(&mut self, mode: SearchMode, dir: SearchDirection) {
-        let origin = self.nav.table_state.selected().unwrap_or(0);
+        let origin = self.nav.selected_item().unwrap_or(0);
         self.search = Some(Search {
             intent: SearchIntent {
                 mode,
@@ -670,7 +674,7 @@ impl<'ctx> BalanceView<'ctx> {
     fn search_cancel(&mut self) {
         if let Some(search) = self.search.take() {
             // on cancel, search query won't be saved.
-            self.nav.select(search.intent.origin);
+            self.nav.select_item(search.intent.origin);
         }
     }
 
@@ -747,11 +751,11 @@ impl<'ctx> BalanceView<'ctx> {
         let Some(Ok(m)) = search.matches.as_ref() else {
             return;
         };
-        let current = self.nav.table_state.selected().unwrap_or(0);
+        let current = self.nav.selected_item().unwrap_or(0);
         let Some(next) = m.step(current, search.intent.dir) else {
             return;
         };
-        self.nav.select(next);
+        self.nav.select_item(next);
     }
 
     /// Recompiles the search pattern, recollects matching balance-row indices,
@@ -768,7 +772,7 @@ impl<'ctx> BalanceView<'ctx> {
         let origin = intent.origin;
         let reference = match intent.mode {
             SearchMode::Modal(_) => origin,
-            SearchMode::Interactive => self.nav.table_state.selected().unwrap_or(origin),
+            SearchMode::Interactive => self.nav.selected_item().unwrap_or(origin),
         };
         let matches = SearchMatch::compute(&intent.input, &self.rows);
         let jump = match &matches {
@@ -777,7 +781,7 @@ impl<'ctx> BalanceView<'ctx> {
         };
         search.matches = matches;
         if let Some(idx) = jump {
-            self.nav.select(idx);
+            self.nav.select_item(idx);
         }
     }
 }
@@ -868,8 +872,10 @@ mod tests {
         (ctx, view)
     }
 
+    /// The selected *account* (an index into `view.rows`), which is what every
+    /// test below means — the table itself has one row per commodity line.
     fn selected(view: &BalanceView<'_>) -> Option<usize> {
-        view.nav.table_state.selected()
+        view.nav.selected_item()
     }
 
     fn full_names(view: &BalanceView<'_>) -> Vec<String> {
@@ -1292,14 +1298,14 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select(0); // Assets
+        view.nav.select_item(0); // Assets
         view.update(BalanceMessage::ToggleFold);
         assert_eq!(
             full_names(&view),
             ["Assets", "Equity", "Expenses", "Expenses:Food"]
         );
         assert!(view.rows[0].folded);
-        assert_eq!(view.nav.table_state.selected(), Some(0));
+        assert_eq!(selected(&view), Some(0));
         view.update(BalanceMessage::ToggleFold);
         assert!(!view.rows[0].folded);
         assert_eq!(view.rows.len(), 7);
@@ -1321,7 +1327,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select(0); // Assets
+        view.nav.select_item(0); // Assets
         let action = view.update(BalanceMessage::OpenRegister);
         assert_matches!(
             action,
@@ -1333,7 +1339,7 @@ mod tests {
     fn flat_open_register_drills_into_single_account() {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
-        view.nav.select(1); // Assets:Cash
+        view.nav.select_item(1); // Assets:Cash
         let action = view.update(BalanceMessage::OpenRegister);
         assert_matches!(
             action,
@@ -1353,7 +1359,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select(0); // Assets
+        view.nav.select_item(0); // Assets
         view.update(BalanceMessage::ToggleFold); // fold Assets
         let snapshot = view.snapshot();
 

--- a/cli/src/ui/report/overlay.rs
+++ b/cli/src/ui/report/overlay.rs
@@ -18,12 +18,13 @@ pub enum ScrollDelta {
 
 /// The error popup reuses the table navigation keys for scrolling: a row step
 /// scrolls one line, a page step scrolls a page, and first/last jump to the
-/// ends.
+/// ends. An error report is one flat run of lines with no items in it, so the
+/// item steps (`J`/`K`) scroll a line like their lowercase siblings.
 impl From<NavCommand> for ScrollDelta {
     fn from(cmd: NavCommand) -> Self {
         match cmd {
-            NavCommand::Up => ScrollDelta::Lines(-1),
-            NavCommand::Down => ScrollDelta::Lines(1),
+            NavCommand::Up | NavCommand::PrevItem => ScrollDelta::Lines(-1),
+            NavCommand::Down | NavCommand::NextItem => ScrollDelta::Lines(1),
             NavCommand::PageUp => ScrollDelta::Pages(-1),
             NavCommand::PageDown => ScrollDelta::Pages(1),
             NavCommand::First => ScrollDelta::Top,

--- a/cli/src/ui/report/register.rs
+++ b/cli/src/ui/report/register.rs
@@ -9,7 +9,7 @@ use okane_core::report::{Account, AccountAggregate, Amount};
 
 use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
-use super::balance::amount_line_count;
+use super::render::amount_line_count;
 
 /// What a register drill-in from the balance screen should match.
 #[derive(Debug, Clone, Copy)]
@@ -75,7 +75,8 @@ pub struct RegisterRow<'ctx> {
 }
 
 impl RegisterRow<'_> {
-    /// Number of rendered lines this row occupies (>= 1).
+    /// Number of table rows this entry occupies (>= 1) — the taller of its two
+    /// amount columns, since each contributes one line per commodity.
     pub fn line_count(&self) -> u16 {
         max(
             amount_line_count(&self.amount),
@@ -109,9 +110,12 @@ pub struct RegisterView<'ctx> {
 
 impl<'ctx> RegisterView<'ctx> {
     pub fn new(scope: RegisterScope<'ctx>, rows: Vec<RegisterRow<'ctx>>) -> Self {
-        let mut nav = TableNav::new(rows.len());
-        // Most recent entry is the most useful starting point.
-        nav.select_last();
+        let mut nav = TableNav::with_lines(rows.iter().map(RegisterRow::line_count));
+        // Most recent entry is the most useful starting point — its *last* row,
+        // so the running total it carries is on screen whole. Landing on its
+        // first row would pin that row to the bottom edge and cut the rest of
+        // the entry off below it.
+        nav.select_last_row();
         Self {
             scope,
             rows,
@@ -172,7 +176,9 @@ pub struct RegisterSnapshot {
     /// What the register was filtered to (single account or subtree), owned so
     /// it survives the arena reset.
     pub(super) scope: OwnedRegisterScope,
-    /// Selected cursor index.
+    /// Index of the selected entry — an index into
+    /// [`RegisterView::rows`], not a table row, so it survives an entry
+    /// whose line count changes with the data.
     pub(super) cursor: usize,
 }
 
@@ -181,7 +187,7 @@ impl RegisterSnapshot {
     pub(super) fn capture(view: &RegisterView<'_>) -> Self {
         Self {
             scope: view.scope.as_owned_scope(),
-            cursor: view.nav.table_state.selected().unwrap_or(0),
+            cursor: view.nav.selected_item().unwrap_or(0),
         }
     }
 
@@ -225,11 +231,11 @@ mod tests {
     }
 
     #[test]
-    fn new_selects_last_row() {
+    fn new_selects_last_entry() {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:A");
         let view = register_view(account, 3);
-        assert_eq!(view.nav.table_state.selected(), Some(2));
+        assert_eq!(view.nav.selected_item(), Some(2));
     }
 
     #[test]
@@ -238,13 +244,13 @@ mod tests {
         let (_ctx, account) = make_account(&arena, "Assets:A");
         let mut view = register_view(account, 3);
         view.update(RegisterMessage::Nav(NavCommand::First));
-        assert_eq!(view.nav.table_state.selected(), Some(0));
+        assert_eq!(view.nav.selected_row(), 0);
         assert_eq!(view.update(RegisterMessage::Nav(NavCommand::Up)), None);
-        assert_eq!(view.nav.table_state.selected(), Some(0));
+        assert_eq!(view.nav.selected_row(), 0);
         view.update(RegisterMessage::Nav(NavCommand::Down));
-        assert_eq!(view.nav.table_state.selected(), Some(1));
+        assert_eq!(view.nav.selected_row(), 1);
         view.update(RegisterMessage::Nav(NavCommand::Last));
-        assert_eq!(view.nav.table_state.selected(), Some(2));
+        assert_eq!(view.nav.selected_row(), 2);
     }
 
     #[test]

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -1,5 +1,25 @@
 //! Pure rendering functions for the TUI.
 //!
+//! Both report tables draw **one row per line**: an account whose balance spans
+//! six commodities occupies six table rows rather than one six-line row. That
+//! is what makes every line reachable — a row taller than the body used to be
+//! clipped silently, with no way to scroll to what it hid — and
+//! [`crate::ui::table::LineIndex`] translates those rows back into the accounts
+//! and entries the rest of the UI reasons about.
+//!
+//! Exploding the rows moves the account label onto the first row of its block,
+//! which leaves two things to say. Both are applied by [`build_body`], which
+//! knows the exact window it drew:
+//!
+//! - **Sticky account.** When the body's top row is a continuation, the account
+//!   it belongs to has scrolled off; its label is redrawn there in
+//!   [`STICKY_COLOR`]. Colour alone, with no prefix, so the text still sits in
+//!   the column it belongs to — the register's date column is exactly
+//!   `YYYY-MM-DD` wide and a prefix would push the date out of it.
+//! - **`+N more`.** An account cut by the top or bottom edge of the body says
+//!   how many of its lines the reader cannot see, in place of the amount on the
+//!   edge row itself — which is one of them, since the marker takes its place.
+//!
 //! The popup pattern follows
 //! <https://ratatui.rs/recipes/layout/center-a-widget/>:
 //! render a `Clear` widget over a centered rect, then render the popup
@@ -17,17 +37,21 @@ use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Table
 use unicode_width::UnicodeWidthStr;
 
 use super::app::{App, Screen};
-use super::balance::{BalanceRow, DisplayMode};
+use super::balance::{BalanceRow, BalanceView, DisplayMode};
 use super::overlay::{ErrorPopup, Overlay};
-use super::register::{RegisterRow, RegisterView};
-use super::search::{Search, SearchDirection, SearchMatch, SearchMode, SearchPhase};
+use super::register::RegisterView;
+use super::search::{Search, SearchDirection, SearchMode, SearchPhase};
 use crate::ui::table::TableNav;
 
-const FOOTER_HINT_BALANCE: &str = " ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r reload · q quit ";
+const FOOTER_HINT_BALANCE: &str = " ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / search · r reload · q quit ";
 const FOOTER_HINT_REGISTER: &str =
-    " ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back ";
+    " ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back ";
 const ERROR_POPUP_HINT: &str =
     " ↑/↓ scroll · PgUp/PgDn page · g/G top/end · r reload · Esc/Enter close · q quit ";
+
+/// Colour that marks a redrawn (sticky) account label, so it never reads as a
+/// label the row itself owns.
+const STICKY_COLOR: Color = Color::Cyan;
 
 /// Renders a frame for the given app state.
 pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'ctx>) {
@@ -42,21 +66,7 @@ pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'c
     draw_title(frame, layout[0], app);
     match &mut app.screen {
         Screen::Balance => {
-            let matches = app
-                .balance
-                .search
-                .as_ref()
-                .and_then(|s| s.matches.as_ref())
-                .and_then(|r| r.as_ref().ok());
-            draw_balance_body(
-                frame,
-                layout[1],
-                &app.balance.rows,
-                &mut app.balance.nav,
-                matches,
-                ctx,
-                app.balance.mode,
-            );
+            draw_balance_body(frame, layout[1], &mut app.balance, ctx);
             match (&app.error_toast, &app.balance.search) {
                 (Some(msg), _) => draw_error(frame, layout[2], msg),
                 (None, Some(search)) => draw_search_bar(frame, layout[2], search),
@@ -93,59 +103,228 @@ fn draw_title(frame: &mut Frame, area: Rect, app: &App<'_>) {
     frame.render_widget(paragraph, area);
 }
 
-fn draw_balance_body<'ctx>(
+/// One physical table row — exactly one terminal line.
+#[derive(Debug, PartialEq, Eq)]
+struct LineRow {
+    /// Leading columns: the account, or the date and payee. Blank on a
+    /// continuation line, except where the sticky overlay refills them.
+    head: Vec<String>,
+    /// One entry per amount column: the text on this line, or `None` where the
+    /// column has no line here — a register entry's Amount is one line however
+    /// tall its Total is, and marking the shorter one would be a lie.
+    cells: Vec<Option<String>>,
+    /// This row carries a search-matched account's own label.
+    is_match: bool,
+    /// [`Self::head`] was refilled by the sticky overlay rather than owned.
+    sticky: bool,
+}
+
+/// The visible rows of a table body, with the sticky account label and the
+/// `+N more` cut markers already applied.
+struct Body {
+    rows: Vec<LineRow>,
+    /// The selection, as an index into [`Self::rows`].
+    selected: usize,
+}
+
+/// Builds the table rows for `nav`'s current window.
+///
+/// `head_of` and `columns_of` are called once per *item* in the window rather
+/// than once per row, so a multi-commodity account formats its amounts once
+/// however many lines it spans. Neither is called for anything off screen,
+/// which is what keeps per-frame work proportional to the viewport rather than
+/// to the row count.
+fn build_body(
+    nav: &mut TableNav,
+    head_of: impl Fn(usize) -> Vec<String>,
+    columns_of: impl Fn(usize) -> Vec<Vec<String>>,
+    is_match: impl Fn(usize) -> bool,
+) -> Body {
+    let (offset, end) = nav.visible_window();
+    let mut rows: Vec<LineRow> = Vec::with_capacity(end - offset);
+    // Set only when the top item's own first row is above the window: its head,
+    // which the sticky overlay redraws on the body's top line, and the lines it
+    // hides up there.
+    let mut cut_above: Option<(Vec<String>, u16)> = None;
+    // The bottom item's line at the bottom edge, with how many lines each of
+    // its columns holds — between them, what it hides below.
+    let mut bottom_edge: Option<(u16, Vec<usize>)> = None;
+
+    for (nth, (item, window)) in nav.lines().items_in(offset..end).enumerate() {
+        let head = head_of(item);
+        let columns = columns_of(item);
+        let matched = is_match(item);
+        if nth == 0 && window.start > 0 {
+            // This item's own label went off screen with the lines above it.
+            cut_above = Some((head.clone(), window.start));
+        }
+        bottom_edge = Some((window.end - 1, columns.iter().map(Vec::len).collect()));
+        for line in window {
+            rows.push(LineRow {
+                head: match line {
+                    0 => head.clone(),
+                    // A continuation line owns no label; the sticky overlay
+                    // below refills the top one when the item's own is gone.
+                    _ => vec![String::new(); head.len()],
+                },
+                cells: columns
+                    .iter()
+                    .map(|col| col.get(usize::from(line)).cloned())
+                    .collect(),
+                is_match: matched && line == 0,
+                sticky: false,
+            });
+        }
+    }
+
+    // No *row* is ever clipped now, but an item's block still runs past the top
+    // and bottom of the body, which is the same news the marker has always
+    // carried. Above the top row every column that reaches it hid the same
+    // lines; below the bottom one each column ran out where it ran out.
+    if let Some((head, above)) = cut_above
+        && let Some(top) = rows.first_mut()
+    {
+        top.head = head;
+        top.sticky = true;
+        mark_cut(top, |_| usize::from(above), "above");
+    }
+    if let Some((edge, lengths)) = bottom_edge
+        && let Some(bottom) = rows.last_mut()
+    {
+        let below = usize::from(edge) + 1;
+        mark_cut(
+            bottom,
+            |column| lengths[column].saturating_sub(below),
+            "more",
+        );
+    }
+
+    Body {
+        selected: nav.selected_row().saturating_sub(offset),
+        rows,
+    }
+}
+
+/// Replaces the amounts on a cut edge row with `+{n} {suffix}`, asking `beyond`
+/// per column how many of that column's lines lie past the edge: how much a
+/// column hides is its own business — a register entry's Amount is one line
+/// however far past the edge its Total runs — and a column that ends on the
+/// edge keeps its value, since there is nothing past it to warn about.
+///
+/// The count is `beyond + 1`, because the marker also spends the line it is
+/// written on: the value that was there is one the reader cannot see either.
+/// Spending the edge line rather than adding one keeps the body exactly as tall
+/// as the viewport, which is what lets the marker be decided after the window
+/// is fixed rather than as part of choosing it.
+fn mark_cut(row: &mut LineRow, beyond: impl Fn(usize) -> usize, suffix: &str) {
+    for (column, cell) in row.cells.iter_mut().enumerate() {
+        let beyond = beyond(column);
+        if beyond > 0 && cell.is_some() {
+            *cell = Some(format!("+{} {suffix}", beyond + 1));
+        }
+    }
+}
+
+/// Everything about a table body that is not its data: what to say when there
+/// is none, the header labels, and the column constraints. One per screen,
+/// built where the column widths are known.
+struct TableChrome<'a> {
+    empty_message: &'a str,
+    headers: &'a [&'a str],
+    constraints: Vec<Constraint>,
+}
+
+/// Draws one table body: the bordered block, the window `nav` selects, and the
+/// rows [`build_body`] makes of it.
+///
+/// Both screens differ only in their [`TableChrome`] and in what the three
+/// closures read, so the framing — the empty and too-short notices, the
+/// viewport height the nav needs, and rendering only the chosen window so
+/// ratatui never scrolls on its own — lives here once.
+fn draw_table_body(
     frame: &mut Frame,
     area: Rect,
-    rows: &[BalanceRow<'ctx>],
     nav: &mut TableNav,
-    matches: Option<&SearchMatch>,
-    ctx: &ReportContext<'ctx>,
-    mode: DisplayMode,
+    chrome: TableChrome<'_>,
+    head_of: impl Fn(usize) -> Vec<String>,
+    columns_of: impl Fn(usize) -> Vec<Vec<String>>,
+    is_match: impl Fn(usize) -> bool,
 ) {
     let block = Block::default().borders(Borders::ALL);
     let inner = block.inner(area);
+    // The header takes the first line of the body; the rest is the window.
     nav.viewport_height = inner.height.saturating_sub(1);
 
-    if rows.is_empty() {
-        let msg = Paragraph::new("No balances to display")
+    if nav.is_empty() {
+        let msg = Paragraph::new(chrome.empty_message)
             .alignment(Alignment::Center)
             .block(block);
         frame.render_widget(msg, area);
         return;
     }
+    if draw_body_too_short(frame, area, &block) {
+        return;
+    }
 
-    let header = Row::new(vec![Cell::from("Account"), Cell::from("Amount")])
+    let body = build_body(nav, head_of, columns_of, is_match);
+    let header = Row::new(chrome.headers.iter().copied().map(Cell::from))
         .style(Style::default().add_modifier(Modifier::BOLD));
+    let table = Table::new(body.rows.iter().map(to_table_row), chrome.constraints)
+        .header(header)
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .block(block);
 
-    let formatted: Vec<Vec<String>> = rows
-        .iter()
-        .map(|row| format_amount_lines(&row.amount, ctx))
-        .collect();
-    let amount_width = compute_amount_width(&formatted);
-    let table_rows: Vec<Row> = rows
-        .iter()
-        .zip(&formatted)
-        .enumerate()
-        .map(|(i, (row, lines))| {
-            make_balance_row(
-                row,
-                lines,
-                matches.is_some_and(|m| m.contains_row(i)),
-                mode,
-                nav.viewport_height,
-            )
-        })
-        .collect();
+    // The window was already chosen by `TableNav::visible_window`, and the
+    // marker and sticky-label decisions depend on it being the one actually
+    // drawn, so hand ratatui a state that keeps it.
+    let mut state = TableState::default()
+        .with_offset(0)
+        .with_selected(Some(body.selected));
+    frame.render_stateful_widget(table, area, &mut state);
+}
 
-    let table = Table::new(
-        table_rows,
-        [Constraint::Min(10), Constraint::Length(amount_width)],
-    )
-    .header(header)
-    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
-    .block(block);
+fn draw_balance_body<'ctx>(
+    frame: &mut Frame,
+    area: Rect,
+    view: &mut BalanceView<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) {
+    // Split the borrows: the row closures below read `rows` while
+    // `draw_table_body` drives `nav`.
+    let BalanceView {
+        rows,
+        nav,
+        search,
+        mode,
+        amount_width,
+        ..
+    } = view;
+    let (rows, mode) = (&*rows, *mode);
+    let matches = search
+        .as_ref()
+        .and_then(|s| s.matches.as_ref())
+        .and_then(|r| r.as_ref().ok());
 
-    frame.render_stateful_widget(table, area, &mut nav.table_state);
+    // The column is one width for the whole table — the one thing that has to
+    // look at every row — so it is computed once per set of rows and cached;
+    // the rows themselves are built for the visible window only.
+    let amount_width = *amount_width.get_or_insert_with(|| {
+        compute_amount_width(rows.iter().map(|row| format_amount_lines(&row.amount, ctx)))
+    });
+
+    draw_table_body(
+        frame,
+        area,
+        nav,
+        TableChrome {
+            empty_message: "No balances to display",
+            headers: &["Account", "Amount"],
+            constraints: vec![Constraint::Min(10), Constraint::Length(amount_width)],
+        },
+        |i| vec![account_cell_text(&rows[i], mode)],
+        |i| vec![format_amount_lines(&rows[i].amount, ctx)],
+        |i| matches.is_some_and(|m| m.contains_row(i)),
+    );
 }
 
 fn draw_register_body<'ctx>(
@@ -154,89 +333,65 @@ fn draw_register_body<'ctx>(
     view: &mut RegisterView<'ctx>,
     ctx: &ReportContext<'ctx>,
 ) {
-    let block = Block::default().borders(Borders::ALL);
-    let inner = block.inner(area);
-    view.nav.viewport_height = inner.height.saturating_sub(1);
-
-    if view.rows.is_empty() {
-        let msg = Paragraph::new("No register entries to display")
-            .alignment(Alignment::Center)
-            .block(block);
-        frame.render_widget(msg, area);
-        return;
-    }
-
-    let header = Row::new(vec![
-        Cell::from("Date"),
-        Cell::from("Payee"),
-        Cell::from("Amount"),
-        Cell::from("Total"),
-    ])
-    .style(Style::default().add_modifier(Modifier::BOLD));
+    // Split the borrows: the row closures below read `rows` while
+    // `draw_table_body` drives `nav`.
+    let RegisterView {
+        rows,
+        nav,
+        col_widths,
+        ..
+    } = view;
+    let rows = &*rows;
 
     // The amount/total column widths are fixed for the life of the view, so
-    // compute them once (scanning all rows) and cache them. Everything else
-    // below only touches the visible window, keeping per-frame work
-    // proportional to the viewport rather than the (potentially large) row
-    // count of the register.
-    let (amount_width, total_width) = match view.col_widths {
-        Some(t) => t,
-        None => {
-            let amount_width = compute_amount_width(
-                view.rows
-                    .iter()
-                    .map(|row| format_amount_lines(&row.amount, ctx)),
-            );
-            let total_width = compute_amount_width(
-                view.rows
-                    .iter()
-                    .map(|row| format_amount_lines(&row.total, ctx)),
-            );
-            view.col_widths = Some((amount_width, total_width));
-            (amount_width, total_width)
-        }
-    };
+    // compute them once (scanning all rows) and cache them.
+    let (amount_width, total_width) = *col_widths.get_or_insert_with(|| {
+        (
+            compute_amount_width(rows.iter().map(|row| format_amount_lines(&row.amount, ctx))),
+            compute_amount_width(rows.iter().map(|row| format_amount_lines(&row.total, ctx))),
+        )
+    });
 
-    // Virtualize: build widget rows only for the slice that is actually
-    // visible. The absolute selection stays in `nav.table_state`; the local
-    // `TableState` below carries the viewport-relative position for rendering.
-    let (offset, end) = view.nav.visible_window(|i| view.rows[i].line_count());
+    draw_table_body(
+        frame,
+        area,
+        nav,
+        TableChrome {
+            empty_message: "No register entries to display",
+            headers: &["Date", "Payee", "Amount", "Total"],
+            constraints: vec![
+                Constraint::Length(10), // YYYY-MM-DD
+                Constraint::Min(10),    // payee, takes remaining
+                Constraint::Length(amount_width),
+                Constraint::Length(total_width),
+            ],
+        },
+        |i| vec![rows[i].date.to_string(), rows[i].payee.clone()],
+        |i| {
+            vec![
+                format_amount_lines(&rows[i].amount, ctx),
+                format_amount_lines(&rows[i].total, ctx),
+            ]
+        },
+        |_| false,
+    );
+}
 
-    let visible = &view.rows[offset..end];
-    // these are collected as the following register row is borrowing this String.
-    let amount_lines: Vec<Vec<String>> = visible
-        .iter()
-        .map(|row| format_amount_lines(&row.amount, ctx))
-        .collect();
-    let total_lines: Vec<Vec<String>> = visible
-        .iter()
-        .map(|row| format_amount_lines(&row.total, ctx))
-        .collect();
-
-    let table_rows: Vec<Row> = visible
-        .iter()
-        .zip(amount_lines.iter())
-        .zip(total_lines.iter())
-        .map(|((row, amt), tot)| make_register_row(row, amt, tot, view.nav.viewport_height))
-        .collect();
-
-    let table = Table::new(
-        table_rows,
-        [
-            Constraint::Length(10), // YYYY-MM-DD
-            Constraint::Min(10),    // payee, takes remaining
-            Constraint::Length(amount_width),
-            Constraint::Length(total_width),
-        ],
-    )
-    .header(header)
-    .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
-    .block(block);
-
-    let mut state = TableState::default()
-        .with_offset(0)
-        .with_selected(Some(view.nav.selected_index() - offset));
-    frame.render_stateful_widget(table, area, &mut state);
+/// A body with no room for a row after its header draws nothing at all, however
+/// short the rows are — and now that no row is ever taller than one line, there
+/// is nothing left to cap. Say so instead of showing an empty box, which reads
+/// as "no data". The border goes too: at this size it *is* the body.
+fn draw_body_too_short(frame: &mut Frame, area: Rect, block: &Block) -> bool {
+    if block.inner(area).height >= 2 {
+        return false;
+    }
+    frame.render_widget(
+        Paragraph::new("terminal too short")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Red)),
+        area,
+    );
+    true
 }
 
 fn draw_footer(frame: &mut Frame, area: Rect, hint: &str) {
@@ -402,6 +557,8 @@ fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
 
 /// Formats the amount lines for one balance/register cell — one line per
 /// commodity, or a single `"0"` line when the balance is empty.
+///
+/// Must agree with [`amount_line_count`]; see there.
 fn format_amount_lines<'ctx>(amount: &Amount<'ctx>, ctx: &ReportContext<'ctx>) -> Vec<String> {
     let mut lines: Vec<String> = amount
         .iter()
@@ -413,24 +570,40 @@ fn format_amount_lines<'ctx>(amount: &Amount<'ctx>, ctx: &ReportContext<'ctx>) -
     lines
 }
 
-fn make_balance_row<'r>(
-    row: &'r BalanceRow<'_>,
-    lines: &'r [String],
-    is_match: bool,
-    mode: DisplayMode,
-    viewport_height: u16,
-) -> Row<'r> {
-    let height = clip_row_height(row.line_count(), viewport_height);
-    let mut account_cell = Cell::from(account_cell_text(row, mode));
-    if is_match {
-        account_cell = account_cell.style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        );
-    }
-    let amount_cell = Cell::from(amount_text(clip_lines(lines, height)));
-    Row::new(vec![account_cell, amount_cell]).height(height)
+/// Lines [`format_amount_lines`] will produce for `amount` (always `>= 1`),
+/// without formatting them.
+///
+/// This is what the screens size their [`LineIndex`](crate::ui::table::LineIndex)
+/// with, so it decides how many table rows an account or entry gets. It lives
+/// next to the function it predicts because the two must agree exactly: were
+/// the count to fall short, the extra lines would get no row and become
+/// unreachable — the very thing exploding the rows set out to fix — and were it
+/// to run over, the table would draw blank rows nothing can fill.
+pub(super) fn amount_line_count(amount: &Amount<'_>) -> u16 {
+    let n = amount.iter().count();
+    n.clamp(1, u16::MAX as usize) as u16
+}
+
+/// Turns one [`LineRow`] into a ratatui row: the head columns as text, the
+/// amount columns right-aligned.
+fn to_table_row(row: &LineRow) -> Row<'_> {
+    let head_style = match (row.sticky, row.is_match) {
+        (true, _) => Style::default().fg(STICKY_COLOR),
+        (false, true) => Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+        (false, false) => Style::default(),
+    };
+    Row::new(
+        row.head
+            .iter()
+            .map(|text| Cell::from(text.as_str()).style(head_style))
+            .chain(
+                row.cells
+                    .iter()
+                    .map(|line| Cell::from(amount_text(line.as_deref()))),
+            ),
+    )
 }
 
 /// Account-column text for a balance row: the full name in flat mode, or the
@@ -450,47 +623,13 @@ fn account_cell_text(row: &BalanceRow<'_>, mode: DisplayMode) -> String {
     }
 }
 
-fn make_register_row<'r>(
-    row: &'r RegisterRow<'_>,
-    amount_lines: &'r [String],
-    total_lines: &'r [String],
-    viewport_height: u16,
-) -> Row<'r> {
-    let height = clip_row_height(row.line_count(), viewport_height);
-    let date_cell = Cell::from(row.date.to_string());
-    let payee_cell = Cell::from(row.payee.as_str());
-    let amount_cell = Cell::from(amount_text(clip_lines(amount_lines, height)));
-    let total_cell = Cell::from(amount_text(clip_lines(total_lines, height)));
-    Row::new(vec![date_cell, payee_cell, amount_cell, total_cell]).height(height)
-}
-
-/// The height a table row may declare, given the height of the table body.
-///
-/// A row taller than the body is not clipped by ratatui's `Table` — it is
-/// dropped outright. `Table::visible_rows` refuses to count it (`height +
-/// item.height > area.height` breaks the fill loop), then its scroll-to-
-/// selection loop admits it and immediately evicts it again to get back under
-/// budget, leaving `start == end` and an empty render range. The whole table
-/// comes out blank. Capping the declared height keeps the row renderable; its
-/// extra lines are cut by [`clip_lines`].
-///
-/// The `max(1)` floor keeps a degenerate zero-height viewport (a terminal too
-/// short for the body) from producing zero-height rows.
-fn clip_row_height(line_count: u16, viewport_height: u16) -> u16 {
-    min(line_count, max(viewport_height, 1))
-}
-
-/// The leading `height` lines of a cell's text — the rest do not fit the row.
-fn clip_lines(lines: &[String], height: u16) -> &[String] {
-    &lines[..min(lines.len(), usize::from(height))]
-}
-
-fn amount_text<'a>(lines: &'a [String]) -> Text<'a> {
-    let lines: Vec<Line<'a>> = lines
-        .iter()
-        .map(|s| Line::from(s.as_str()).alignment(Alignment::Right))
-        .collect();
-    Text::from(lines)
+/// One right-aligned amount line, or nothing where the column has run out of
+/// them.
+fn amount_text(line: Option<&str>) -> Text<'_> {
+    match line {
+        Some(text) => Text::from(Line::from(text).alignment(Alignment::Right)),
+        None => Text::default(),
+    }
 }
 
 /// Returns the display width (in columns) needed for an amount column, given
@@ -561,30 +700,113 @@ mod tests {
         assert_eq!(compute_amount_width(&formatted), 18);
     }
 
-    #[test]
-    fn clip_row_height_leaves_rows_that_fit() {
-        assert_eq!(clip_row_height(1, 19), 1);
-        assert_eq!(clip_row_height(19, 19), 19);
+    /// A one-amount-column body over items of the given line counts, with the
+    /// window sized to `viewport` and the selection on row `selected`. Item `i`
+    /// is headed `item{i}` and its lines read `{i}.{line}`.
+    fn body_of(line_counts: &[u16], viewport: u16, selected: usize) -> Body {
+        let mut nav = TableNav::with_lines(line_counts.iter().copied());
+        nav.viewport_height = viewport;
+        nav.select_row(selected);
+        build_body(
+            &mut nav,
+            |i| vec![format!("item{i}")],
+            |i| vec![(0..line_counts[i]).map(|l| format!("{i}.{l}")).collect()],
+            |_| false,
+        )
+    }
+
+    fn heads(body: &Body) -> Vec<&str> {
+        body.rows.iter().map(|row| row.head[0].as_str()).collect()
+    }
+
+    fn amounts(body: &Body) -> Vec<&str> {
+        body.rows
+            .iter()
+            .map(|row| row.cells[0].as_deref().unwrap_or(""))
+            .collect()
     }
 
     #[test]
-    fn clip_row_height_caps_rows_taller_than_the_body() {
-        assert_eq!(clip_row_height(32, 19), 19);
+    fn build_body_gives_every_amount_line_its_own_row() {
+        let body = body_of(&[1, 3], 10, 0);
+        // Only the first row of an item carries its label.
+        assert_eq!(heads(&body), ["item0", "item1", "", ""]);
+        assert_eq!(amounts(&body), ["0.0", "1.0", "1.1", "1.2"]);
+        assert_eq!(body.selected, 0);
+    }
+
+    /// The marker counts every line the reader cannot see, the one it is
+    /// written over included: of six lines, two are readable and four are not.
+    #[test]
+    fn build_body_marks_the_lines_cut_below() {
+        let body = body_of(&[6], 3, 0);
+        assert_eq!(amounts(&body), ["0.0", "0.1", "+4 more"]);
+        // Nothing is cut above, so the label is the row's own.
+        assert!(!body.rows[0].sticky);
+    }
+
+    /// The follow-up problem: once the top of an account's block is off screen
+    /// its name goes with it, so it is redrawn on the top line — and the same
+    /// line says how many of the account's lines it is standing in front of.
+    #[test]
+    fn build_body_sticks_the_label_of_an_account_cut_above() {
+        let body = body_of(&[1, 6], 3, 6);
+        assert_eq!(heads(&body), ["item1", "", ""]);
+        assert!(body.rows[0].sticky);
+        assert_eq!(amounts(&body), ["+4 above", "1.4", "1.5"]);
+        // The selection is the last row of the window, window-relative.
+        assert_eq!(body.selected, 2);
     }
 
     #[test]
-    fn clip_row_height_never_returns_zero() {
-        // A terminal too short to have a body still gets a one-line row.
-        assert_eq!(clip_row_height(32, 0), 1);
-        assert_eq!(clip_row_height(1, 0), 1);
+    fn build_body_leaves_a_fully_visible_body_unmarked() {
+        let body = body_of(&[2, 2], 4, 0);
+        assert_eq!(heads(&body), ["item0", "", "item1", ""]);
+        assert_eq!(amounts(&body), ["0.0", "0.1", "1.0", "1.1"]);
+        assert!(body.rows.iter().all(|row| !row.sticky));
+    }
+
+    /// A register entry's Amount is one line however tall its Total is, so the
+    /// two columns are cut at different places — or not at all. Marking a
+    /// column that hid nothing would both lie and eat a real value.
+    fn register_shaped_body(amount_lines: usize, viewport: u16) -> Body {
+        let mut nav = TableNav::with_lines([4]);
+        nav.viewport_height = viewport;
+        nav.select_row(0);
+        build_body(
+            &mut nav,
+            |_| vec!["2024-01-01".to_owned(), "payee".to_owned()],
+            |_| {
+                vec![
+                    (0..amount_lines).map(|l| format!("amount{l}")).collect(),
+                    (0..4).map(|l| format!("total{l}")).collect(),
+                ]
+            },
+            |_| false,
+        )
     }
 
     #[test]
-    fn clip_lines_cuts_to_the_row_height() {
-        let lines = vec!["a".to_owned(), "b".to_owned(), "c".to_owned()];
-        assert_eq!(clip_lines(&lines, 2), &lines[..2]);
-        // Fewer lines than the row is tall (the other column is the tall one).
-        assert_eq!(clip_lines(&lines, 10), &lines[..]);
+    fn build_body_leaves_a_column_with_no_line_on_the_edge_alone() {
+        let body = register_shaped_body(1, 2);
+        assert_eq!(
+            body.rows[0].cells,
+            [Some("amount0".to_owned()), Some("total0".to_owned())]
+        );
+        // The Amount column ran out a line ago; only the Total is still cut,
+        // hiding `total1` under the marker and `total2`/`total3` below it.
+        assert_eq!(body.rows[1].cells, [None, Some("+3 more".to_owned())]);
+    }
+
+    #[test]
+    fn build_body_leaves_a_column_that_ends_on_the_edge_alone() {
+        let body = register_shaped_body(2, 2);
+        // `amount1` is the Amount column's last line: nothing is hidden behind
+        // it, so it stays put while the Total says what it is still holding.
+        assert_eq!(
+            body.rows[1].cells,
+            [Some("amount1".to_owned()), Some("+3 more".to_owned())]
+        );
     }
 
     #[test]
@@ -606,6 +828,31 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines.iter().any(|s| s == "100 USD"));
         assert!(lines.iter().any(|s| s == "200 EUR"));
+    }
+
+    /// The invariant the exploded rows rest on: the count the `LineIndex` is
+    /// built from is exactly the number of lines the renderer then produces.
+    /// A count that fell short would leave lines with no row to be drawn on —
+    /// unreachable, the bug this all fixes — and one that ran over would draw
+    /// rows nothing fills.
+    #[test]
+    fn amount_line_count_agrees_with_format_amount_lines() {
+        let arena = Bump::new();
+        let mut ctx = ReportContext::new(&arena);
+        let usd = ctx.commodity_store_mut().ensure("USD");
+        let eur = ctx.commodity_store_mut().ensure("EUR");
+        let chf = ctx.commodity_store_mut().ensure("CHF");
+
+        let one = Amount::from_value(usd, dec!(100));
+        let three =
+            one.clone() + Amount::from_value(eur, dec!(200)) + Amount::from_value(chf, dec!(3));
+        for amount in [Amount::zero(), one, three] {
+            assert_eq!(
+                usize::from(amount_line_count(&amount)),
+                format_amount_lines(&amount, &ctx).len(),
+                "line count and rendered lines disagree for {amount:?}"
+            );
+        }
     }
 
     #[test]
@@ -962,34 +1209,108 @@ mod tests {
         golden(&golden_name(&input, "register-subtree")).assert(&render(&mut app, &ctx));
     }
 
-    /// A balance row taller than the table body must still be drawn, clipped.
-    ///
-    /// ratatui's `Table` drops such a row outright rather than clipping it, and
-    /// its scroll-to-selection pass then renders some *other* row — so before
-    /// [`clip_row_height`] this showed `Equity:Initial` with the selected
-    /// account nowhere on screen. `Assets:Brokers:Bar` holds all 26 stock lots,
-    /// against a 19-line body on an 80×24 terminal.
-    ///
-    /// The `many_commodities` goldens only cover the initial selection (row 0),
-    /// where the tall row happens to survive as ratatui's trailing partial row,
-    /// so this needs its own test.
-    #[test]
-    fn balance_row_taller_than_the_body_is_clipped_not_dropped() {
-        let arena = Bump::new();
+    /// The `many_commodities` balance: `Assets:Banks:Foo` holds 6 commodities
+    /// and `Assets:Brokers:Bar` all 26 stock lots, against a 19-line body on an
+    /// 80×24 terminal — more lines than one screen can hold.
+    fn many_commodities_balance<'ctx>(arena: &'ctx Bump) -> (ReportContext<'ctx>, App<'ctx>) {
         let input = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../testdata/report/many_commodities.ledger");
-        let (ctx, mut app) = balance_app(&arena, &input);
-        // Row 0 is Assets:Banks:Foo (6 lines); row 1 is the tall broker account.
+        balance_app(arena, &input)
+    }
+
+    /// `↓` walks one commodity line; the account stays put until its lines run
+    /// out. `J` skips the rest of them.
+    #[test]
+    fn item_step_moves_a_whole_account_at_a_time() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        render(&mut app, &ctx); // the first frame teaches the nav its viewport
+
+        assert_eq!(app.balance.nav.selected_item(), Some(0));
         app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
+        // Assets:Banks:Foo has six commodities; one line down is still inside it.
+        assert_eq!(app.balance.nav.selected_item(), Some(0));
+
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        assert_eq!(app.balance.nav.selected_item(), Some(1));
+        // …and lands on the account's own first line, not partway into it.
+        let nav = &app.balance.nav;
+        assert_eq!(nav.lines().first_row(1), Some(nav.selected_row()));
+
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::PrevItem)));
+        assert_eq!(app.balance.nav.selected_item(), Some(0));
+    }
+
+    /// An account taller than the body is reachable line by line, and the two
+    /// things that used to be lost when it was — its name and the fact that
+    /// there is more — are on screen.
+    #[test]
+    fn scrolling_into_a_tall_account_keeps_its_name_and_reports_the_cut() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        render(&mut app, &ctx);
+
+        // Into the broker account, then down to its 26th and last lot — far
+        // enough past the top of the body that its label has scrolled off.
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        for _ in 0..25 {
+            app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
+        }
         let out = render(&mut app, &ctx);
+        assert_eq!(app.balance.nav.selected_item(), Some(1));
+        assert!(
+            out.contains("10 STOCKZ"),
+            "the last lot should be reachable:\n{out}"
+        );
         assert!(
             out.contains("Assets:Brokers:Bar"),
-            "the selected row should be on screen:\n{out}"
+            "the account label should be redrawn on the top line:\n{out}"
         );
         assert!(
-            out.contains("10 STOCKA"),
-            "its commodity lines should be on screen:\n{out}"
+            out.contains("above"),
+            "the top line should say how much is cut off above it:\n{out}"
         );
+    }
+
+    /// The sticky label is marked by colour alone — no prefix, so the text
+    /// stays in the column it belongs to.
+    #[test]
+    fn sticky_account_label_is_drawn_in_its_own_color() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        render(&mut app, &ctx);
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        for _ in 0..25 {
+            app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
+        }
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| draw(frame, &mut app, &ctx)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+
+        // The body's first line: inside the border, below the header.
+        let sticky: String = (1..79)
+            .map(|x| buf[Position { x, y: 3 }].symbol())
+            .collect();
+        assert!(
+            sticky.trim_end().ends_with("Assets:Brokers:Bar")
+                || sticky.trim_start().starts_with("Assets:Brokers:Bar"),
+            "expected the cut account's label on the top body line: {sticky:?}"
+        );
+        assert_eq!(buf[Position { x: 1, y: 3 }].fg, STICKY_COLOR);
+    }
+
+    /// A body with no room for a row after its header draws nothing at all, so
+    /// it says why rather than showing an empty box.
+    #[test]
+    fn a_terminal_too_short_for_a_body_says_so() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        // 1 title + 1 footer leaves 3 lines: two borders and the header, with
+        // no room for a row.
+        let out = render_sized(&mut app, &ctx, 40, 5);
+        assert!(out.contains("terminal too short"), "{out}");
     }
 
     /// Renders `app` into a `width`×`height` headless terminal, plain text.

--- a/cli/src/ui/table.rs
+++ b/cli/src/ui/table.rs
@@ -1,4 +1,5 @@
 use std::cmp::{max, min};
+use std::ops::Range;
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::widgets::TableState;
@@ -8,7 +9,11 @@ use crate::ui::keys::is_ctrl;
 /// A navigation command over a table — the vocabulary shared by every table
 /// screen. Keeps the key bindings and the [`TableNav`] mutations in one place
 /// so each screen wraps [`NavCommand`] in its own message rather than
-/// re-deriving `move_selection`/`select_first` from scratch.
+/// re-deriving `move_rows`/`select_first_row` from scratch.
+///
+/// The report tables draw one row per *line* (an account's balance is one line
+/// per commodity), so `Up`/`Down` walk lines while [`NavCommand::NextItem`] and
+/// [`NavCommand::PrevItem`] walk whole accounts/entries — see [`LineIndex`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NavCommand {
     Up,
@@ -17,6 +22,10 @@ pub enum NavCommand {
     PageDown,
     First,
     Last,
+    /// First line of the next item (`J`).
+    NextItem,
+    /// First line of the previous item (`K`).
+    PrevItem,
 }
 
 /// Maps a key event to a [`NavCommand`], the navigation bindings shared by the
@@ -29,6 +38,8 @@ pub fn key_to_nav(key: KeyEvent) -> Option<NavCommand> {
         KeyCode::Char('p') if ctrl => Some(NavCommand::Up),
         KeyCode::Down | KeyCode::Char('j') => Some(NavCommand::Down),
         KeyCode::Char('n') if ctrl => Some(NavCommand::Down),
+        KeyCode::Char('K') => Some(NavCommand::PrevItem),
+        KeyCode::Char('J') => Some(NavCommand::NextItem),
         KeyCode::PageUp => Some(NavCommand::PageUp),
         KeyCode::Char('b') if ctrl => Some(NavCommand::PageUp),
         KeyCode::PageDown => Some(NavCommand::PageDown),
@@ -39,6 +50,106 @@ pub fn key_to_nav(key: KeyEvent) -> Option<NavCommand> {
     }
 }
 
+/// Maps the one-line table rows of a screen to the logical items they belong
+/// to: a balance account occupies one row per commodity, a register entry one
+/// row per line of its taller amount column.
+///
+/// Everything the tables draw is a *row* (one terminal line); everything the
+/// rest of the UI reasons about — the selected account, a search match, the
+/// register a drill-in opens — is an *item*. This is the translation between
+/// the two, so neither side has to carry the other's indices.
+#[derive(Debug, Default, Clone)]
+pub struct LineIndex {
+    /// Item -> its first row, ascending. `starts.len()` is the item count, and
+    /// everything else is derived from it: a row's item is the last start
+    /// at-or-below it. Keeping only the item ends means the index costs one
+    /// entry per account rather than one per commodity line.
+    starts: Vec<usize>,
+    /// Total rows, i.e. where a hypothetical item after the last one would
+    /// start.
+    row_count: usize,
+}
+
+impl LineIndex {
+    /// Builds an index from each item's rendered line count. A count of `0` is
+    /// treated as `1`: every item occupies at least one row.
+    pub fn new(line_counts: impl IntoIterator<Item = u16>) -> Self {
+        let mut index = Self::default();
+        for count in line_counts {
+            index.starts.push(index.row_count);
+            index.row_count += usize::from(max(count, 1));
+        }
+        index
+    }
+
+    /// An index over `items` items of one line each — the shape of a table
+    /// that needs no exploding (the import screen, the pure nav tests).
+    pub fn uniform(items: usize) -> Self {
+        Self::new(std::iter::repeat_n(1u16, items))
+    }
+
+    /// Number of table rows.
+    pub fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    /// Number of logical items.
+    pub fn item_count(&self) -> usize {
+        self.starts.len()
+    }
+
+    /// The item a row belongs to.
+    pub fn item_at(&self, row: usize) -> Option<usize> {
+        if row >= self.row_count {
+            return None;
+        }
+        // Every item starts at or below its own rows, and `starts[0] == 0`, so
+        // an in-range row always has one before it.
+        Some(self.starts.partition_point(|&start| start <= row) - 1)
+    }
+
+    /// The first row of `item`.
+    pub fn first_row(&self, item: usize) -> Option<usize> {
+        self.starts.get(item).copied()
+    }
+
+    /// One past the last row of `item`.
+    fn end_row(&self, item: usize) -> usize {
+        self.first_row(item + 1).unwrap_or(self.row_count)
+    }
+
+    /// The items whose rows intersect `window`, in order, each paired with the
+    /// range of *its own* lines that falls inside it.
+    ///
+    /// This is what a table body is built from: the renderer walks items rather
+    /// than rows (it formats an account's amounts once, however many lines they
+    /// span) but must draw only the lines the window actually holds, and the
+    /// clipped range is also what says whether the item is cut by an edge.
+    pub fn items_in(
+        &self,
+        window: Range<usize>,
+    ) -> impl Iterator<Item = (usize, Range<u16>)> + use<'_> {
+        let start = min(window.start, self.row_count);
+        let end = min(window.end, self.row_count);
+        // The first item is the one holding `start`; the last is the one
+        // holding `end - 1`, which is one before the first item starting at or
+        // after `end`. Both come out of the same search.
+        let items = match start < end {
+            true => {
+                self.starts.partition_point(|&s| s <= start) - 1
+                    ..self.starts.partition_point(|&s| s < end)
+            }
+            false => 0..0,
+        };
+        items.map(move |item| {
+            let first_row = self.starts[item];
+            let first_line = (max(start, first_row) - first_row) as u16;
+            let end_line = (min(end, self.end_row(item)) - first_row) as u16;
+            (item, first_line..end_line)
+        })
+    }
+}
+
 /// Pure scroll/selection state for a table.
 ///
 /// Lives separately from row data so the navigation math can be tested
@@ -46,49 +157,81 @@ pub fn key_to_nav(key: KeyEvent) -> Option<NavCommand> {
 #[derive(Debug, Default)]
 pub struct TableNav {
     pub table_state: TableState,
-    pub row_count: usize,
+    /// Row ↔ item translation for this table; also the source of the row count.
+    lines: LineIndex,
     /// Last known viewport height for the table body. Updated each frame and
     /// used to size page-up/page-down jumps.
     pub viewport_height: u16,
-    /// Index of the first visible row, maintained by the register renderer's
-    /// virtualization ([`visible_window`]). The balance table leaves this at 0
-    /// and relies on ratatui's built-in scrolling instead.
-    pub offset: usize,
+    /// Index of the first visible row, maintained by [`Self::visible_window`].
+    offset: usize,
 }
 
 impl TableNav {
-    pub fn new(row_count: usize) -> Self {
+    /// A table of `item_count` single-line items.
+    pub fn new(item_count: usize) -> Self {
+        Self::from_index(LineIndex::uniform(item_count))
+    }
+
+    /// A table whose items occupy the given line counts.
+    pub fn with_lines(line_counts: impl IntoIterator<Item = u16>) -> Self {
+        Self::from_index(LineIndex::new(line_counts))
+    }
+
+    fn from_index(lines: LineIndex) -> Self {
         let mut table_state = TableState::default();
-        if row_count > 0 {
+        if lines.row_count() > 0 {
             table_state.select(Some(0));
         }
         Self {
             table_state,
-            row_count,
+            lines,
             viewport_height: 0,
             offset: 0,
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.row_count == 0
+    pub fn lines(&self) -> &LineIndex {
+        &self.lines
     }
 
-    /// Current selection index, defaulting to 0 when nothing is selected.
-    pub fn selected_index(&self) -> usize {
+    pub fn row_count(&self) -> usize {
+        self.lines.row_count()
+    }
+
+    pub fn item_count(&self) -> usize {
+        self.lines.item_count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.row_count() == 0
+    }
+
+    /// Current row selection, defaulting to 0 when nothing is selected.
+    ///
+    /// A *row* is one line of the table. To address what the row belongs to —
+    /// the account or register entry the rest of the UI reasons about — use
+    /// [`Self::selected_item`]: the two indices differ as soon as anything
+    /// spans more than one commodity, and nothing but the name says which is
+    /// which.
+    pub fn selected_row(&self) -> usize {
         self.table_state.selected().unwrap_or(0)
     }
 
-    fn last_index(&self) -> Option<usize> {
-        self.row_count.checked_sub(1)
+    /// The item the selection sits in, if any.
+    pub fn selected_item(&self) -> Option<usize> {
+        self.lines.item_at(self.table_state.selected()?)
+    }
+
+    fn last_row(&self) -> Option<usize> {
+        self.row_count().checked_sub(1)
     }
 
     /// Moves the selection by `delta` rows, clamping to the row range.
-    pub fn move_selection(&mut self, delta: isize) {
-        let Some(last) = self.last_index() else {
+    pub fn move_rows(&mut self, delta: isize) {
+        let Some(last) = self.last_row() else {
             return;
         };
-        let current = self.table_state.selected().unwrap_or(0) as isize;
+        let current = self.selected_row() as isize;
         let next = (current + delta).clamp(0, last as isize);
         self.table_state.select(Some(next as usize));
     }
@@ -99,76 +242,98 @@ impl TableNav {
         max(1, self.viewport_height) as usize
     }
 
-    pub fn select_first(&mut self) {
+    pub fn select_first_row(&mut self) {
         if !self.is_empty() {
             self.table_state.select(Some(0));
         }
     }
 
-    pub fn select_last(&mut self) {
-        if let Some(last) = self.last_index() {
+    pub fn select_last_row(&mut self) {
+        if let Some(last) = self.last_row() {
             self.table_state.select(Some(last));
         }
     }
 
     /// Selects an explicit row index, ignored when out of range.
-    pub fn select(&mut self, index: usize) {
-        if index < self.row_count {
-            self.table_state.select(Some(index));
+    pub fn select_row(&mut self, row: usize) {
+        if row < self.row_count() {
+            self.table_state.select(Some(row));
+        }
+    }
+
+    /// Selects the first row of `item`, ignored when out of range.
+    pub fn select_item(&mut self, item: usize) {
+        if let Some(row) = self.lines.first_row(item) {
+            self.select_row(row);
+        }
+    }
+
+    /// Steps the selection a whole item at a time (`J`/`K`), landing on the
+    /// neighbour's first row. At either end there is no neighbour to land on,
+    /// so the selection goes to that end of the table instead — the key always
+    /// moves the way it points.
+    fn step_item(&mut self, delta: isize) {
+        let Some(item) = self.selected_item() else {
+            return;
+        };
+        let target = item as isize + delta;
+        match usize::try_from(target) {
+            Ok(target) if target < self.item_count() => self.select_item(target),
+            // Past the last item, or before the first.
+            _ if delta > 0 => self.select_last_row(),
+            _ => self.select_first_row(),
         }
     }
 
     /// Applies a [`NavCommand`].
     pub fn apply(&mut self, cmd: NavCommand) {
         match cmd {
-            NavCommand::Up => self.move_selection(-1),
-            NavCommand::Down => self.move_selection(1),
+            NavCommand::Up => self.move_rows(-1),
+            NavCommand::Down => self.move_rows(1),
             NavCommand::PageUp => {
                 let delta = -(self.page_size() as isize);
-                self.move_selection(delta);
+                self.move_rows(delta);
             }
             NavCommand::PageDown => {
                 let delta = self.page_size() as isize;
-                self.move_selection(delta);
+                self.move_rows(delta);
             }
-            NavCommand::First => self.select_first(),
-            NavCommand::Last => self.select_last(),
+            NavCommand::First => self.select_first_row(),
+            NavCommand::Last => self.select_last_row(),
+            NavCommand::NextItem => self.step_item(1),
+            NavCommand::PrevItem => self.step_item(-1),
         }
     }
 
-    /// Recomputes the virtualized window from the current selection, stores the
-    /// new [`offset`](Self::offset), and returns the visible `[offset, end)`.
-    /// `height_of(i)` gives row `i`'s rendered line count (always `>= 1`).
+    /// Recomputes the visible window from the current selection, stores the new
+    /// offset, and returns the visible `[offset, end)`.
     ///
     /// Thin wrapper over [`visible_window`]: the window math lives there, tested
     /// in isolation; this just feeds it the nav's own fields and writes the
     /// offset back so the caller can't compute it and forget to store it.
-    pub fn visible_window(&mut self, height_of: impl Fn(usize) -> u16) -> (usize, usize) {
-        let selected = self.selected_index();
+    pub fn visible_window(&mut self) -> (usize, usize) {
         let (offset, end) = visible_window(
-            selected,
+            self.selected_row(),
             self.offset,
             self.viewport_height,
-            self.row_count,
-            height_of,
+            self.row_count(),
         );
         self.offset = offset;
         (offset, end)
     }
 }
 
-/// Computes the visible row window `[offset, end)` for a variable-height table,
-/// scrolling the minimum amount needed to keep `selected` in view.
+/// Computes the visible row window `[offset, end)`, scrolling the minimum
+/// amount needed to keep `selected` in view.
 ///
-/// This is the virtualization primitive for the register table: rather than
-/// building a widget row for every entry (O(n) per frame), the renderer builds
-/// rows only for `[offset, end)`. `height_of(i)` returns the rendered line
-/// count of row `i` (always `>= 1`); `viewport_height` is the number of body
-/// lines available.
+/// Every table row is one line tall (tall balances are exploded into one row
+/// per commodity by [`LineIndex`]), so the window is just a slice: the renderer
+/// builds widget rows only for `[offset, end)` rather than one per entry, which
+/// keeps per-frame work proportional to the viewport rather than to the
+/// (potentially large) row count.
 ///
 /// Guarantees `offset <= selected < end <= row_count` whenever `row_count > 0`
-/// and `selected < row_count`. Both scans touch at most a viewport's worth of
-/// rows, so it stays O(viewport) even when `selected` jumps to either end.
+/// and `selected < row_count`.
 ///
 /// [`TableNav::visible_window`] is the ergonomic entry point; this free function
 /// is the pure primitive the unit tests drive directly.
@@ -177,52 +342,24 @@ fn visible_window(
     prev_offset: usize,
     viewport_height: u16,
     row_count: usize,
-    height_of: impl Fn(usize) -> u16,
 ) -> (usize, usize) {
     if row_count == 0 {
         return (0, 0);
     }
-    let budget = viewport_height;
+    // A viewport too short to have a body still shows the selected row; the
+    // renderer says so rather than drawing an empty table.
+    let budget = max(viewport_height, 1) as usize;
+    let selected = min(selected, row_count - 1);
     // The window never starts below the selection; a selection above the
     // previous offset pulls the window up to it (selection at the top).
-    let offset = min(prev_offset, selected);
-    let end = fill_forward(offset, budget, row_count, &height_of);
-    if selected < end {
-        return (offset, end);
+    let mut offset = min(prev_offset, selected);
+    // Never leave the body half empty when there are rows to fill it with.
+    offset = min(offset, row_count.saturating_sub(budget));
+    // Selection below the window: pin it to the bottom line.
+    if selected >= offset + budget {
+        offset = selected + 1 - budget;
     }
-    // Selection sits below the window: pin it to the bottom by walking up from
-    // it, accumulating heights until the viewport is full.
-    (fill_backward(selected, budget, &height_of), selected + 1)
-}
-
-/// Smallest `end` such that rows `start..end` fulfill the `budget` lines.
-fn fill_forward(
-    start: usize,
-    budget: u16,
-    row_count: usize,
-    height_of: &impl Fn(usize) -> u16,
-) -> usize {
-    let mut end = start;
-    let mut used = 0u16;
-    while end < row_count && used < budget {
-        used += height_of(end);
-        end += 1;
-    }
-    end
-}
-
-/// Largest `start` such that rows `start..=last` fulfill the `budget` lines.
-fn fill_backward(last: usize, budget: u16, height_of: &impl Fn(usize) -> u16) -> usize {
-    let mut start = last;
-    let mut used = 0u16;
-    loop {
-        used += height_of(start);
-        if start == 0 || used >= budget {
-            break;
-        }
-        start -= 1;
-    }
-    start
+    (offset, min(offset + budget, row_count))
 }
 
 #[cfg(test)]
@@ -242,6 +379,10 @@ mod tests {
 
     fn ctrl(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    fn shift(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::SHIFT)
     }
 
     #[test]
@@ -264,6 +405,16 @@ mod tests {
         assert_eq!(key_to_nav(key(KeyCode::Char('q'))), None);
         assert_eq!(key_to_nav(key(KeyCode::Enter)), None);
         assert_eq!(key_to_nav(key(KeyCode::Char('f'))), None); // f without ctrl
+    }
+
+    /// `J`/`K` are the item-wise siblings of `j`/`k`, and arrive shifted.
+    #[test]
+    fn key_to_nav_maps_item_steps_to_shifted_j_and_k() {
+        assert_eq!(key_to_nav(shift('J')), Some(NavCommand::NextItem));
+        assert_eq!(key_to_nav(shift('K')), Some(NavCommand::PrevItem));
+        // Unshifted, they stay line-wise.
+        assert_eq!(key_to_nav(key(KeyCode::Char('j'))), Some(NavCommand::Down));
+        assert_eq!(key_to_nav(key(KeyCode::Char('k'))), Some(NavCommand::Up));
     }
 
     #[test]
@@ -293,38 +444,38 @@ mod tests {
     }
 
     #[test]
-    fn move_selection_clamps_to_bounds() {
+    fn move_rows_clamps_to_bounds() {
         let mut n = nav(3);
         assert_eq!(n.table_state.selected(), Some(0));
 
-        n.move_selection(-1);
+        n.move_rows(-1);
         assert_eq!(n.table_state.selected(), Some(0));
 
-        n.move_selection(1);
+        n.move_rows(1);
         assert_eq!(n.table_state.selected(), Some(1));
 
-        n.move_selection(100);
+        n.move_rows(100);
         assert_eq!(n.table_state.selected(), Some(2));
 
-        n.move_selection(-100);
+        n.move_rows(-100);
         assert_eq!(n.table_state.selected(), Some(0));
     }
 
     #[test]
-    fn select_first_and_last() {
+    fn select_first_and_last_row() {
         let mut n = nav(5);
-        n.select_last();
+        n.select_last_row();
         assert_eq!(n.table_state.selected(), Some(4));
-        n.select_first();
+        n.select_first_row();
         assert_eq!(n.table_state.selected(), Some(0));
     }
 
     #[test]
-    fn select_first_or_last_on_empty_is_noop() {
+    fn select_first_or_last_row_on_empty_is_noop() {
         let mut n = nav(0);
-        n.select_last();
+        n.select_last_row();
         assert_eq!(n.table_state.selected(), None);
-        n.select_first();
+        n.select_first_row();
         assert_eq!(n.table_state.selected(), None);
     }
 
@@ -341,79 +492,176 @@ mod tests {
         assert_eq!(n.page_size(), 20);
     }
 
-    /// All rows one line tall — the common register case.
-    fn uniform(_i: usize) -> u16 {
-        1
+    /// Three items of 1, 3 and 2 lines: rows 0 | 1,2,3 | 4,5.
+    fn ragged() -> TableNav {
+        TableNav::with_lines([1, 3, 2])
+    }
+
+    #[test]
+    fn line_index_maps_rows_to_items_and_back() {
+        let index = LineIndex::new([1, 3, 2]);
+        assert_eq!(index.row_count(), 6);
+        assert_eq!(index.item_count(), 3);
+        // Every row of item 1 (rows 1..4) reports item 1, its first row and
+        // last alike.
+        assert_eq!(index.item_at(0), Some(0));
+        assert_eq!(index.item_at(1), Some(1));
+        assert_eq!(index.item_at(3), Some(1));
+        assert_eq!(index.item_at(4), Some(2));
+        assert_eq!(index.item_at(6), None);
+        assert_eq!(index.first_row(1), Some(1));
+        assert_eq!(index.first_row(2), Some(4));
+        assert_eq!(index.first_row(3), None);
+    }
+
+    /// A zero-line item would make its rows unreachable; it gets one row.
+    #[test]
+    fn line_index_gives_every_item_at_least_one_row() {
+        let index = LineIndex::new([0, 0]);
+        assert_eq!(index.row_count(), 2);
+        assert_eq!(index.item_at(1), Some(1));
+    }
+
+    #[test]
+    fn line_index_uniform_is_one_row_per_item() {
+        let index = LineIndex::uniform(3);
+        assert_eq!(index.row_count(), 3);
+        assert_eq!(index.item_count(), 3);
+        assert_eq!(index.item_at(2), Some(2));
+    }
+
+    /// The renderer walks items but draws rows, so the window has to arrive
+    /// already clipped to each item's own lines.
+    #[test]
+    fn line_index_items_in_clips_each_item_to_the_window() {
+        let index = LineIndex::new([1, 3, 2]); // rows 0 | 1,2,3 | 4,5
+        let items = |window: Range<usize>| index.items_in(window).collect::<Vec<_>>();
+
+        // The whole table: every item, every line.
+        assert_eq!(items(0..6), [(0, 0..1), (1, 0..3), (2, 0..2)]);
+        // A window cutting item 1 on both edges yields only its middle line.
+        assert_eq!(items(2..3), [(1, 1..2)]);
+        // Cut above on the left, cut below on the right.
+        assert_eq!(items(3..5), [(1, 2..3), (2, 0..1)]);
+        // Out of range is clamped; an empty window yields nothing.
+        assert_eq!(items(4..99), [(2, 0..2)]);
+        assert_eq!(items(3..3), []);
+        assert_eq!(items(9..12), []);
+        assert_eq!(LineIndex::default().items_in(0..5).count(), 0);
+    }
+
+    #[test]
+    fn selected_item_follows_the_row_selection() {
+        let mut n = ragged();
+        assert_eq!(n.selected_item(), Some(0));
+        n.select_row(2);
+        assert_eq!(n.selected_item(), Some(1));
+        n.select_row(5);
+        assert_eq!(n.selected_item(), Some(2));
+    }
+
+    #[test]
+    fn select_item_lands_on_its_first_row() {
+        let mut n = ragged();
+        n.select_item(1);
+        assert_eq!(n.table_state.selected(), Some(1));
+        n.select_item(2);
+        assert_eq!(n.table_state.selected(), Some(4));
+        // Out of range leaves the selection alone.
+        n.select_item(9);
+        assert_eq!(n.table_state.selected(), Some(4));
+    }
+
+    /// `J`/`K` skip the rest of the current item rather than stepping a line.
+    #[test]
+    fn item_steps_jump_whole_items() {
+        let mut n = ragged();
+        n.apply(NavCommand::NextItem);
+        assert_eq!(n.table_state.selected(), Some(1)); // item 1, first line
+        n.apply(NavCommand::Down);
+        assert_eq!(n.table_state.selected(), Some(2)); // still inside item 1
+        n.apply(NavCommand::NextItem);
+        assert_eq!(n.table_state.selected(), Some(4)); // item 2, first line
+        n.apply(NavCommand::PrevItem);
+        assert_eq!(n.table_state.selected(), Some(1)); // back to item 1
+    }
+
+    /// With no neighbour left, the key still moves the way it points: to the
+    /// last row going down, to the first going up.
+    #[test]
+    fn item_steps_run_to_the_ends_of_the_table() {
+        let mut n = ragged();
+        n.select_item(2);
+        n.apply(NavCommand::NextItem);
+        assert_eq!(n.table_state.selected(), Some(5));
+        n.apply(NavCommand::NextItem);
+        assert_eq!(n.table_state.selected(), Some(5));
+        n.select_row(3); // middle of item 1
+        n.apply(NavCommand::PrevItem);
+        assert_eq!(n.table_state.selected(), Some(0));
+        n.apply(NavCommand::PrevItem);
+        assert_eq!(n.table_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn item_steps_on_empty_table_are_noop() {
+        let mut n = nav(0);
+        n.apply(NavCommand::NextItem);
+        n.apply(NavCommand::PrevItem);
+        assert_eq!(n.table_state.selected(), None);
     }
 
     #[test]
     fn empty_table_has_empty_window() {
-        assert_eq!(visible_window(0, 0, 10, 0, uniform), (0, 0));
+        assert_eq!(visible_window(0, 0, 10, 0), (0, 0));
     }
 
     #[test]
     fn everything_fits_shows_all() {
         // 5 rows, viewport of 10: whole table visible, offset stays 0.
-        assert_eq!(visible_window(4, 0, 10, 5, uniform), (0, 5));
-        assert_eq!(visible_window(0, 0, 10, 5, uniform), (0, 5));
+        assert_eq!(visible_window(4, 0, 10, 5), (0, 5));
+        assert_eq!(visible_window(0, 0, 10, 5), (0, 5));
     }
 
     #[test]
     fn selection_above_offset_scrolls_up_to_top() {
         // Window was scrolled down to offset 20; selecting row 5 pulls it up so
         // row 5 sits at the top.
-        assert_eq!(visible_window(5, 20, 10, 100, uniform), (5, 15));
+        assert_eq!(visible_window(5, 20, 10, 100), (5, 15));
     }
 
     #[test]
     fn selection_within_window_keeps_offset() {
         // offset 10, viewport 10 → rows [10, 20); selecting 15 changes nothing.
-        assert_eq!(visible_window(15, 10, 10, 100, uniform), (10, 20));
+        assert_eq!(visible_window(15, 10, 10, 100), (10, 20));
     }
 
     #[test]
     fn selection_below_window_pins_to_bottom() {
         // offset 10, viewport 10 → rows [10, 20); selecting 25 scrolls down so
         // 25 is the last visible row.
-        assert_eq!(visible_window(25, 10, 10, 100, uniform), (16, 26));
+        assert_eq!(visible_window(25, 10, 10, 100), (16, 26));
     }
 
     #[test]
     fn jump_to_last_row_shows_final_page() {
         // g→G style jump from the top: last row pinned to the bottom.
-        assert_eq!(visible_window(99, 0, 10, 100, uniform), (90, 100));
+        assert_eq!(visible_window(99, 0, 10, 100), (90, 100));
     }
 
     #[test]
     fn jump_to_first_row_shows_first_page() {
-        assert_eq!(visible_window(0, 90, 10, 100, uniform), (0, 10));
+        assert_eq!(visible_window(0, 90, 10, 100), (0, 10));
+    }
+
+    /// A stale offset from a longer table must not leave the body half empty.
+    #[test]
+    fn offset_is_pulled_back_when_the_table_shrinks() {
+        assert_eq!(visible_window(9, 8, 10, 10), (0, 10));
     }
 
     #[test]
-    fn variable_heights_respect_line_budget() {
-        // Rows alternate 1 and 2 lines tall. Viewport of 5 lines from offset 0:
-        // row0(1)+row1(2)+row2(1) = 4, +row3(2)=6 > 5 → stop → rows [0, 4).
-        let heights = |i: usize| if i.is_multiple_of(2) { 1 } else { 2 };
-        assert_eq!(visible_window(0, 0, 5, 10, heights), (0, 4));
-    }
-
-    #[test]
-    fn variable_heights_pin_bottom_accounts_for_tall_rows() {
-        // Same alternating heights, viewport 5. Select row 5 (2 lines tall):
-        // walk up 5(2),4(1),3(2)=5 fits, 2(1)=6>5 stop → offset 3, end 6.
-        let heights = |i: usize| if i.is_multiple_of(2) { 1 } else { 2 };
-        assert_eq!(visible_window(5, 0, 5, 10, heights), (3, 6));
-    }
-
-    #[test]
-    fn row_taller_than_viewport_still_shows_selection() {
-        // A single 4-line row in a 2-line viewport: show it alone.
-        let heights = |_i: usize| 4u16;
-        assert_eq!(visible_window(7, 0, 2, 10, heights), (7, 8));
-    }
-
-    #[test]
-    fn zero_viewport_shows_only_selection() {
-        assert_eq!(visible_window(3, 0, 0, 10, uniform), (3, 4));
+    fn zero_viewport_shows_only_the_selection() {
+        assert_eq!(visible_window(3, 0, 0, 10), (3, 4));
     }
 }

--- a/testdata/report/ui/alias.balance-tree-all-folded.txt
+++ b/testdata/report/ui/alias.balance-tree-all-folded.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/alias.balance-tree.txt
+++ b/testdata/report/ui/alias.balance-tree.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/alias.balance.txt
+++ b/testdata/report/ui/alias.balance.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/alias.register-subtree.txt
+++ b/testdata/report/ui/alias.register-subtree.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/alias.register.txt
+++ b/testdata/report/ui/alias.register.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/many_commodities.balance-tree-all-folded.txt
+++ b/testdata/report/ui/many_commodities.balance-tree-all-folded.txt
@@ -19,6 +19,6 @@
 │                                                                     10 STOCKJ│
 │                                                                     10 STOCKK│
 │                                                                     10 STOCKL│
-│                                                                     10 STOCKM│
+│                                                                      +14 more│
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/many_commodities.balance-tree.txt
+++ b/testdata/report/ui/many_commodities.balance-tree.txt
@@ -1,24 +1,24 @@
  okane ui — many_commodities.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                        Amount         │
+│▼ Assets                                                             +21 above│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                     10 STOCKR│
+│                                                                     10 STOCKS│
+│                                                                     10 STOCKT│
+│                                                                     10 STOCKU│
+│                                                                     10 STOCKV│
+│                                                                     10 STOCKW│
+│                                                                     10 STOCKX│
+│                                                                     10 STOCKY│
+│                                                                     10 STOCKZ│
 │  ▼ Banks                                                           992000 JPY│
 │                                                                   5000.00 CHF│
 │                                                                   9800.00 USD│
 │                                                                   8000.00 EUR│
 │                                                                   3000.00 AUD│
 │                                                                 195000.00 TWD│
-│      Foo                                                           992000 JPY│
-│                                                                   5000.00 CHF│
-│                                                                   9800.00 USD│
-│                                                                   8000.00 EUR│
-│                                                                   3000.00 AUD│
-│                                                                 195000.00 TWD│
-│  ▼ Brokers                                                          10 STOCKA│
-│                                                                     10 STOCKB│
-│                                                                     10 STOCKC│
-│                                                                     10 STOCKD│
-│                                                                     10 STOCKE│
-│                                                                     10 STOCKF│
-│                                                                     10 STOCKG│
+│      Foo                                                              +6 more│
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/many_commodities.balance.txt
+++ b/testdata/report/ui/many_commodities.balance.txt
@@ -19,6 +19,6 @@
 │                                                                     10 STOCKJ│
 │                                                                     10 STOCKK│
 │                                                                     10 STOCKL│
-│                                                                     10 STOCKM│
+│                                                                      +14 more│
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/many_commodities.register-subtree.txt
+++ b/testdata/report/ui/many_commodities.register-subtree.txt
@@ -1,24 +1,24 @@
  okane ui — many_commodities.ledger — register: Assets                          
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Date       Payee                                 Amount         Total         │
-│2024-01-27 ATM abroad                               -200.00 USD     992000 JPY│
-│                                                                   5000.00 CHF│
-│                                                                   9800.00 USD│
-│                                                                   8000.00 EUR│
-│                                                                   3000.00 AUD│
-│                                                                 195000.00 TWD│
-│                                                                     10 STOCKA│
-│                                                                     10 STOCKB│
-│                                                                     10 STOCKC│
-│                                                                     10 STOCKD│
-│                                                                     10 STOCKE│
-│                                                                     10 STOCKF│
-│                                                                     10 STOCKG│
-│                                                                     10 STOCKH│
+│2024-01-27 ATM abroad                                                +14 above│
 │                                                                     10 STOCKI│
 │                                                                     10 STOCKJ│
 │                                                                     10 STOCKK│
 │                                                                     10 STOCKL│
 │                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                     10 STOCKR│
+│                                                                     10 STOCKS│
+│                                                                     10 STOCKT│
+│                                                                     10 STOCKU│
+│                                                                     10 STOCKV│
+│                                                                     10 STOCKW│
+│                                                                     10 STOCKX│
+│                                                                     10 STOCKY│
+│                                                                     10 STOCKZ│
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/many_commodities.register.txt
+++ b/testdata/report/ui/many_commodities.register.txt
@@ -1,6 +1,7 @@
  okane ui — many_commodities.ledger — register: Assets:Banks:Foo                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Date       Payee                                 Amount         Total         │
+│2024-01-01 Opening balances across currencies                         +6 above│
 │2024-01-18 Cash withdrawal                         -5000.00 TWD    1000000 JPY│
 │                                                                   5000.00 CHF│
 │                                                                  10000.00 USD│
@@ -19,6 +20,5 @@
 │                                                                   8000.00 EUR│
 │                                                                   3000.00 AUD│
 │                                                                 195000.00 TWD│
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/multi_commodity.balance-tree-all-folded.txt
+++ b/testdata/report/ui/multi_commodity.balance-tree-all-folded.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.balance-tree.txt
+++ b/testdata/report/ui/multi_commodity.balance-tree.txt
@@ -19,6 +19,6 @@
 │  ▼ Wire                                                                     0│
 │      US Broker                                                              0│
 │▼ Equity                                                         -48000.00 CHF│
-│                                                                    900000 JPY│
+│                                                                       +2 more│
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.balance.txt
+++ b/testdata/report/ui/multi_commodity.balance.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.register-subtree.txt
+++ b/testdata/report/ui/multi_commodity.register-subtree.txt
@@ -1,6 +1,10 @@
  okane ui — multi_commodity.ledger — register: Assets                           
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Date       Payee                               Amount          Total          │
+│2024-02-09 Sell stock                                                 +2 above│
+│                                                                  11570.00 USD│
+│                                                                410.0000 OKANE│
+│                                                                   12.300 GOLD│
 │2024-02-09 Sell stock                              1700.00 USD    37518.47 CHF│
 │                                                                    100000 JPY│
 │                                                                  13270.00 USD│
@@ -16,9 +20,5 @@
 │                                                                  13270.00 USD│
 │                                                                390.0000 OKANE│
 │                                                                   12.300 GOLD│
-│                                                                              │
-│                                                                              │
-│                                                                              │
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/multi_commodity.register.txt
+++ b/testdata/report/ui/multi_commodity.register.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/render_error_modal.txt
+++ b/testdata/report/ui/render_error_modal.txt
@@ -21,4 +21,4 @@
 │       └──────────────────────────────────────────────────────────────┘       │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/render_error_modal_scrolled_to_bottom.txt
+++ b/testdata/report/ui/render_error_modal_scrolled_to_bottom.txt
@@ -21,4 +21,4 @@
 │       └──────────────────────────────────────────────────────────────┘       │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.balance-tree-all-folded.txt
+++ b/testdata/report/ui/single_commodity.balance-tree-all-folded.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.balance-tree.txt
+++ b/testdata/report/ui/single_commodity.balance-tree.txt
@@ -21,4 +21,4 @@
 │      Card X                                                                 0│
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.balance.txt
+++ b/testdata/report/ui/single_commodity.balance.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · Enter register · t tree · space fold · x fold-all · / search · r r
+ ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.register-subtree.txt
+++ b/testdata/report/ui/single_commodity.register-subtree.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   

--- a/testdata/report/ui/single_commodity.register.txt
+++ b/testdata/report/ui/single_commodity.register.txt
@@ -21,4 +21,4 @@
 │                                                                              │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
- ↑/↓ scroll · PgUp/PgDn page · g/G home/end · r reload · q/Esc back             
+ ↑/↓ line · J/K entry · PgUp/PgDn page · g/G home/end · r reload · q/Esc back   


### PR DESCRIPTION
Reworks the balance and register tables along the lines picked from the [okane-tui-mock bench](https://github.com/xkikeg/okane-tui-mock/pull/1) for #513: `rows: exploded`, `ctx: sticky-color`, `mark: +N more`, plus a new `J`/`K` for the "next item" step the mock only had as its `group` row layout.

Today a balance row is as tall as the account has commodities. #517 stopped a row taller than the body from being dropped, but it is still clipped silently and the hidden lines are unreachable.

## What changed

**One table row per amount line.** `ui::table::LineIndex` maps those rows back to the accounts and register entries the rest of the UI reasons about, so search matches, the register drill-in, folding and the reload snapshot all keep working in account terms while the cursor moves a line at a time. Nothing is ever clipped, and scrolling is uniform: leaving a tall account slides the next one in from the bottom instead of jumping it to the top.

**`J`/`K` step a whole account or entry**, since plain `j`/`k` no longer do. They land on the item's own first line; at either end of the table they run to that end.

**Sticky account label.** Once the top of an account's block is off screen its name goes with it, so it is redrawn on the top body line in cyan. Colour rather than a `…` prefix, so the text stays in the column it belongs to — the register's date column is exactly `YYYY-MM-DD` wide and a prefix renders it as `⋮ 2026-12-`.

**`+N above` / `+N more`.** An account cut by the top or bottom edge of the body says how much is hidden, in place of the amount on the edge line itself. Per column: a register entry's Amount is one line however far past the edge its Total runs, so marking it there would both lie and eat a real value.

```
│Account                                                        Amount         │
│▼ Assets                                                             +20 above│
│                                                                     10 STOCKP│
...
│      Foo                                                              +5 more│
```

## Notes

- Both screens now choose their own window via `TableNav::visible_window` instead of letting ratatui scroll. That is what makes the marker and the sticky label decidable at all — the mock found that `TableState::offset` is not correct until after the table is laid out, so anything depending on it had to be drawn as a post-pass overlay. Owning the window instead puts both decisions in the cells, where the search highlight and the column alignment already are. It also drops the balance screen's per-frame O(rows) row building to O(viewport), which the register already had.
- Row heights are gone along with the clipping, so a terminal with no room for a row after the header can no longer be rescued by capping them. It now says `terminal too short` rather than drawing an empty box that reads as "no data".
- The goldens under `testdata/report/ui/` are regenerated; every diff is the new layout or the new footer hint.

## Verifying

```
cargo test
cargo clippy --all-targets
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
