### PR TITLE
doc: add English import documentation and refresh the Japanese one

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In future in-place format would be provided, also to emit diffs to be used as Gi
 ### Import CSV or ISO Camt053 XML files
 
 First you need to write YAML file to control import behavior. We'll assume those are placed under `~/ledger/`.
-See the [import](doc/import.ja.md) page (Japanese only, sorry) for the format,
+See the [import](doc/import.md) page for the format,
 and the `testdata/import/` directory for example configurations.
 
 Then run the `okane import` command with logging and redirecting to `/dev/null`. This way you can dry-run and check its output.

--- a/about.toml
+++ b/about.toml
@@ -15,6 +15,7 @@ accepted = [
     "MIT",
     "Apache-2.0",
     "BSD-3-Clause",
+    "0BSD",
     "Unicode-3.0",
     "Zlib",
 ]

--- a/doc/import.ja.md
+++ b/doc/import.ja.md
@@ -1,12 +1,30 @@
 # okane import
 
+[English version here](import.md)
+
 `okane import` は CSV ファイルをはじめ、各種の銀行やカード会社からダウンロードしてきたファイルから Ledger 形式のファイルを生成するコマンドです。
+
+```console
+$ RUST_LOG=info okane import --config path/to/import.yml path/to/statement.csv
+```
+
+結果は標準出力に書き出されるので、まず `/dev/null` にリダイレクトしつつログで設定の漏れを確認し、問題なさそうならLedgerファイルに追記するのがよいでしょう。`RUST_LOG=info` でマッチするルールがなかったデータが分かります。
+
+生成された取引をTUIで一件ずつ確認し、書き出す前にアカウントを修正できる対話モードもあります。
+
+```console
+$ okane import --config path/to/import.yml --interactive \
+    --ledger path/to/main.ledger --output path/to/output.ledger \
+    path/to/statement.csv
+```
+
+`--interactive` を使う場合、`--ledger` (補完に使うアカウント名を読み込むLedgerファイル) と `--output` (確定した取引が追記されるファイル) の両方が必須です。
 
 ## 設定
 
 このコマンドを使用するにはYaML形式の設定ファイルが必須なので、まずはその書き方を紹介します。
 
-ただ、実際に設定を書く際は[テスト用の設定ファイル](../cli/tests/testdata/import/test_config.yml)などを参考に書いていくのがいいかもしれません。このドキュメントは主にどんな意味の設定だったかわからなくなった時用のリファレンスです。
+ただ、実際に設定を書く際は[テスト用の設定ファイル](../testdata/import/test_config.yml)などを参考に書いていくのがいいかもしれません。このドキュメントは主にどんな意味の設定だったかわからなくなった時用のリファレンスです。
 
 ### 設定ファイルの概要
 
@@ -29,12 +47,18 @@ path: bar/
 * `account`: 必須属性: Ledger に読み込まれたときのアカウント名を指定します。(例: `Assets:Banks:Tanuki` とか `Liabilities:Card:Kitsune` とか)
 * `account_type` 必須属性: アカウントが資産か負債かを `asset`, `liability` の二値で指定します。例えば銀行なら `asset` に、クレカなら `liability` にします。
 * `operator`: オプション属性: 取引の際に手数料が発生した場合、その手数料の支払先として登録される文字列を指定します。手数料の出てこないサービスなら指定不要です。
