### PR TITLE
ui: show the whole ledger's total at the top of the balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 
 * CLI: Added `tags` command, listing all tags in the file, sorted and deduped (https://github.com/xkikeg/okane/pull/523). Pass `--values` to print `key: value` pairs instead of the keys alone.
+* CLI: `ui` balance now opens with a `(total)` row holding the balance of every account combined
+  (https://github.com/xkikeg/okane/pull/549). It is the first row of both views — in the tree it is
+  the tree's own root, above the top-level accounts — and `Enter` on it drills into the register of
+  the whole ledger. It is never foldable, so the total stays on screen.
 
 ### Changed
 

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -346,9 +346,15 @@ mod tests {
             let SessionData { mut app, .. } = build(&mut ctx, V1, None).unwrap();
             assert_eq!(
                 account_names(&app),
-                ["Assets:Bank", "Assets:Cash", "Equity", "Expenses:Food"]
+                [
+                    "(total)",
+                    "Assets:Bank",
+                    "Assets:Cash",
+                    "Equity",
+                    "Expenses:Food"
+                ]
             );
-            app.balance.nav.select_item(3); // Expenses:Food
+            app.balance.nav.select_item(4); // Expenses:Food
             app.snapshot()
         };
         arena.reset();
@@ -360,6 +366,7 @@ mod tests {
         assert_eq!(
             account_names(&app),
             [
+                "(total)",
                 "Assets:Aaa",
                 "Assets:Bank",
                 "Assets:Cash",
@@ -368,7 +375,7 @@ mod tests {
             ]
         );
         // The selection followed Expenses:Food to its new index.
-        assert_eq!(app.balance.nav.selected_item(), Some(4));
+        assert_eq!(app.balance.nav.selected_item(), Some(5));
     }
 
     /// The reason reload rebuilds from scratch: interned entries of the
@@ -444,7 +451,7 @@ mod tests {
         assert_matches!(&app.error_toast, Some(_));
         assert_eq!(
             account_names(&app),
-            ["Assets:Bank", "Assets:Cash", "Equity"]
+            ["(total)", "Assets:Bank", "Assets:Cash", "Equity"]
         );
     }
 

--- a/cli/src/ui/report/balance.rs
+++ b/cli/src/ui/report/balance.rs
@@ -24,6 +24,10 @@ use super::render::amount_line_count;
 use super::search::{Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase};
 
 /// Whether the balance screen shows a flat account list or the account tree.
+///
+/// Both modes open with the [total row](BalanceView::total_row): in
+/// [`Self::Tree`] it is the tree's root, and a flat list is that same root
+/// followed by its accounts rather than its children.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DisplayMode {
     /// Every posted account, alphabetically, showing its own amount.
@@ -31,6 +35,10 @@ pub enum DisplayMode {
     /// The account hierarchy, indented and foldable, showing subtree totals.
     Tree,
 }
+
+/// Label of the total row — the whole ledger's balance, which is the tree's
+/// synthetic root rather than an account, so it is named rather than addressed.
+pub const TOTAL_LABEL: &str = "(total)";
 
 /// One visible row of the balance table.
 ///
@@ -47,13 +55,13 @@ pub struct BalanceRow<'ctx> {
     /// Used for search, snapshot and reload restore.
     pub account: AccountTreeKey<'ctx>,
     /// Display label: the full path in [`DisplayMode::Flat`], the leaf segment
-    /// in [`DisplayMode::Tree`].
+    /// in [`DisplayMode::Tree`], and [`TOTAL_LABEL`] for the total row.
     pub label: &'ctx str,
-    /// Depth in the account tree (`1` for a top-level account). Drives the
-    /// tree-view indentation.
+    /// Depth in the account tree (`1` for a top-level account, `0` for the
+    /// total row). Drives the tree-view indentation.
     pub depth: u16,
     /// Amount to display: the node's own amount in flat view, its subtree
-    /// total in tree view.
+    /// total in tree view — and, for the total row, the whole ledger's.
     pub amount: Amount<'ctx>,
     /// Whether the backing node has children (shows a fold marker in tree view).
     pub has_children: bool,
@@ -98,7 +106,7 @@ impl<'ctx> BalanceRow<'ctx> {
 /// Printable full label of the AccountTeeKey.
 pub fn account_full_label<'ctx>(account: &AccountTreeKey<'ctx>) -> &'ctx str {
     match account {
-        AccountTreeKey::Root => "(total)",
+        AccountTreeKey::Root => TOTAL_LABEL,
         AccountTreeKey::Descendant(account) => account.as_str(),
     }
 }
@@ -372,38 +380,64 @@ impl<'ctx> BalanceView<'ctx> {
         }
     }
 
-    /// Flat rows: every posted account (non-zero own amount), full name, own
-    /// amount. Ancestor-only nodes have a zero own amount and are skipped.
-    fn build_flat_rows(&self) -> Vec<BalanceRow<'ctx>> {
-        self.tree
-            .iter()
-            .enumerate()
-            .filter_map(|(i, node)| {
-                let account = match node.account.as_aggregate()? {
-                    AccountAggregate::Account(account) => account,
-                    AccountAggregate::Ancestor(_) => return None,
-                };
-                Some(BalanceRow {
-                    node: i,
-                    account: account.into(),
-                    label: account.as_str(),
-                    depth: node.depth,
-                    amount: node.self_amount.clone(),
-                    // it's flat and impossible to have children.
-                    has_children: false,
-                    folded: false,
-                    scope: RegisterScope::Single(account),
-                })
-            })
-            .collect()
+    /// The whole ledger's balance as a row, from the tree's synthetic root:
+    /// the first row of either mode, so the number every account row is a part
+    /// of is read before them rather than hunted for at the end.
+    ///
+    /// Unlike a parent row it is never foldable — folding it would hide every
+    /// account behind the one row that cannot be scrolled away from — and it
+    /// drills into the register of every account ([`RegisterScope::All`]), the
+    /// same relationship a tree row has with its subtree.
+    ///
+    /// `None` for a ledger with no accounts, where a lone zero would say less
+    /// than the "no balances" notice it would replace.
+    fn total_row(&self) -> Option<BalanceRow<'ctx>> {
+        let root = self.tree.first()?;
+        if !root.has_children() {
+            return None;
+        }
+        Some(BalanceRow {
+            node: 0,
+            account: AccountTreeKey::Root,
+            label: TOTAL_LABEL,
+            depth: 0,
+            amount: root.subtree_amount.clone(),
+            has_children: false,
+            folded: false,
+            scope: RegisterScope::All,
+        })
     }
 
