### PR TITLE
ci: discard restored criterion baselines before benching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,16 @@ jobs:
           toolchain: stable
           target: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Discard restored criterion baselines
+        # rust-cache prunes target/ before saving it, and since v2.9.2 that
+        # leaves target/criterion as a tree of empty directories. criterion
+        # then finds an existing base/ directory without base/sample.json,
+        # fails to compare against it, and prints "Criterion.rs ERROR: ..." on
+        # stdout in the middle of the bencher output, so
+        # github-action-benchmark cannot parse output.txt anymore. The local
+        # baselines are useless to us anyway: the benchmark history lives on
+        # the gh-pages branch.
+        run: rm -rf target/criterion
       - name: Run benchmark
         run: cargo bench --bench decimal_bench --bench report_bench -- --output-format bencher | tee output.txt
       - name: Store benchmark result


### PR DESCRIPTION
## Problem

`Run report bench` has been failing on recent PRs (e.g. [run 32004014089](https://github.com/xkikeg/okane/actions/runs/32004014089/job/95322664082)) with:

```
##[error]No benchmark result was found in .../output.txt. Benchmark output was
'test parse plain ... Criterion.rs ERROR: error: Failed to access file
".../target/criterion/parse plain/base/sample.json": No such file or directory (os error 2)
bench:          21 ns/iter (+/- 0)
...
```

The benchmarks themselves run fine — the output just cannot be parsed anymore.

## Cause

`Swatinem/rust-cache` 2.9.2 (merged in 8a11e7f) changed how `target/` is pruned before the cache is saved: `cleanTargetDir` now identifies profile directories by the presence of `build`/`.fingerprint`/`deps` instead of `CACHEDIR.TAG`/`.rustc_info.json`. `target/criterion` has none of those, so instead of being deleted wholesale as a profile directory it is now walked recursively with only its *files* removed. The restored cache therefore contains `target/criterion/<id>/base/` as an **empty directory**.

criterion's `base_dir_exists()` only checks that `base/` exists before comparing against it, so it tries to load `base/sample.json`, fails, and reports the error with `println!` — landing in the middle of the bencher reporter's unterminated `test <id> ... ` line. Every measurement line ends up malformed and `github-action-benchmark` finds nothing to parse.

Reproduced locally by emulating the pruned cache (`find target/criterion -type f -delete`), which yields byte-for-byte the same broken output.

## Fix

Drop the restored baselines before running the benchmarks. They are of no use in this job anyway: the history `github-action-benchmark` compares against lives on the `gh-pages` branch, and a baseline shared across unrelated PR branches would not be meaningful. Verified locally that the bench output is clean and parseable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)