+* `charge_account`: オプション属性: 手数料が計上されるアカウントを指定します。指定がない場合 `Expenses:Commissions` が使われます。
+* `template`: オプション属性 (デフォルトは `false`): `true` にするとそのエントリはテンプレートとなり、マージで値を提供することしかできず、単独でファイルにマッチすることはできなくなります。後述の[複数エントリのマージ](#複数エントリのマージ)を参照してください。
 * `commodity`: 必須属性: コモディティについての設定です。長いので後回しにします。
 * `format`: オプション属性: 入力ファイルの仕様・書式についての設定です。長いので後回しにします。
 * `output`: オプション属性: 出力されるLedgerファイルについての設定です。長いので後回しにします。
 * `rewrite`: オプション属性: 読み込み時のマッチングするルールについて記述します。一番大事な設定ですので後で解説します。
 
-これを入力分だけ書けばいいということになります。ただ、複数のファイルで設定を使いまわしたいこともあると思います。そんなときのために設定は `path` がマッチする設定すべてをマージして適用することにしています。設定はマッチした長さが短い順からマージされます。`rewrite` の設定は追記、他の設定はいい感じにマージされると思ってください。
+これを入力分だけ書けばいいということになります。なお「必須属性」はマージ後の結果に存在していればよく、個々のエントリすべてに書く必要はありません。
+
+### 複数エントリのマージ
+
+複数のファイルで設定を使いまわしたいこともあると思います。そんなときのために設定は `path` がマッチする設定すべてをマージして適用することにしています。設定はマッチした長さが短い順からマージされます。`rewrite` の設定は追記、他の設定は last win でマージされると思ってください。
 
 ```yaml
 path: foo/
@@ -50,6 +74,17 @@ path: foo/bar/
 commodity: USD
 rewrite:
 - ...
+```
+
+`template: true` が指定されたエントリはこのマージには参加しますが、単独では成立しません。あるファイルにマッチしたエントリがすべてテンプレートだった場合、そのファイルはマッチする設定が見つからなかったとしてエラーになります。すべてにマッチする `path: ""` に共通のデフォルト値を置く際に便利です。
+
+```yaml
+path: ""
+template: true
+output:
+  commodity:
+    default:
+      scale: 2
 ```
 
 ### コモディティ(通貨)の設定
@@ -72,20 +107,25 @@ commodity:
     commodity: string
     rate: *price_of_secondary|price_of_primary
     disabled: *false|true
+  hidden_fee:
+    spread: 1.8%
+    condition: *ALWAYS_INCURRED|DEBIT_ONLY
   rename:
     米ドル: USD
 ```
 
 * `primary`: 口座内での主要通貨を指定します。文字列で指定するのと同じです。
 * `conversion`: 外貨取引が行われた際のレート計算に関する設定のデフォルト値です。あとで`rewrite`の項目として詳しく説明します。
-* `rename`: ハッシュのkeyとなる通貨をvalueに置き換えます。この場合米ドルをUSDに書き換えます。
+* `hidden_fee`: 隠れ手数料の設定のデフォルト値です。あとで`rewrite`の項目として詳しく説明します。
+* `rename`: ハッシュのkeyとなる通貨をvalueに置き換えます。この場合米ドルをUSDに書き換えます。なお置き換えは出力時に行われるので、`rewrite`の`commodity`/`secondary_commodity` matcherが見るのは置き換え前の名前です ([#304](https://github.com/xkikeg/okane/issues/304))。
 
 ### format(書式)の設定
 
-書式設定では入力ファイルや出力の書式について設定します。例はこんな感じです。
+書式設定では入力ファイルの書式について設定します。例はこんな感じです。
 
 ```yaml
 format:
+  file_type: CSV
   date: "%Y/%m/%d"
   delimiter: ";"
   fields:
@@ -104,21 +144,50 @@ format:
 
 下記の属性が指定できます。
 
-* `date`: 必須: 日付のフォーマット文字列を指定します。`"%Y/%m/%d"` (年/月/日)が日本ではよく使われると思います。
-* `delimiter`: ファイルの区切り文字を指定します。2024-07-30時点ではCSVファイルにしか効果がありません。
-* `fields`: CSVファイルで列の意味を記述します。数字の場合は1-originの列番号として、文字列の場合はCSVの一行目をheaderと考えてその値で列を指定できます。以下の項目に対して文字列ないし数字で列を指定します。
-    * `date`: 日付
-    * `payee`: 受取/支払先
-    * `category`: 取引の種類
-    * `note`: 追記事項
-    * `amount`: 取引の金額
-    * `credit`: アカウント残高が増加する際の取引の金額
-    * `debit`: アカウント残高が減少する際の取引の金額
-    * `balance`: アカウントの残高
-    * `commodity`: 取引のコモディティ
-    * `rate`: 取引時のコモディティ(為替)レート
-    * `secondary_amount`: 取引が2つのコモディティでされている際のその2つ目のコモディティでの金額。
-    * `secondary_commodity`: 2つ目のコモディティ。rewriteの`conversion`も参照すること。
+* `file_type`: 入力ファイルの種別で、`CSV`, `TSV`, `ISO_CAMT053`, `VISECA` のいずれかです。指定がない場合は拡張子から推測され、`.csv` ならCSV、`.tsv` ならTSVとなります。それ以外のファイルではこの属性の指定が必須です。
+* `date`: 日付のフォーマット文字列を [`chrono::format::strftime`](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) の書式で指定します。CSV/TSVでは必須です。`"%Y/%m/%d"` (年/月/日)が日本ではよく使われると思います。
+* `delimiter`: ファイルの区切り文字を指定します。2024-07-30時点ではCSVファイルにしか効果がありません。ASCII1文字である必要があります。
+* `fields`: CSVファイルで列の意味を記述します。詳細は後述します。
+* `skip.head`: ヘッダ行を読み込む前に、ファイル先頭で読み飛ばす行数を指定します。CSVのみで有効です。
+* `row_order`: `old_to_new` (デフォルト) または `new_to_old` を指定します。`new_to_old` の場合、出力が日付順になるように取引の順序を反転します。
+
+#### format.fields の設定
+
+以下の各項目には数字、文字列、あるいはテンプレートを指定します。数字の場合は1-originの列番号として、文字列の場合はCSVの一行目をheaderと考えてその値で列を指定できます。`{template: "..."}` の形のハッシュを指定すると他のフィールドから値を組み立てられます(次節参照)。
+
+`amount` または `credit`/`debit` のペアのどちらかが必須です。また `date` と `payee` は常に必須です。
+
+* `date`: 日付
+* `payee`: 受取/支払先
+* `code`: 取引を一意に識別するコード。Ledgerの取引コードとして出力されます。`rewrite`のmatcherで `(?P<code>...)` がキャプチャされた場合はそちらが優先されます。
+* `category`: 取引の種類。直接は出力されませんが、`rewrite`のmatcherやテンプレートから参照できます。
+* `note`: 追記事項。取引のコメントとして出力されます。
+* `amount`: 取引の金額。符号は `account_type` に従って解釈され、`liability` の口座では符号が反転します。
+* `credit`: アカウント残高が増加する際の取引の金額
+* `debit`: アカウント残高が減少する際の取引の金額
+* `balance`: アカウントの残高。Ledgerの残高アサーションとして出力されます。
+* `commodity`: 取引のコモディティ。列がない場合は `commodity.primary` にフォールバックします。
+* `rate`: 取引時のコモディティ(為替)レート
+* `secondary_amount`: 取引が2つのコモディティでされている際のその2つ目のコモディティでの金額。
+* `secondary_commodity`: 2つ目のコモディティ。rewriteの`conversion`も参照すること。
+* `charge`: 取引に関連する手数料。`charge_account` (指定がなければ `Expenses:Commissions`) に、`operator` を支払先として計上されます。そのためこの列が非ゼロになりうる場合は `operator` の指定が必須です。
+
+#### format.fields のテンプレート
+
+列の代わりに、テンプレートからフィールドを組み立てることもできます。
+
+```yaml
+format:
+  fields:
+    date: Date
+    category: Action
+    note: Description
+    payee:
+      template: "{category} - {note}"
+    amount: Amount
+```
+
+テンプレート内では `{name}` で他のフィールドキーを、`{1}` で1-originの列番号を参照できます。参照できるのは単純な列に対応付けられたフィールドだけで、他のテンプレートや、レンダリング中のフィールド自身を参照するとエラーになります。
 
 ### outputの設定
 
@@ -141,6 +210,7 @@ output:
         * `style`: 数値のスタイルを指定します。`plain`で通常、`comma3_dot`で3桁コンマ区切りです。
         * `scale`: 金額が最低でも小数点以下何桁まで表示されてほしいかを指定します。
           例えば`2`の場合`1.00`のようにピッタリでも小数点2桁で表示されます。
+    * `overrides`: コモディティ名をkeyとした個別の上書き設定です。指定されなかった項目は `default` にフォールバックします。
 
 ### rewriteルール
 
@@ -156,28 +226,36 @@ rewrite:
   matcher:
     payee: 円普通預金(へ|より)振替
   conversion:
-    type: primary
+    commodity: JPY
+    rate: price_of_primary
 - account: Expenses:Grocery
   matcher:
   - payee: EURO GROCERY
   - payee: 山田商店
-
 ```
 
-* `matcher`: 必須: このルールを適用する条件です。すぐ下で説明する属性を持つハッシュか、そのlistとして記述します。ハッシュの属性は論理積(AND)ですべてマッチしないと適用されません。listの場合要素同士は論理和(OR)になり、一つでも当てはまったら適用されます。
-    * `domain_code`, `domain_family`, `domain_sub_family`: ISO Camt053フォーマットのみで有効です。取引の各コードが一致するものを選択します。
+* `matcher`: 必須: このルールを適用する条件です。すぐ下で説明する属性を持つハッシュか、そのlistとして記述します。ハッシュの属性は論理積(AND)ですべてマッチしないと適用されません。listの場合要素同士は論理和(OR)になり、一つでも当てはまったら適用されます。値はすべて正規表現で、**大文字小文字を区別せず**、また部分一致でマッチします。つまり `payee: Migros` は `MIGROS SUPERMARKT` にもマッチします。
+    * `domain_code`, `domain_family`, `domain_sub_family`: ISO Camt053フォーマットのみで有効です。取引の各コードが一致するものを選択します。これらは正規表現ではなくコードそのものの一致です。
     * `creditor_name`, `creditor_account_id`, `ultimate_creditor_name`: ISO Camt053フォーマットのみで有効です。正規表現で支払側の名前やIDにマッチします。
     * `debtor_name`, `debtor_account_id`, `ultimate_debtor_name`: ISO Camt053フォーマットのみで有効です。正規表現で受け取り側の名前やIDにマッチします。
     * `remittance_unstructured_info`, `additional_entry_info`, `additional_transaction_info`: ISO Camt053フォーマットのみで有効です。正規表現で対応するフィールドにマッチします。
     * `category`: CSV/visecaのみで有効です。取引のカテゴリで、`fields`で`category`として指定された列の値です。正規表現でマッチします。
+    * `commodity`, `secondary_commodity`: 取引のコモディティと第二コモディティに正規表現でマッチします。特定の通貨ペアにだけ `hidden_fee` を適用したい場合に便利です。`commodity.rename` の適用**前**の名前を見ることに注意してください。
     * `payee`: この取引の相手方の名前です。正規表現が指定できます。以前のルールで上書きされた場合その値が適用されます。
 * `account`: ルールが適用された場合アカウントを指定された文字列にします。
 * `payee`: ルールが適用された場合`payee`(相手方)を指定された文字列にします。
-* `pending`: `true`にした場合その取引が保留中のマークがつきます。
+* `pending`: `true`にした場合 `account` へのpostingに保留中のマーク (`!`) がつきます。`account`と併せて指定したときのみ有効です。この節の最後の注記も参照してください。
 * `conversion`: コモディティ(通貨)の為替レートについて指定します。取引が2つの通貨をまたいで行われた際にのみ有効です。次の項目を設定できます。
     * `amount`: 第二通貨(外貨)側での金額の計算方法を指定します。デフォルトでは`extract`で、フィールドとして指定された`secondary_amount`に書かれた値を読み込みます。`compute`が指定されたときはレートから計算します。
     * `commodity`: 取引の第二通貨(外貨)を指定できます。指定がなければfieldsで指定された`secondary_commodity`の値を使用します。
     * `rate`: `rate`フィールドで指定された値がどちら向きの値なのかを指定します。標準では`price_of_secondary`、つまり第二通貨のレートを第一通貨で指定します。(`1 $secondary_commodity = $rate $comodity`)。`price_of_primary`が指定された場合、逆に第一通貨のレートを第二通貨で指定します。(`1 $commodity = $rate $secondary_commodity`)
+    * `disabled`: `true`にすると、入力にレートと第二通貨の金額があってもマッチした取引の変換をすべて無効にします。
+* `hidden_fee`: 明示的な手数料としてではなく、事業者が提示する為替レートにスプレッドとして埋め込まれた「隠れ手数料」を指定します。設定すると okane は本来のレートを逆算し、その差額を手数料として `charge_account` に計上するため、`operator` の指定も必要になります。次の項目を設定できます。
+    * `spread`: スプレッドを、パーセント (`1.8%`) またはレートと同じコモディティの固定額 (`0.15 JPY`) で指定します。指定しない場合、隠れ手数料は無効になります。
+    * `condition`: 隠れ手数料が発生する条件です。`ALWAYS_INCURRED` (デフォルト) は事業者が両方向でスプレッドを取ると仮定し、取引の符号によって本来のレートが提示レートより上か下かを判断します。`DEBIT_ONLY` はレートのついた記帳を常に支出とみなします。クレジットカードでは「収入」のほぼすべてが元のレートでの払い戻しなので、こちらが適切です。
 
 このmatcherは複数マッチした場合listの順が早い方から適用されます。途中でマッチしてもそれ以降のmatcherは適用されます。また、正規表現中に名前付きグループがあった場合、その部分マッチが`payee`ならpayee(相手方の名前)が、`code`なら取引コードが上書きされます。
 
+どの項目も、後続のマッチしたルールが実際に値を設定したときにだけ上書きされます。そのため、マッチしたものの `account` を設定していないルールがあっても、以前のルールが決めたアカウントはそのまま残ります。
+
+`pending` は相手方のpostingに `!` を付けるもので、`account` も設定しているルールでのみ有効です。`account` のないルールに `pending: true` を書いても何も起きません。どのルールでもアカウントが決まらなかった取引は `Expenses:Unknown` (または `Income:Unknown`) にフォールバックし、保留中となり、okane は警告をログに出します。

--- a/doc/import.md
+++ b/doc/import.md
@@ -1,0 +1,371 @@
+# okane import
+
+[日本語版はこちら](import.ja.md)
+
+`okane import` generates a Ledger-format file out of files downloaded from banks and
+credit card issuers, such as CSV statements.
+
+```console
+$ okane import --config path/to/import.yml path/to/statement.csv
+```
+
+The result is written to stdout, so redirect it to `/dev/null` first to check for
+configuration errors, then append it to your ledger once it looks right.
+`RUST_LOG=info` prints which rows were skipped and which rules matched.
+
+There is also an interactive review mode, which shows every generated transaction in a
+TUI and lets you fix the account before anything is written:
+
+```console
+$ okane import --config path/to/import.yml --interactive \
+    --ledger path/to/main.ledger --output path/to/output.ledger \
+    path/to/statement.csv
+```
+
+`--interactive` requires both `--ledger` (the ledger whose account names feed the
+autocomplete) and `--output` (the file the accepted transactions are appended to).
+
+## Configuration
+
+This command requires a YAML config file, so this document describes how to write one.
+
+In practice you may find it easier to start from the
+[test config file](../testdata/import/test_config.yml) and adapt it. This document is
+mainly a reference for when you cannot remember what a given setting meant.
+
+### Overview of the config file
+
+The config file is a YAML file. There is currently no requirement on its file name.
+
+You write one config entry per group of input files to import. So a config file as a
+whole looks like:
+
+```yaml
+path: foo/
+...
+---
+path: bar/
+...
+```
+
+that is, several settings each containing a `path`, separated by `---`. Besides `path`,
+the following settings exist.
+
+* `path`: **required**. Specifies a part of the input file path. Currently it is a
+  plain substring comparison; regular expressions and glob patterns are not supported.
+* `encoding`: **required**. The character encoding of the target file, such as `UTF-8`
+  or `Shift_JIS`. The accepted strings are the ones
+  [supported](https://encoding.spec.whatwg.org/) by encoding_rs.
+* `account`: **required**. The account name used once loaded into Ledger
+  (e.g. `Assets:Banks:Tanuki` or `Liabilities:Card:Kitsune`).
+* `account_type`: **required**. Whether the account is an asset or a liability, given as
+  `asset` or `liability`. A bank account is `asset`, a credit card is `liability`.
+* `operator`: optional. The string recorded as the counterparty of any fee incurred by
+  the transaction. Not needed for services that never charge fees.
+* `charge_account`: optional. The account fees and commissions are posted to. Defaults
+  to `Expenses:Commissions` when unset.
+* `template`: optional, defaults to `false`. Set `true` to make this entry a template
+  fragment, meaning it can only contribute values through merging and can never be the
+  sole match for a file. See [merging](#merging-multiple-entries) below.
+* `commodity`: **required**. Settings about the commodity. Covered later, it is long.
+* `format`: optional. Settings about the specification and format of the input file.
+  Covered later, it is long.
+* `output`: optional. Settings about the emitted Ledger file. Covered later, it is long.
+* `rewrite`: optional. Describes the rules matched while loading. This is the most
+  important setting, so it is explained later.
+
+Writing that once per input is all that is needed. Note the "required" attributes only
+have to be present in the *merged* result, not in every fragment.
+
+### Merging multiple entries
+
+You often want to reuse settings across several files. For that, all entries whose
+`path` matches are merged and then applied. Entries are merged in order of increasing
+match length, so more specific paths win. `rewrite` rules are appended, and the other
+settings are merged sensibly (a later, more specific value overrides an earlier one).
+
+```yaml
+path: foo/
+encoding: UTF-8
+account_type: asset
+commodity: JPY
+format:
+  ...
+rewrite:
+- ...
+---
+path: foo/bar/
+commodity: USD
+rewrite:
+- ...
+```
+
+An entry with `template: true` participates in this merge but cannot stand on its own:
+if every fragment matching a file is a template, the file is treated as unmatched. This
+is handy for putting shared defaults under `path: ""`, which matches everything:
+
+```yaml
+path: ""
+template: true
+output:
+  commodity:
+    default:
+      scale: 2
+```
+
+### Commodity (currency) settings
+
+In economics a commodity means a good traded on the futures market, but in Ledger
+terminology it refers to anything whose value is determined solely by its quantity,
+including currencies and stocks. In practice it is the currency.
+
+Commodity settings are needed because CSV files in particular express amounts as bare
+numbers, which often makes it impossible to tell Japanese yen from US dollars. The
+simplest way to configure it is to name the currency with a string.
+
+```yaml
+commodity: JPY
+```
+
+Alternatively, more complex items can be given as a hash.
+
+```yaml
+commodity:
+  primary: JPY
+  conversion:
+    amount: *extract|compute
+    commodity: string
+    rate: *price_of_secondary|price_of_primary
+    disabled: *false|true
+  hidden_fee:
+    spread: 1.8%
+    condition: *ALWAYS_INCURRED|DEBIT_ONLY
+  rename:
+    米ドル: USD
+```
+
+* `primary`: the main currency used inside the account. Equivalent to giving the string
+  directly.
+* `conversion`: the default values for the rate computation applied when a foreign
+  currency transaction happens. Explained in detail later as a `rewrite` item.
+* `hidden_fee`: the default hidden fee settings. Explained in detail later as a
+  `rewrite` item.
+* `rename`: replaces the commodity named by the hash key with the value. In this case
+  it rewrites 米ドル into USD. Note that renaming happens on output, so `rewrite`
+  matchers on `commodity` / `secondary_commodity` still see the original name
+  ([#304](https://github.com/xkikeg/okane/issues/304)).
+
+### format settings
+
+The format settings describe the format of the input file.
+An example looks like this:
+
+```yaml
+format:
+  file_type: CSV
+  date: "%Y/%m/%d"
+  delimiter: ";"
+  fields:
+    date: お取り引き日
+    payee: 摘要
+    debit: 出金額
+    credit: 入金額
+    balance: 残高
+    commodity: 通貨
+    rate: 適用レート
+    secondary_amount: 取引円換算額
+  skip:
+    head: 10
+  row_order: new_to_old
+```
+
+The following attributes can be specified.
+
+* `file_type`: the type of the input file, one of `CSV`, `TSV`, `ISO_CAMT053` or
+  `VISECA`. If unset, it is guessed from the suffix: `.csv` means CSV and `.tsv` means
+  TSV. For any other file it is mandatory to set this field.
+* `date`: the format string for the date, in
+  [`chrono::format::strftime`](https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+  syntax. Required for CSV/TSV. `"%Y/%m/%d"` (year/month/day) is commonly used in Japan.
+* `delimiter`: the delimiter of the file. As of 2024-07-30 it only takes effect for CSV
+  files. It must be a single ASCII character.
+* `fields`: describes the meaning of the columns of a CSV file. See below.
+* `skip.head`: the number of lines skipped at the head of the file, before the header
+  row is read. CSV only.
+* `row_order`: `old_to_new` (the default) or `new_to_old`. With `new_to_old` the emitted
+  transactions are reversed so that the output is in chronological order.
+
+#### format.fields
+
+Each key below is given either a number, a string, or a template. A number is treated as
+a 1-origin column index; a string selects the column by matching the value in the first
+row of the CSV, which is treated as the header. A hash of the form
+`{template: "..."}` builds the value out of other fields (see the next section).
+
+Either `amount`, or the `credit`/`debit` pair, must be set; `date` and `payee` are always
+required.
+
+* `date`: the date.
+* `payee`: the payee, i.e. the other side of the transaction.
+* `code`: a code that uniquely identifies the transaction. Emitted as the Ledger
+  transaction code. A `(?P<code>...)` capture in a `rewrite` matcher takes precedence
+  over this field.
+* `category`: the type of the transaction. Not emitted directly, but usable in
+  `rewrite` matchers and in templates.
+* `note`: additional information. Emitted as a comment on the transaction.
+* `amount`: the amount of the transaction. Its sign is interpreted according to
+  `account_type`: on a `liability` account the sign is flipped.
+* `credit`: the amount of the transaction when the account balance increases.
+* `debit`: the amount of the transaction when the account balance decreases.
+* `balance`: the balance of the account, emitted as a Ledger balance assertion.
+* `commodity`: the commodity of the transaction. Falls back to `commodity.primary` when
+  the column is absent.
+* `rate`: the commodity (exchange) rate at the time of the transaction.
+* `secondary_amount`: when the transaction is done in two commodities, the amount in the
+  second one.
+* `secondary_commodity`: the second commodity. See also `conversion` under `rewrite`.
+* `charge`: the charge, commission or fee related to the transaction. Posted to
+  `charge_account` (or `Expenses:Commissions`) with `operator` recorded as its payee, so
+  `operator` must be set whenever this field can be non-zero.
+
+#### Templates in format.fields
+
+Instead of a column, a field can be built from a template:
+
+```yaml
+format:
+  fields:
+    date: Date
+    category: Action
+    note: Description
+    payee:
+      template: "{category} - {note}"
+    amount: Amount
+```
+
+Inside the template, `{name}` refers to another field key and `{1}` refers to the
+1-origin column index. A template may only reference fields that are mapped to a plain
+column: referring to another template, or to the field being rendered itself, is an
+error.
+
+### output settings
+
+These settings specify the format of the Ledger output.
+
+```yaml
+output:
+  commodity:
+    default:
+      style: comma3_dot
+      scale: null
+    overrides:
+      EUR:
+        style: plain
+        scale: 2
+```
+
+* `commodity`: settings for the commodity (currency).
+    * `default`: the standard commodity setting. Used whenever `overrides` does not
+      specify one.
+        * `style`: the style of the number. `plain` for the usual form, `comma3_dot` for
+          comma separation every three digits.
+        * `scale`: the minimum number of digits below the decimal point that an amount
+          should be shown with. For instance with `2`, an exact amount is still shown
+          with two decimal places, as `1.00`.
+    * `overrides`: per-commodity overrides, keyed by commodity name. Fields left unset
+      fall back to `default`.
+
+### rewrite rules
+
+The rewrite rules are the most important part of this config file. They make the actual
+transactions automatically get assigned the account they belong to and the party they
+were made with.
+
+Example:
+
+```yaml
+rewrite:
+- matcher:
+    payee: ^Visaデビット　(?P<code>\d+)　(?P<payee>.*)$
+- account: Assets:Wire
+  matcher:
+    payee: 円普通預金(へ|より)振替
+  conversion:
+    commodity: JPY
+    rate: price_of_primary
+- account: Expenses:Grocery
+  matcher:
+  - payee: EURO GROCERY
+  - payee: 山田商店
+```
+
+* `matcher`: **required**. The condition under which this rule applies. Written as a
+  hash with the attributes described just below, or as a list of such hashes. The
+  attributes of a hash are a logical AND: the rule does not apply unless all of them
+  match. In the list form, the elements are a logical OR: the rule applies as soon as
+  one of them matches. All values are regular expressions, matched **case
+  insensitively** and not anchored, so `payee: Migros` also matches `MIGROS SUPERMARKT`.
+    * `domain_code`, `domain_family`, `domain_sub_family`: valid only for the ISO
+      Camt053 format. Selects the entries whose respective transaction codes match.
+      These are exact code values, not regular expressions.
+    * `creditor_name`, `creditor_account_id`, `ultimate_creditor_name`: valid only for
+      the ISO Camt053 format. Matches the name or ID of the crediting side by regexp.
+    * `debtor_name`, `debtor_account_id`, `ultimate_debtor_name`: valid only for the ISO
+      Camt053 format. Matches the name or ID of the debiting side by regexp.
+    * `remittance_unstructured_info`, `additional_entry_info`,
+      `additional_transaction_info`: valid only for the ISO Camt053 format. Matches the
+      corresponding field by regexp.
+    * `category`: valid only for CSV/viseca. The category of the transaction, i.e. the
+      value of the column given as `category` in `fields`. Matched by regexp.
+    * `commodity`, `secondary_commodity`: the commodity and the secondary commodity of
+      the transaction, matched by regexp. Useful for applying a `hidden_fee` only to a
+      specific currency pair. These see the name *before* `commodity.rename` is applied.
+    * `payee`: the name of the counterparty of this transaction. A regular expression
+      can be given. If an earlier rule overwrote it, that value applies.
+* `account`: sets the account to the given string when the rule applies.
+* `payee`: sets the `payee` (the counterparty) to the given string when the rule
+  applies.
+* `pending`: when set to `true`, the posting to `account` gets marked as pending (`!`).
+  Only effective together with `account`; see the note at the end of this section.
+* `conversion`: specifies the exchange rate of the commodity (currency). Only effective
+  when a transaction spans two currencies. The following items can be set.
+    * `amount`: how the amount on the second (foreign) currency side is computed. The
+      default is `extract`, which reads the value written in the field given as
+      `secondary_amount`. When `compute` is given, it is computed from the rate.
+    * `commodity`: specifies the second (foreign) currency of the transaction. If
+      unspecified, the value of the `secondary_commodity` field given in `fields` is
+      used.
+    * `rate`: specifies in which direction the value given by the `rate` field points.
+      By default it is `price_of_secondary`, i.e. the rate of the second currency
+      expressed in the first one (`1 $secondary_commodity = $rate $commodity`). When
+      `price_of_primary` is given, it is the reverse: the rate of the first currency
+      expressed in the second one (`1 $commodity = $rate $secondary_commodity`).
+    * `disabled`: set `true` to disable all conversions for the matched transactions,
+      even when the input has a rate and a secondary amount.
+* `hidden_fee`: specifies a fee that is not charged explicitly, but is instead baked
+  into the exchange rate advertised by the operator as a spread. When set, okane
+  recovers the real rate and books the difference as a commission to `charge_account`,
+  so `operator` must be set as well. The following items can be set.
+    * `spread`: the spread, given either as a percentage (`1.8%`) or as a fixed amount
+      in the same commodity as the rate (`0.15 JPY`). Leaving it unset disables the
+      hidden fee.
+    * `condition`: when the hidden fee is incurred. `ALWAYS_INCURRED` (the default)
+      assumes the operator takes the spread in both directions, so the sign of the
+      transaction decides whether the real rate is above or below the advertised one.
+      `DEBIT_ONLY` always assumes the rated posting is an expense, which is what you
+      want for a credit card, where almost every "income" is a reimbursement priced at
+      the original rate.
+
+When several matchers match, they are applied in list order, earliest first. Matching
+partway through does not stop the later matchers from being applied. Also, if the
+regular expression has a named group, that submatch overwrites the payee (the name of
+the counterparty) when it is named `payee`, and the transaction code when it is named
+`code`.
+
+Every field is only overwritten when a later matching rule actually sets it, so a rule
+that matches but leaves `account` unset keeps the account chosen by an earlier rule.
+
+`pending` marks the destination posting with `!`, and it only takes effect on a rule
+that also sets `account`; putting `pending: true` on a rule without an `account` does
+nothing. A transaction that no rule assigned an account to falls back to
+`Expenses:Unknown` (or `Income:Unknown`), is marked pending, and okane logs a warning.


### PR DESCRIPTION
`doc/import.ja.md` had drifted from the config it documents, and no English version existed. This adds `doc/import.md` and brings both in sync with the code.

### Fixes to the existing content

* The link to the example config pointed at `cli/tests/testdata/`; the file lives at `testdata/import/test_config.yml`.
* The `rewrite` example used `conversion: {type: primary}`, which cannot parse — `CommodityConversionSpec` is `deny_unknown_fields` and has no `type`.
* `pending` marks the destination posting (`!`), not the transaction, and is a no-op unless the same rule also sets `account`.

### Newly documented

* Top level: `charge_account`, `template`.
* `format`: `file_type`, `skip.head`, `row_order`, and the `{template: "..."}` field form.
* `format.fields`: `code`, `charge`.
* `hidden_fee` under both `commodity` and `rewrite` (`spread` as `1.8%` or `0.15 JPY`, `condition` as `ALWAYS_INCURRED`/`DEBIT_ONLY`).
* Matchers on `commodity` / `secondary_commodity`, and `conversion.disabled`.
* Matchers are case-insensitive unanchored regexes; `commodity.rename` applies at output time so matchers see the pre-rename name (#304); `output.commodity.overrides` fall back to `default`; the `--interactive` / `--ledger` / `--output` flags.

`README.md` now links the English page instead of apologizing for Japanese-only, and the two docs cross-link each other.

### Verification

Claims were checked by running `okane import` against configs assembled from the doc's own examples, not just by reading the types. Two initial statements were wrong and corrected after testing:

* `account` is **not** cleared by a later rule that omits it — `Fragment`'s `AddAssign` merges with `.or()`.
* `pending: true` on a rule without `account` leaves the transaction cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