-    /// Tree rows: a pre-order walk that skips the root and jumps over a folded
-    /// node's whole (contiguous) subtree. Each row shows the leaf label,
-    /// indented by depth, and the subtree total.
+    /// Flat rows: the total, then every posted account (non-zero own amount),
+    /// full name, own amount. Ancestor-only nodes have a zero own amount and
+    /// are skipped.
+    fn build_flat_rows(&self) -> Vec<BalanceRow<'ctx>> {
+        let accounts = self.tree.iter().enumerate().filter_map(|(i, node)| {
+            let account = match node.account.as_aggregate()? {
+                AccountAggregate::Account(account) => account,
+                AccountAggregate::Ancestor(_) => return None,
+            };
+            Some(BalanceRow {
+                node: i,
+                account: account.into(),
+                label: account.as_str(),
+                depth: node.depth,
+                amount: node.self_amount.clone(),
+                // it's flat and impossible to have children.
+                has_children: false,
+                folded: false,
+                scope: RegisterScope::Single(account),
+            })
+        });
+        self.total_row().into_iter().chain(accounts).collect()
+    }
+
+    /// Tree rows: the root as the total row, then a pre-order walk of its
+    /// descendants that jumps over a folded node's whole (contiguous) subtree.
+    /// Each row shows the leaf label, indented by depth, and the subtree total.
     fn build_tree_rows(&self) -> Vec<BalanceRow<'ctx>> {
-        let mut rows = Vec::new();
-        let mut i = 1; // index 0 is the synthetic root, never shown.
+        let mut rows: Vec<BalanceRow<'ctx>> = self.total_row().into_iter().collect();
+        let mut i = 1; // index 0 is the synthetic root, drawn as the total row.
         while i < self.tree.len() {
             let node = &self.tree[i];
             let Some(aggregate) = node.account.as_aggregate() else {
@@ -411,10 +445,7 @@ impl<'ctx> BalanceView<'ctx> {
                 continue;
             };
             let folded = self.folded.contains(&i);
-            let label = match node.account {
-                AccountTreeKey::Root => "(total)",
-                AccountTreeKey::Descendant(account) => account.last_segment(),
-            };
+            let label = aggregate.last_segment();
             rows.push(BalanceRow {
                 node: i,
                 account: aggregate.into(),
@@ -558,6 +589,10 @@ impl<'ctx> BalanceView<'ctx> {
     /// Falls back to a matching visible row when there is no backing tree (the
     /// state-machine tests), where a row still carries a usable scope.
     pub(super) fn resolve_scope(&self, scope: &OwnedRegisterScope) -> Option<RegisterScope<'ctx>> {
+        // The total names no account, so there is nothing to lose to a reload.
+        if matches!(scope, OwnedRegisterScope::All) {
+            return Some(RegisterScope::All);
+        }
         let name = scope.name();
         if let Some(aggregate) = self
             .tree
@@ -571,6 +606,8 @@ impl<'ctx> BalanceView<'ctx> {
                     AccountAggregate::Ancestor(_) => None,
                 },
                 OwnedRegisterScope::Subtree(_) => Some(RegisterScope::Subtree(aggregate)),
+                // Handled above, before any account lookup.
+                OwnedRegisterScope::All => Some(RegisterScope::All),
             };
         }
         self.rows
@@ -791,7 +828,8 @@ impl<'ctx> BalanceView<'ctx> {
 /// to the end). `None` when `rows` is empty.
 ///
 /// Relies on `rows` being sorted by account name, which is the order
-/// `Balance::into_vec` produces.
+/// `Balance::into_vec` produces — and which the leading [`TOTAL_LABEL`] row
+/// keeps, `(` sorting ahead of the letters an account name starts with.
 pub(super) fn restore_index(prev_name: &str, rows: &[BalanceRow<'_>]) -> Option<usize> {
     let last = rows.len().checked_sub(1)?;
     let idx = rows
@@ -1243,12 +1281,13 @@ mod tests {
     // --- tree / fold (BalanceView::update) ---
 
     #[test]
-    fn flat_mode_shows_only_posted_accounts() {
+    fn flat_mode_shows_the_total_then_posted_accounts() {
         let arena = Bump::new();
         let (_ctx, view) = tree_view(&arena, TREE_LEDGER);
         assert_eq!(
             full_names(&view),
             [
+                "(total)",
                 "Assets:Bank:Checking",
                 "Assets:Cash",
                 "Equity",
@@ -1257,17 +1296,80 @@ mod tests {
         );
     }
 
+    /// The total row is the tree's root in either mode: the sum of every
+    /// account, first, and drilling into it opens the whole ledger's register.
+    #[test]
+    fn total_row_sums_every_account_in_both_modes() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        let mut sum: Amount<'_> = view.rows[1..]
+            .iter()
+            .fold(Amount::zero(), |acc, row| acc + row.amount.clone());
+        // The tree drops commodities that net out; the plain sum keeps them.
+        sum.remove_zero_entries();
+
+        for mode in [DisplayMode::Flat, DisplayMode::Tree] {
+            if view.mode != mode {
+                view.update(BalanceMessage::ToggleTree);
+            }
+            let total = &view.rows[0];
+            assert_eq!(total.full_name(), "(total)");
+            assert_eq!(total.label, "(total)");
+            assert_eq!(total.depth, 0);
+            assert_eq!(total.amount, sum, "in {mode:?}");
+            // Never foldable: it would hide every row behind the one row that
+            // is always on screen.
+            assert!(!total.has_children);
+        }
+    }
+
+    /// `space` on the total row does nothing — the whole tree would vanish.
+    #[test]
+    fn total_row_does_not_fold() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.update(BalanceMessage::ToggleTree);
+        view.nav.select_item(0); // (total)
+        view.update(BalanceMessage::ToggleFold);
+        assert!(view.folded.is_empty());
+        assert_eq!(view.rows.len(), 8);
+    }
+
+    #[test]
+    fn total_open_register_drills_into_every_account() {
+        let arena = Bump::new();
+        let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
+        view.nav.select_item(0); // (total)
+        let action = view.update(BalanceMessage::OpenRegister);
+        assert_matches!(
+            action,
+            Some(BalanceAction::OpenRegister {
+                scope: RegisterScope::All
+            })
+        );
+    }
+
+    /// A ledger with no accounts has no total to show either: a lone zero row
+    /// would displace the "no balances" notice with less information.
+    #[test]
+    fn no_accounts_means_no_total_row() {
+        let arena = Bump::new();
+        let (_ctx, view) = tree_view(&arena, "");
+        assert!(view.rows.is_empty());
+    }
+
     #[test]
     fn toggle_tree_shows_hierarchy_with_leaf_labels() {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
-        let checking = view.rows[0].amount.clone();
-        let cash = view.rows[1].amount.clone();
+        let checking = view.rows[1].amount.clone();
+        let cash = view.rows[2].amount.clone();
         view.update(BalanceMessage::ToggleTree);
         assert_eq!(view.mode, DisplayMode::Tree);
         assert_eq!(
             full_names(&view),
             [
+                "(total)",
                 "Assets",
                 "Assets:Bank",
                 "Assets:Bank:Checking",
@@ -1280,17 +1382,17 @@ mod tests {
         assert_eq!(
             row_labels(&view),
             [
-                "Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"
+                "(total)", "Assets", "Bank", "Checking", "Cash", "Equity", "Expenses", "Food"
             ]
         );
-        assert_eq!(view.rows[0].depth, 1);
-        assert!(view.rows[0].has_children);
-        assert_eq!(view.rows[2].depth, 3);
-        assert!(!view.rows[2].has_children);
-        assert_eq!(view.rows[0].amount, checking + cash);
+        assert_eq!(view.rows[1].depth, 1);
+        assert!(view.rows[1].has_children);
+        assert_eq!(view.rows[3].depth, 3);
+        assert!(!view.rows[3].has_children);
+        assert_eq!(view.rows[1].amount, checking + cash);
         view.update(BalanceMessage::ToggleTree);
         assert_eq!(view.mode, DisplayMode::Flat);
-        assert_eq!(view.rows.len(), 4);
+        assert_eq!(view.rows.len(), 5);
     }
 
     #[test]
@@ -1298,17 +1400,17 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select_item(0); // Assets
+        view.nav.select_item(1); // Assets
         view.update(BalanceMessage::ToggleFold);
         assert_eq!(
             full_names(&view),
-            ["Assets", "Equity", "Expenses", "Expenses:Food"]
+            ["(total)", "Assets", "Equity", "Expenses", "Expenses:Food"]
         );
-        assert!(view.rows[0].folded);
-        assert_eq!(selected(&view), Some(0));
+        assert!(view.rows[1].folded);
+        assert_eq!(selected(&view), Some(1));
         view.update(BalanceMessage::ToggleFold);
-        assert!(!view.rows[0].folded);
-        assert_eq!(view.rows.len(), 7);
+        assert!(!view.rows[1].folded);
+        assert_eq!(view.rows.len(), 8);
     }
 
     #[test]
@@ -1317,9 +1419,13 @@ mod tests {
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
         view.update(BalanceMessage::ToggleFoldAll);
-        assert_eq!(full_names(&view), ["Assets", "Equity", "Expenses"]);
+        // The total survives fold-all: it is not one of the foldable nodes.
+        assert_eq!(
+            full_names(&view),
+            ["(total)", "Assets", "Equity", "Expenses"]
+        );
         view.update(BalanceMessage::ToggleFoldAll);
-        assert_eq!(view.rows.len(), 7);
+        assert_eq!(view.rows.len(), 8);
     }
 
     #[test]
@@ -1327,7 +1433,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select_item(0); // Assets
+        view.nav.select_item(1); // Assets
         let action = view.update(BalanceMessage::OpenRegister);
         assert_matches!(
             action,
@@ -1339,7 +1445,7 @@ mod tests {
     fn flat_open_register_drills_into_single_account() {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
-        view.nav.select_item(1); // Assets:Cash
+        view.nav.select_item(2); // Assets:Cash
         let action = view.update(BalanceMessage::OpenRegister);
         assert_matches!(
             action,
@@ -1359,7 +1465,7 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, mut view) = tree_view(&arena, TREE_LEDGER);
         view.update(BalanceMessage::ToggleTree);
-        view.nav.select_item(0); // Assets
+        view.nav.select_item(1); // Assets
         view.update(BalanceMessage::ToggleFold); // fold Assets
         let snapshot = view.snapshot();
 
@@ -1368,9 +1474,22 @@ mod tests {
         assert_eq!(view2.mode, DisplayMode::Tree);
         assert_eq!(
             full_names(&view2),
-            ["Assets", "Equity", "Expenses", "Expenses:Food"]
+            ["(total)", "Assets", "Equity", "Expenses", "Expenses:Food"]
         );
-        assert!(view2.rows[0].folded);
+        assert!(view2.rows[1].folded);
+    }
+
+    /// The total row's scope names no account, so a reload can never lose it.
+    #[test]
+    fn total_scope_survives_snapshot_restore() {
+        let arena = Bump::new();
+        let (_ctx, view) = tree_view(&arena, TREE_LEDGER);
+        let owned = view.rows[0].scope.as_owned_scope();
+        assert_matches!(
+            view.resolve_scope(&owned),
+            Some(RegisterScope::All),
+            "the total row should resolve without an account to look up"
+        );
     }
 
     // --- key mapping (BalanceView::key_to_message) ---

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -141,6 +141,7 @@ pub fn load_register<'ctx>(
     let account = match scope {
         RegisterScope::Single(account) => AccountFilter::single(account),
         RegisterScope::Subtree(aggregate) => AccountFilter::descendants_of(ctx, aggregate),
+        RegisterScope::All => AccountFilter::All,
     };
     let query = RegisterQuery {
         account,

--- a/cli/src/ui/report/register.rs
+++ b/cli/src/ui/report/register.rs
@@ -9,6 +9,7 @@ use okane_core::report::{Account, AccountAggregate, Amount};
 
 use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
+use super::balance::TOTAL_LABEL;
 use super::render::amount_line_count;
 
 /// What a register drill-in from the balance screen should match.
@@ -18,6 +19,10 @@ pub enum RegisterScope<'ctx> {
     Single(Account<'ctx>),
     /// An account and all of its descendants (tree-view drill-in).
     Subtree(AccountAggregate<'ctx>),
+    /// Every account — the drill-in of the balance screen's total row, which
+    /// stands for the whole ledger the same way a parent row stands for its
+    /// subtree.
+    All,
 }
 
 impl<'ctx> RegisterScope<'ctx> {
@@ -26,6 +31,7 @@ impl<'ctx> RegisterScope<'ctx> {
         match self {
             RegisterScope::Single(account) => account.as_str(),
             RegisterScope::Subtree(aggregate) => aggregate.as_str(),
+            RegisterScope::All => TOTAL_LABEL,
         }
     }
 
@@ -38,6 +44,7 @@ impl<'ctx> RegisterScope<'ctx> {
             RegisterScope::Subtree(aggregate) => {
                 OwnedRegisterScope::Subtree(aggregate.as_str().to_owned())
             }
+            RegisterScope::All => OwnedRegisterScope::All,
         }
     }
 }
@@ -51,6 +58,8 @@ pub enum OwnedRegisterScope {
     Single(String),
     /// An account and all its descendants, by full name.
     Subtree(String),
+    /// Every account; nothing to re-resolve, so it always survives a reload.
+    All,
 }
 
 impl OwnedRegisterScope {
@@ -58,6 +67,7 @@ impl OwnedRegisterScope {
     pub(super) fn name(&self) -> &str {
         match self {
             OwnedRegisterScope::Single(name) | OwnedRegisterScope::Subtree(name) => name,
+            OwnedRegisterScope::All => TOTAL_LABEL,
         }
     }
 }

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -1226,19 +1226,21 @@ mod tests {
         let (ctx, mut app) = many_commodities_balance(&arena);
         render(&mut app, &ctx); // the first frame teaches the nav its viewport
 
-        assert_eq!(app.balance.nav.selected_item(), Some(0));
-        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
-        // Assets:Banks:Foo has six commodities; one line down is still inside it.
-        assert_eq!(app.balance.nav.selected_item(), Some(0));
-
+        // Row 0 is the total; the first account is one item down.
         app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
         assert_eq!(app.balance.nav.selected_item(), Some(1));
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
+        // Assets:Banks:Foo has six commodities; one line down is still inside it.
+        assert_eq!(app.balance.nav.selected_item(), Some(1));
+
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        assert_eq!(app.balance.nav.selected_item(), Some(2));
         // …and lands on the account's own first line, not partway into it.
         let nav = &app.balance.nav;
-        assert_eq!(nav.lines().first_row(1), Some(nav.selected_row()));
+        assert_eq!(nav.lines().first_row(2), Some(nav.selected_row()));
 
         app.update(Message::Balance(BalanceMessage::Nav(NavCommand::PrevItem)));
-        assert_eq!(app.balance.nav.selected_item(), Some(0));
+        assert_eq!(app.balance.nav.selected_item(), Some(1));
     }
 
     /// An account taller than the body is reachable line by line, and the two
@@ -1250,14 +1252,17 @@ mod tests {
         let (ctx, mut app) = many_commodities_balance(&arena);
         render(&mut app, &ctx);
 
-        // Into the broker account, then down to its 26th and last lot — far
-        // enough past the top of the body that its label has scrolled off.
-        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        // Past the total and the bank account into the broker one, then down to
+        // its 26th and last lot — far enough past the top of the body that its
+        // label has scrolled off.
+        for _ in 0..2 {
+            app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        }
         for _ in 0..25 {
             app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
         }
         let out = render(&mut app, &ctx);
-        assert_eq!(app.balance.nav.selected_item(), Some(1));
+        assert_eq!(app.balance.nav.selected_item(), Some(2));
         assert!(
             out.contains("10 STOCKZ"),
             "the last lot should be reachable:\n{out}"
@@ -1279,7 +1284,10 @@ mod tests {
         let arena = Bump::new();
         let (ctx, mut app) = many_commodities_balance(&arena);
         render(&mut app, &ctx);
-        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        // Past the total and the bank account, then deep into the broker one.
+        for _ in 0..2 {
+            app.update(Message::Balance(BalanceMessage::Nav(NavCommand::NextItem)));
+        }
         for _ in 0..25 {
             app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
         }

--- a/testdata/report/ui/alias.balance-tree-all-folded.txt
+++ b/testdata/report/ui/alias.balance-tree-all-folded.txt
@@ -1,9 +1,9 @@
  okane ui — alias.ledger                                                        
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                             Amount    │
+│  (total)                                                                    0│
 │▶ Equity                                                              -100 JPY│
 │▶ Expenses                                                             100 JPY│
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/testdata/report/ui/alias.balance-tree.txt
+++ b/testdata/report/ui/alias.balance-tree.txt
@@ -1,11 +1,11 @@
  okane ui — alias.ledger                                                        
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                             Amount    │
+│  (total)                                                                    0│
 │▼ Equity                                                              -100 JPY│
 │    Initial                                                           -100 JPY│
 │▼ Expenses                                                             100 JPY│
 │    Grocery                                                            100 JPY│
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/testdata/report/ui/alias.balance.txt
+++ b/testdata/report/ui/alias.balance.txt
@@ -1,9 +1,9 @@
  okane ui — alias.ledger                                                        
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                             Amount    │
+│(total)                                                                      0│
 │Equity:Initial                                                        -100 JPY│
 │Expenses:Grocery                                                       100 JPY│
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/testdata/report/ui/many_commodities.balance-tree-all-folded.txt
+++ b/testdata/report/ui/many_commodities.balance-tree-all-folded.txt
@@ -1,12 +1,7 @@
  okane ui — many_commodities.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                        Amount         │
-│▶ Assets                                                            992000 JPY│
-│                                                                   5000.00 CHF│
-│                                                                   9800.00 USD│
-│                                                                   8000.00 EUR│
-│                                                                   3000.00 AUD│
-│                                                                 195000.00 TWD│
+│  (total)                                                        -29250.00 USD│
 │                                                                     10 STOCKA│
 │                                                                     10 STOCKB│
 │                                                                     10 STOCKC│
@@ -19,6 +14,11 @@
 │                                                                     10 STOCKJ│
 │                                                                     10 STOCKK│
 │                                                                     10 STOCKL│
-│                                                                      +14 more│
+│                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                       +9 more│
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/many_commodities.balance-tree.txt
+++ b/testdata/report/ui/many_commodities.balance-tree.txt
@@ -1,24 +1,24 @@
  okane ui — many_commodities.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                        Amount         │
-│▼ Assets                                                             +21 above│
+│  (total)                                                        -29250.00 USD│
+│                                                                     10 STOCKA│
+│                                                                     10 STOCKB│
+│                                                                     10 STOCKC│
+│                                                                     10 STOCKD│
+│                                                                     10 STOCKE│
+│                                                                     10 STOCKF│
+│                                                                     10 STOCKG│
+│                                                                     10 STOCKH│
+│                                                                     10 STOCKI│
+│                                                                     10 STOCKJ│
+│                                                                     10 STOCKK│
+│                                                                     10 STOCKL│
+│                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
 │                                                                     10 STOCKP│
 │                                                                     10 STOCKQ│
-│                                                                     10 STOCKR│
-│                                                                     10 STOCKS│
-│                                                                     10 STOCKT│
-│                                                                     10 STOCKU│
-│                                                                     10 STOCKV│
-│                                                                     10 STOCKW│
-│                                                                     10 STOCKX│
-│                                                                     10 STOCKY│
-│                                                                     10 STOCKZ│
-│  ▼ Banks                                                           992000 JPY│
-│                                                                   5000.00 CHF│
-│                                                                   9800.00 USD│
-│                                                                   8000.00 EUR│
-│                                                                   3000.00 AUD│
-│                                                                 195000.00 TWD│
-│      Foo                                                              +6 more│
+│                                                                       +9 more│
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/many_commodities.balance.txt
+++ b/testdata/report/ui/many_commodities.balance.txt
@@ -1,13 +1,8 @@
  okane ui — many_commodities.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                        Amount         │
-│Assets:Banks:Foo                                                    992000 JPY│
-│                                                                   5000.00 CHF│
-│                                                                   9800.00 USD│
-│                                                                   8000.00 EUR│
-│                                                                   3000.00 AUD│
-│                                                                 195000.00 TWD│
-│Assets:Brokers:Bar                                                   10 STOCKA│
+│(total)                                                          -29250.00 USD│
+│                                                                     10 STOCKA│
 │                                                                     10 STOCKB│
 │                                                                     10 STOCKC│
 │                                                                     10 STOCKD│
@@ -19,6 +14,11 @@
 │                                                                     10 STOCKJ│
 │                                                                     10 STOCKK│
 │                                                                     10 STOCKL│
-│                                                                      +14 more│
+│                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                       +9 more│
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.balance-tree-all-folded.txt
+++ b/testdata/report/ui/multi_commodity.balance-tree-all-folded.txt
@@ -1,6 +1,11 @@
  okane ui — multi_commodity.ledger                                              
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                       Amount          │
+│  (total)                                                        -10481.53 CHF│
+│                                                               -13348.9400 USD│
+│                                                                390.0000 OKANE│
+│                                                                   12.300 GOLD│
+│                                                                    518.50 EUR│
 │▶ Assets                                                          44018.47 CHF│
 │                                                                    100000 JPY│
 │                                                                  13270.00 USD│
@@ -15,10 +20,5 @@
 │▶ Income                                                          -8500.00 CHF│
 │                                                                   -400.00 USD│
 │▶ Liabilities                                                     -1000000 JPY│
-│                                                                              │
-│                                                                              │
-│                                                                              │
-│                                                                              │
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.balance-tree.txt
+++ b/testdata/report/ui/multi_commodity.balance-tree.txt
@@ -1,6 +1,11 @@
  okane ui — multi_commodity.ledger                                              
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                       Amount          │
+│  (total)                                                        -10481.53 CHF│
+│                                                               -13348.9400 USD│
+│                                                                390.0000 OKANE│
+│                                                                   12.300 GOLD│
+│                                                                    518.50 EUR│
 │▼ Assets                                                          44018.47 CHF│
 │                                                                    100000 JPY│
 │                                                                  13270.00 USD│
@@ -14,11 +19,6 @@
 │                                                                390.0000 OKANE│
 │                                                                   12.300 GOLD│
 │      US Broker                                                   13270.00 USD│
-│                                                                390.0000 OKANE│
-│                                                                   12.300 GOLD│
-│  ▼ Wire                                                                     0│
-│      US Broker                                                              0│
-│▼ Equity                                                         -48000.00 CHF│
 │                                                                       +2 more│
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/multi_commodity.balance.txt
+++ b/testdata/report/ui/multi_commodity.balance.txt
@@ -1,6 +1,11 @@
  okane ui — multi_commodity.ledger                                              
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                       Amount          │
+│(total)                                                          -10481.53 CHF│
+│                                                               -13348.9400 USD│
+│                                                                390.0000 OKANE│
+│                                                                   12.300 GOLD│
+│                                                                    518.50 EUR│
 │Assets:Banks:Swiss Bank                                           44018.47 CHF│
 │Assets:Banks:あおによし                                             100000 JPY│
 │Assets:Brokers:US Broker                                          13270.00 USD│
@@ -15,10 +20,5 @@
 │Expenses:Commissions                                                  7.50 EUR│
 │Expenses:Tax:Income                                                2000.00 CHF│
 │Income:Capital Gain                                                -400.00 USD│
-│Income:Salary                                                     -8500.00 CHF│
-│Liabilities:My Card                                                          0│
-│Liabilities:Study Loan                                            -1000000 JPY│
-│                                                                              │
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.balance-tree-all-folded.txt
+++ b/testdata/report/ui/single_commodity.balance-tree-all-folded.txt
@@ -1,12 +1,12 @@
  okane ui — single_commodity.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                           Amount      │
+│  (total)                                                                    0│
 │▶ Assets                                                            306000 JPY│
 │▶ Equity                                                            -99000 JPY│
 │▶ Expenses                                                           93000 JPY│
 │▶ Income                                                           -300000 JPY│
 │▶ Liabilities                                                                0│
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/testdata/report/ui/single_commodity.balance-tree.txt
+++ b/testdata/report/ui/single_commodity.balance-tree.txt
@@ -1,6 +1,7 @@
  okane ui — single_commodity.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                           Amount      │
+│  (total)                                                                    0│
 │▼ Assets                                                            306000 JPY│
 │  ▼ Banks                                                           306000 JPY│
 │      Foo                                                            -1000 JPY│
@@ -19,6 +20,5 @@
 │▼ Liabilities                                                                0│
 │  ▼ Cards                                                                    0│
 │      Card X                                                                 0│
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
  ↑/↓ line · J/K account · Enter register · t tree · space fold · x fold-all · / 

--- a/testdata/report/ui/single_commodity.balance.txt
+++ b/testdata/report/ui/single_commodity.balance.txt
@@ -1,6 +1,7 @@
  okane ui — single_commodity.ledger                                             
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │Account                                                           Amount      │
+│(total)                                                                      0│
 │Assets:Banks:Foo                                                     -1000 JPY│
 │Assets:Banks:あおによし                                             307000 JPY│
 │Equity:Initial                                                      -99000 JPY│
@@ -9,7 +10,6 @@
 │Expenses:Tax:Income                                                  70000 JPY│
 │Income:Salary                                                      -300000 JPY│
 │Liabilities:Cards:Card X                                                     0│
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │


### PR DESCRIPTION
The balance screen listed accounts with no sum anywhere, so the one number that answers "and altogether?" had to be added up by eye. The balance tree already carries it: its synthetic root holds the subtree amount of every account, and the root was the one node neither view drew.

Draw it, as the first row of both views. In tree mode it is what it already was in the data — the root the top-level accounts hang off — and a flat list is that same root followed by its accounts rather than its children. Being a row rather than a banner means it is searchable, measured for the amount column, and reached with the same keys as everything else.

Flat:

```
┌──────────────────────────────────────────────────────────────────────────────┐
│Account                                                       Amount          │
│(total)                                                          -10481.53 CHF│
│                                                               -13348.9400 USD│
│                                                                390.0000 OKANE│
│                                                                   12.300 GOLD│
│                                                                    518.50 EUR│
│Assets:Banks:Swiss Bank                                           44018.47 CHF│
│Assets:Banks:あおによし                                             100000 JPY│
```

Tree:

```
┌──────────────────────────────────────────────────────────────────────────────┐
│Account                                                           Amount      │
│  (total)                                                                    0│
│▶ Assets                                                            306000 JPY│
│▶ Equity                                                            -99000 JPY│
│▶ Expenses                                                           93000 JPY│
│▶ Income                                                           -300000 JPY│
│▶ Liabilities                                                                0│
```

Two ways it is not an ordinary row. It never folds: it has no children as far as the fold state is concerned, so `space` on it does nothing and `x` leaves it alone, because folding the row that is always on screen would hide every account behind it. And it drills into the new `RegisterScope::All`, the register of every account, which is the relationship a tree row already has with its subtree; nothing about it can be lost to a reload, so it resolves without an account lookup.

A ledger with no accounts still gets no rows: a lone zero says less than the "No balances to display" notice it would replace.

## Test plan

- `cargo test` — new `balance` unit tests cover the total row's amount in both modes, that it does not fold, that `Enter` on it yields `RegisterScope::All`, that its scope survives a reload, and that an empty ledger has no total row.
- Balance goldens under `testdata/report/ui/` regenerated for all four fixtures × flat / tree / tree-all-folded.
- `cargo clippy --all-targets`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)