### PR TITLE
ui: change the query options from inside the session (`.`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Added
 
 * CLI: Added `tags` command, listing all tags in the file, sorted and deduped (https://github.com/xkikeg/okane/pull/523). Pass `--values` to print `key: value` pairs instead of the keys alone.
+* CLI: `ui` can now change the query options without leaving the session
+  (https://github.com/xkikeg/okane/issues/551). `.` opens a form over `-X` / `--exchange`,
+  `--historical`, `--start`, `--end` and `--price-db`; `Enter` applies it and the report is
+  recomputed with your selection, tree state, search and open register kept. Changing only the
+  query re-runs it against the data already in memory; a new `--price-db` re-reads the file, since
+  the rates are read while book-keeping. Whichever options are in effect are named in the status
+  bar, and options that cannot be run (a commodity the file never mentions, a date that does not
+  parse) are refused without disturbing the report on screen.
 * CLI: `ui` balance now opens with a `(total)` row holding the balance of every account combined
   (https://github.com/xkikeg/okane/pull/549). It is the first row of both views — in the tree it is
   the tree's own root, above the top-level accounts — and `Enter` on it drills into the register of
@@ -37,6 +45,11 @@
   accepted).
 
 ### Fixed
+
+* CLI: `ui` no longer exits when a register cannot be loaded — `-X` without `--historical` is
+  unsupported for the register query (https://github.com/xkikeg/okane/issues/313), and pressing
+  `Enter` under it used to take the whole session down. It is now a footer notice, like every other
+  failure that leaves the report intact.
 
 ## [0.20.0] - 2026-06-24
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,13 +59,15 @@ $ okane ui /path/to/file.ledger
 
 最初の画面はフラットなアカウントごとの残高リストです。`t` でアカウントの親子関係を考慮したツリー表示に切り替わり、`space` で選択中のサブツリーを、`x` で全体を折りたたみます。`/`, `C-s`, `C-r` でアカウント名を検索でき (それぞれ Vim 風、Emacs 風になっています)、`Enter` で選択したアカウントの仕訳帳を開きます。`r` でファイルを読み込み直すので、UIを開いたままファイルを編集できます。終了は `q` です。`?` で各種操作を確認できます。
 
-`balance` や `register` と同じ評価用オプションが使えるので、通貨換算や日付指定も可能です。将来的にはこれも対話的に変更できるようにする予定です。
+`balance` や `register` と同じ評価用オプションが使えるので、通貨換算や日付指定も可能です。
 
 ```shell
 $ okane ui --price-db ~/ledger/prices.db -X CHF /path/to/file.ledger
 $ okane ui --price-db ~/ledger/prices.db -X CHF --historical /path/to/file.ledger
 $ okane ui --start 2024-01-01 --end 2025-01-01 /path/to/file.ledger
 ```
+
+同じオプションは `.` で開くフォームから対話的に変更できます。換算先の通貨、日付範囲、価格DBを書き換えるとレポートが再計算され、選択位置などの状態はそのまま保たれます。現在有効なオプションはステータスバーに表示されます。
 
 ### format
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ $ okane ui --price-db ~/ledger/prices.db -X CHF --historical /path/to/file.ledge
 $ okane ui --start 2024-01-01 --end 2025-01-01 /path/to/file.ledger
 ```
 
+`.` opens those same options in a form, so you can change them without leaving
+the UI: pick a commodity to convert into, bound the dates, or point at a
+different price DB, and the report is recomputed with your place in it kept.
+Whichever ones are in effect are shown in the status bar.
+
 ### Format the file
 
 ```shell

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -476,9 +476,7 @@ impl UiCmd {
         // here borrows it.
         let config = ui::report::SessionConfig::new(
             load::new_loader(self.source.clone()),
-            self.eval_options.to_process_options(),
-            self.eval_options.to_conversion_spec(),
-            self.eval_options.to_date_range()?,
+            self.eval_options.to_query_options()?,
         );
         let mut arena = Bump::new();
         ui::report::run_ui(&mut arena, self.source.display().to_string(), &config)
@@ -692,12 +690,21 @@ impl EvalOptions {
         }))
     }
 
-    /// Owned counterpart of [`Self::to_conversion`] for the UI session
-    /// loop, which re-resolves it against each session's fresh context.
-    fn to_conversion_spec(&self) -> Option<ui::report::ConversionSpec> {
-        self.exchange.as_ref().map(|ex| ui::report::ConversionSpec {
-            commodity: ex.clone(),
-            strategy: self.conversion_strategy(),
+    /// Owned counterpart of [`Self::to_conversion`] for the UI, which
+    /// re-resolves the query against every session's fresh context — and lets
+    /// the user restate it from inside the TUI.
+    ///
+    /// `--current` is resolved here rather than carried along: it is shorthand
+    /// for an end date, and the form shows dates.
+    fn to_query_options(&self) -> anyhow::Result<ui::report::QueryOptions> {
+        let range = self.to_date_range()?;
+        Ok(ui::report::QueryOptions {
+            price_db: self.price_db.clone(),
+            exchange: self.exchange.clone(),
+            historical: self.historical,
+            today: self.today,
+            start: range.start,
+            end: range.end,
         })
     }
 

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -16,7 +16,10 @@
 mod app;
 mod balance;
 mod event;
+mod form;
+mod fulfill;
 mod help;
+mod options;
 mod overlay;
 mod register;
 mod render;
@@ -25,17 +28,16 @@ mod search;
 mod testing;
 
 pub use app::App;
-pub use register::RegisterQueryTemplate;
+pub use options::QueryOptions;
 
 use bumpalo::Bump;
 use okane_core::load;
-use okane_core::report::query::{
-    AccountFilter, BalanceQuery, Conversion, ConversionStrategy, DateRange, Ledger, QueryError,
-};
-use okane_core::report::{self, OwnedCommodity, ProcessOptions, ReportContext};
+use okane_core::report::query::Ledger;
+use okane_core::report::{self, ReportContext};
 use ratatui::DefaultTerminal;
 
 use app::UiSnapshot;
+use options::QueryState;
 use overlay::{Overlay, TextPopup};
 
 /// Everything needed to build (and rebuild) a session: the loader re-reads
@@ -48,46 +50,16 @@ pub struct SessionConfig<F: load::FileSystem> {
     /// errors from a reload are shown in the TUI's error modal, which
     /// renders the (styled) ANSI output via `ansi-to-tui`.
     loader: load::Loader<F>,
-    process_options: ProcessOptions,
-    /// `--exchange` conversion as owned data, re-resolved against each
-    /// session's fresh [`ReportContext`].
-    conversion: Option<ConversionSpec>,
-    date_range: DateRange,
+    /// The query the session opens with. Only the *initial* one: the `.` form
+    /// replaces it for the rest of the session, so the loop below tracks the
+    /// current options separately.
+    options: QueryOptions,
 }
 
 impl<F: load::FileSystem> SessionConfig<F> {
-    /// Wraps a loader for the source plus the query configuration.
-    pub fn new(
-        loader: load::Loader<F>,
-        process_options: ProcessOptions,
-        conversion: Option<ConversionSpec>,
-        date_range: DateRange,
-    ) -> Self {
-        Self {
-            loader,
-            process_options,
-            conversion,
-            date_range,
-        }
-    }
-}
-
-/// Owned form of [`Conversion`]: unlike the latter, it holds no arena
-/// reference, so it can be resolved against every session's context anew.
-pub struct ConversionSpec {
-    pub commodity: String,
-    pub strategy: ConversionStrategy,
-}
-
-impl ConversionSpec {
-    fn resolve<'ctx>(&self, ctx: &ReportContext<'ctx>) -> Result<Conversion<'ctx>, QueryError> {
-        let target = ctx.commodity(&self.commodity).ok_or_else(|| {
-            QueryError::CommodityNotFound(OwnedCommodity::from_string(self.commodity.clone()))
-        })?;
-        Ok(Conversion {
-            strategy: self.strategy,
-            target,
-        })
+    /// Wraps a loader for the source plus the query the session opens with.
+    pub fn new(loader: load::Loader<F>, options: QueryOptions) -> Self {
+        Self { loader, options }
     }
 }
 
@@ -122,26 +94,37 @@ fn session_loop<F: load::FileSystem>(
     terminal: &mut Option<DefaultTerminal>,
 ) -> anyhow::Result<()> {
     let mut snapshot: Option<UiSnapshot> = None;
+    // The query in effect. It starts as the CLI's and is replaced by the `.`
+    // form; like the snapshot, it is owned data that crosses the arena reset.
+    let mut options = config.options.clone();
     let mut first = true;
     loop {
         if !first {
             arena.reset();
         }
         let mut ctx = ReportContext::new(arena);
-        let built = build_session(&mut ctx, config, source_display, snapshot.as_ref());
+        let built = build_session(
+            &mut ctx,
+            config,
+            &options,
+            source_display,
+            snapshot.as_ref(),
+        );
         let (mut ledger, mut app, has_data) = match built {
             Ok(SessionData { ledger, app }) => (ledger, app, true),
             // A startup failure aborts before the terminal is set up.
             Err(err) if first => return Err(err),
             // A failed reload shows an empty session with the error in a modal;
             // `r` retries from there. The last snapshot is kept so a later
-            // successful reload still restores the pre-error UI state.
+            // successful reload still restores the pre-error UI state, and the
+            // options are kept as stated so the form opens on the ones that
+            // failed — which is how a bad `--price-db` gets corrected.
             Err(err) => {
-                let template = RegisterQueryTemplate {
-                    conversion: None,
-                    date_range: config.date_range,
-                };
-                let mut app = App::new(source_display.to_owned(), Vec::new(), template);
+                let mut app = App::new(
+                    source_display.to_owned(),
+                    Vec::new(),
+                    QueryState::unresolved(&options),
+                );
                 app.overlay = Some(error_overlay(source_display, err.as_ref()));
                 (Ledger::empty(&ctx), app, false)
             }
@@ -154,6 +137,9 @@ fn session_loop<F: load::FileSystem>(
                 if has_data {
                     snapshot = Some(app.snapshot());
                 }
+                // A reload asked for from the options form carries the new
+                // options on the app; a plain `r` leaves them as they were.
+                options = app.query.options.clone();
             }
         }
     }
@@ -171,44 +157,50 @@ struct SessionData<'ctx> {
 fn build_session<'ctx, F: load::FileSystem>(
     ctx: &mut ReportContext<'ctx>,
     config: &SessionConfig<F>,
+    options: &QueryOptions,
     source_display: &str,
     snapshot: Option<&UiSnapshot>,
 ) -> anyhow::Result<SessionData<'ctx>> {
-    let mut ledger = report::process(ctx, &config.loader, &config.process_options)?;
-    let conversion = config
-        .conversion
-        .as_ref()
-        .map(|spec| spec.resolve(ctx))
-        .transpose()?;
-    let query = BalanceQuery {
-        account: AccountFilter::All,
-        conversion,
-        date_range: config.date_range,
-    };
-    let balance = ledger.balance(ctx, &query)?.into_owned();
+    let mut ledger = report::process(ctx, &config.loader, &options.to_process_options())?;
+    let app = build_app(ctx, &mut ledger, options, source_display, snapshot)?;
+    Ok(SessionData { ledger, app })
+}
+
+/// Builds the whole UI state for `options` over an already-processed `ledger`,
+/// restoring `snapshot` when given.
+///
+/// This is the step a session build and an options change have in common: the
+/// balance is queried, turned into the account tree the screen is drawn from,
+/// and the previous UI state (selection, fold state, search, open register) is
+/// re-applied to it. The two differ only in whether the source was just read
+/// from disk, which is what makes changing a query option cheap — see
+/// [`fulfill`].
+///
+/// Fails without touching anything when the options cannot be run (an
+/// `--exchange` commodity the file never mentions), so the caller can keep the
+/// report it already has.
+fn build_app<'ctx>(
+    ctx: &ReportContext<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    options: &QueryOptions,
+    source_display: &str,
+    snapshot: Option<&UiSnapshot>,
+) -> anyhow::Result<App<'ctx>> {
+    let query = options.resolve(ctx)?;
+    let balance = ledger.balance(ctx, &query.balance_query())?.into_owned();
     let tree = report::BalanceTree::create(ctx, balance)?.into_nodes();
-    let template = RegisterQueryTemplate {
-        conversion,
-        date_range: config.date_range,
-    };
-    let mut app = App::new(source_display.to_owned(), tree, template);
+    let mut app = App::new(source_display.to_owned(), tree, query);
     if let Some(snapshot) = snapshot
         && let Some((scope, index)) = app.restore(snapshot)
     {
         // The snapshot had the register screen open; re-query its rows
         // against the fresh data.
-        match event::load_register(&mut ledger, ctx, &app.register_template, scope) {
+        match fulfill::load_register(ledger, ctx, &app.query.template, scope) {
             Ok(rows) => app.show_register_at(scope, rows, index),
-            Err(err) => {
-                app.error_toast = Some(format!(
-                    "failed to load register for {}: {}",
-                    scope.display_name(),
-                    error_summary(err.as_ref())
-                ));
-            }
+            Err(err) => app.error_toast = Some(fulfill::register_error(scope, err.as_ref())),
         }
     }
-    Ok(SessionData { ledger, app })
+    Ok(app)
 }
 
 /// One-line summary of an error chain, suitable for the TUI footer. Each
@@ -313,12 +305,7 @@ mod tests {
     "};
 
     fn session_config(content: &str) -> SessionConfig<FakeFileSystem> {
-        SessionConfig::new(
-            fake_loader(content),
-            ProcessOptions::default(),
-            None,
-            DateRange::default(),
-        )
+        SessionConfig::new(fake_loader(content), testing::options())
     }
 
     /// Builds one session from `content` the way the session loop does.
@@ -328,7 +315,7 @@ mod tests {
         snapshot: Option<&UiSnapshot>,
     ) -> anyhow::Result<SessionData<'ctx>> {
         let config = session_config(content);
-        build_session(ctx, &config, "test", snapshot)
+        build_session(ctx, &config, &testing::options(), "test", snapshot)
     }
 
     fn account_names(app: &App<'_>) -> Vec<String> {
@@ -409,7 +396,7 @@ mod tests {
             let account = ctx.account("Assets:Bank").unwrap();
             let scope = RegisterScope::Single(account);
             let rows =
-                event::load_register(&mut ledger, &ctx, &app.register_template, scope).unwrap();
+                fulfill::load_register(&mut ledger, &ctx, &app.query.template, scope).unwrap();
             app.show_register(scope, rows);
             app.snapshot()
         };
@@ -439,7 +426,7 @@ mod tests {
             let account = ctx.account("Expenses:Food").unwrap();
             let scope = RegisterScope::Single(account);
             let rows =
-                event::load_register(&mut ledger, &ctx, &app.register_template, scope).unwrap();
+                fulfill::load_register(&mut ledger, &ctx, &app.query.template, scope).unwrap();
             app.show_register(scope, rows);
             app.snapshot()
         };

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -17,11 +17,12 @@ use std::cmp::min;
 use okane_core::report::BalanceTreeNode;
 
 use super::balance::{BalanceAction, BalanceMessage, BalanceSnapshot, BalanceView};
+use super::form::{FormAction, FormMessage, OptionsForm};
 use super::help;
+use super::options::{QueryOptions, QueryState};
 use super::overlay::{Overlay, ScrollDelta};
 use super::register::{
-    RegisterAction, RegisterMessage, RegisterQueryTemplate, RegisterRow, RegisterScope,
-    RegisterSnapshot, RegisterView,
+    RegisterAction, RegisterMessage, RegisterRow, RegisterScope, RegisterSnapshot, RegisterView,
 };
 
 /// Top-level screen the user is currently looking at.
@@ -42,6 +43,8 @@ pub enum Message {
     Balance(BalanceMessage),
     /// A message routed to the active register screen.
     Register(RegisterMessage),
+    /// A message routed to the open query-options form.
+    Form(FormMessage),
     /// User asked to quit from balance — show the confirmation overlay.
     RequestQuit,
     /// Confirm quit from the overlay.
@@ -50,6 +53,8 @@ pub enum Message {
     DismissOverlay,
     /// Show the key help for the focused screen (`?` / `F1`).
     ShowHelp,
+    /// Open the query-options form (`.`).
+    ShowOptions,
     /// Scroll the body of a scrollable overlay.
     OverlayScroll(ScrollDelta),
     /// Unconditional quit (Ctrl-C).
@@ -59,14 +64,17 @@ pub enum Message {
 }
 
 /// Effect requested by [`App::update`] that requires resources the pure
-/// state machine does not own (here: `&mut Ledger` to compute a register).
-#[derive(Debug, Clone, Copy)]
+/// state machine does not own (here: `&mut Ledger` to compute a register or a
+/// balance). Fulfilled by [`super::fulfill`].
+#[derive(Debug, Clone)]
 pub enum Command<'ctx> {
     LoadRegister {
         scope: RegisterScope<'ctx>,
     },
     /// Re-run the whole load/process pipeline and swap the data in.
     Reload,
+    /// Re-run the report under the options just applied in the `.` form.
+    ApplyOptions(QueryOptions),
 }
 
 /// UI state that survives a reload, captured by [`App::snapshot`] and
@@ -95,7 +103,10 @@ pub struct App<'ctx> {
     /// press. Failures worth reading in full go to [`Overlay::Error`] instead,
     /// which is dismissed explicitly.
     pub error_toast: Option<String>,
-    pub register_template: RegisterQueryTemplate<'ctx>,
+    /// The query the shown report was computed with: the options as stated, and
+    /// the resolved parameters every register lookup reuses. Replaced whole
+    /// whenever the report is recomputed, so the two never drift.
+    pub query: QueryState<'ctx>,
     pub should_quit: bool,
 }
 
@@ -106,7 +117,7 @@ impl<'ctx> App<'ctx> {
     pub fn new(
         source_display: String,
         tree: Vec<BalanceTreeNode<'ctx>>,
-        register_template: RegisterQueryTemplate<'ctx>,
+        query: QueryState<'ctx>,
     ) -> Self {
         Self {
             source_display,
@@ -114,7 +125,7 @@ impl<'ctx> App<'ctx> {
             screen: Screen::Balance,
             overlay: None,
             error_toast: None,
-            register_template,
+            query,
             should_quit: false,
         }
     }
@@ -126,7 +137,7 @@ impl<'ctx> App<'ctx> {
     pub fn with_rows(
         source_display: String,
         balance_rows: Vec<super::balance::BalanceRow<'ctx>>,
-        register_template: RegisterQueryTemplate<'ctx>,
+        query: QueryState<'ctx>,
     ) -> Self {
         Self {
             source_display,
@@ -134,7 +145,7 @@ impl<'ctx> App<'ctx> {
             screen: Screen::Balance,
             overlay: None,
             error_toast: None,
-            register_template,
+            query,
             should_quit: false,
         }
     }
@@ -153,6 +164,9 @@ impl<'ctx> App<'ctx> {
 
         if self.overlay.is_some() {
             match msg {
+                // The form is the one overlay that is interacted with rather
+                // than read, so it takes its messages while it is up.
+                Message::Form(form_msg) => return self.update_form(form_msg),
                 Message::ConfirmQuit => self.should_quit = true,
                 Message::DismissOverlay => self.overlay = None,
                 Message::OverlayScroll(delta) => {
@@ -204,11 +218,32 @@ impl<'ctx> App<'ctx> {
             }
             Message::Reload => return Some(Command::Reload),
             Message::ShowHelp => self.overlay = Some(Overlay::Help(help::popup(&self.screen))),
+            Message::ShowOptions => {
+                self.overlay = Some(Overlay::Options(OptionsForm::new(&self.query.options)));
+            }
             // Already handled above, or only meaningful while an overlay is up.
             Message::QuitImmediate
             | Message::ConfirmQuit
             | Message::DismissOverlay
+            | Message::Form(_)
             | Message::OverlayScroll(_) => {}
+        }
+        None
+    }
+
+    /// Routes a message to the open query-options form and acts on what it
+    /// asks for. Applying closes the form and hands the new options to the
+    /// event loop, which is where the ledger they are queried against lives.
+    fn update_form(&mut self, msg: FormMessage) -> Option<Command<'ctx>> {
+        let Some(Overlay::Options(form)) = self.overlay.as_mut() else {
+            return None;
+        };
+        match form.update(msg)? {
+            FormAction::Cancel => self.overlay = None,
+            FormAction::Apply(options) => {
+                self.overlay = None;
+                return Some(Command::ApplyOptions(options));
+            }
         }
         None
     }
@@ -286,14 +321,14 @@ mod tests {
 
     use super::super::balance::BalanceRow;
     use super::super::overlay::TextPopup;
-    use super::super::testing::{make_account, process, template};
+    use super::super::testing::{make_account, process, query_state};
 
     /// Build an `App` with no balance rows — sufficient for testing the
     /// pure state machine. (Constructing a `BalanceRow` requires an
     /// `Account<'ctx>`, whose interner has no public constructor outside
     /// `okane_core`, so we side-step it.)
     fn app_no_rows<'ctx>() -> App<'ctx> {
-        App::new("test".to_owned(), Vec::new(), template())
+        App::new("test".to_owned(), Vec::new(), query_state())
     }
 
     /// Process a ledger containing `names` and return the context plus an
@@ -313,7 +348,7 @@ mod tests {
             .iter()
             .map(|n| BalanceRow::flat(ctx.account(n).unwrap(), Amount::zero()))
             .collect();
-        let app = App::with_rows("test".to_owned(), rows, template());
+        let app = App::with_rows("test".to_owned(), rows, query_state());
         (ctx, app)
     }
 
@@ -476,6 +511,77 @@ mod tests {
         assert_eq!(app.overlay, None);
     }
 
+    /// The form opens on the query the report was computed with, so what it
+    /// shows is what is in effect rather than a blank slate.
+    #[test]
+    fn show_options_opens_the_form_on_the_current_query() {
+        let mut app = app_no_rows();
+        app.query.options.exchange = Some("CHF".to_owned());
+        app.update(Message::ShowOptions);
+        assert_matches!(&app.overlay, Some(Overlay::Options(form)) => {
+            assert_eq!(form.fields()[0].text(), "CHF");
+        });
+    }
+
+    /// Applying closes the form and hands the options to the event loop, which
+    /// is the only place that can run them against the ledger.
+    #[test]
+    fn applying_the_form_closes_it_and_asks_for_the_query() {
+        let mut app = app_no_rows();
+        app.update(Message::ShowOptions);
+        for c in "CHF".chars() {
+            app.update(Message::Form(FormMessage::Push(c)));
+        }
+        assert_matches!(
+            app.update(Message::Form(FormMessage::Submit)),
+            Some(Command::ApplyOptions(options)) => {
+                assert_eq!(options.exchange.as_deref(), Some("CHF"));
+            }
+        );
+        assert_eq!(app.overlay, None);
+        // Nothing is in effect until the command has been fulfilled.
+        assert_eq!(app.query.options.exchange, None);
+    }
+
+    #[test]
+    fn cancelling_the_form_closes_it_without_a_command() {
+        let mut app = app_no_rows();
+        app.update(Message::ShowOptions);
+        app.update(Message::Form(FormMessage::Push('X')));
+        assert!(app.update(Message::Form(FormMessage::Cancel)).is_none());
+        assert_eq!(app.overlay, None);
+        assert_eq!(app.query.options.exchange, None);
+    }
+
+    /// A refused submit leaves the form up with the reason, and asks for
+    /// nothing.
+    #[test]
+    fn a_form_that_does_not_parse_stays_open() {
+        let mut app = app_no_rows();
+        app.update(Message::ShowOptions);
+        app.update(Message::Form(FormMessage::FocusNext)); // --historical
+        app.update(Message::Form(FormMessage::FocusNext)); // --start
+        for c in "yesterday".chars() {
+            app.update(Message::Form(FormMessage::Push(c)));
+        }
+        assert!(app.update(Message::Form(FormMessage::Submit)).is_none());
+        assert_matches!(&app.overlay, Some(Overlay::Options(form)) => {
+            assert!(form.error().is_some());
+        });
+    }
+
+    /// Like the help, the form takes the screen's keys away while it is up —
+    /// it has to, since they are text in it.
+    #[test]
+    fn form_swallows_the_screen_underneath() {
+        let mut app = app_no_rows();
+        app.balance.nav = TableNav::new(3);
+        app.update(Message::ShowOptions);
+        app.update(Message::Balance(BalanceMessage::Nav(NavCommand::Down)));
+        assert_eq!(app.balance.nav.selected_row(), 0);
+        assert_matches!(app.overlay, Some(Overlay::Options(_)));
+    }
+
     #[test]
     fn reload_through_error_modal_returns_command() {
         let mut app = app_with_error_modal();
@@ -537,7 +643,7 @@ mod tests {
 
     /// A fresh `App` over `names`, as if built for the next session.
     fn next_app<'ctx>(ctx: &ReportContext<'ctx>, names: &[&str]) -> App<'ctx> {
-        App::with_rows("test".to_owned(), rows_of(ctx, names), template())
+        App::with_rows("test".to_owned(), rows_of(ctx, names), query_state())
     }
 
     #[test]

--- a/cli/src/ui/report/event.rs
+++ b/cli/src/ui/report/event.rs
@@ -4,25 +4,25 @@
 //! <https://ratatui.rs/concepts/application-patterns/the-elm-architecture/>):
 //! key events are translated into [`Message`]s by [`key_to_message`] (a pure
 //! function that consults the current screen/overlay), [`App::update`] applies
-//! them, and any returned [`Command`] is fulfilled here — the single place
-//! that owns the mutable resources (the `Ledger`) the pure state machine
-//! cannot touch.
+//! them, and any returned [`Command`] is handed to [`super::fulfill`] — the
+//! single place that owns the mutable resources (the `Ledger`) the pure state
+//! machine cannot touch. What is left here is the select: draw, read a key,
+//! route it.
 
 use std::time::Duration;
 
-use anyhow::Context;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
-use lender::FallibleLender;
 use okane_core::report::ReportContext;
-use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
+use okane_core::report::query::Ledger;
 use ratatui::DefaultTerminal;
 
 use crate::ui::keys::is_ctrl;
 use crate::ui::table::key_to_nav;
 
-use super::app::{App, Command, Message, Screen};
+use super::app::{App, Message, Screen};
+use super::fulfill::{self, Fulfilled};
 use super::overlay::Overlay;
-use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope, RegisterView};
+use super::register::RegisterView;
 use super::render;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(250);
@@ -50,17 +50,9 @@ pub(super) fn run<'ctx>(
             && let Event::Key(key) = event::read()?
             && let Some(msg) = key_to_message(app, key)
             && let Some(cmd) = app.update(msg)
+            && fulfill::fulfill(cmd, app, ledger, ctx) == Fulfilled::Reload
         {
-            match cmd {
-                Command::Reload => return Ok(RunOutcome::Reload),
-                Command::LoadRegister { scope } => {
-                    let rows = load_register(ledger, ctx, &app.register_template, scope)
-                        .with_context(|| {
-                            format!("failed to load register for {}", scope.display_name())
-                        })?;
-                    app.show_register(scope, rows);
-                }
-            }
+            return Ok(RunOutcome::Reload);
         }
     }
     Ok(RunOutcome::Quit)
@@ -122,6 +114,9 @@ pub(super) fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
                 _ => None,
             };
         }
+        // The form is typed into, so it takes every key it can use — including
+        // the letters that navigate the screen underneath.
+        Some(Overlay::Options(form)) => return form.key_to_message(key).map(Message::Form),
         None => {}
     }
 
@@ -142,40 +137,9 @@ pub(super) fn key_to_message(app: &App<'_>, key: KeyEvent) -> Option<Message> {
         KeyCode::Char('q') | KeyCode::Esc => Some(Message::RequestQuit),
         KeyCode::Char('r') | KeyCode::F(5) => Some(Message::Reload),
         KeyCode::Char('?') | KeyCode::F(1) => Some(Message::ShowHelp),
+        KeyCode::Char('.') => Some(Message::ShowOptions),
         _ => None,
     }
-}
-
-/// Collects the register rows for `account` into owned [`RegisterRow`]s so
-/// they can be displayed without keeping the `FallibleLender` alive.
-pub fn load_register<'ctx>(
-    ledger: &mut Ledger<'ctx>,
-    ctx: &ReportContext<'ctx>,
-    template: &RegisterQueryTemplate<'ctx>,
-    scope: RegisterScope<'ctx>,
-) -> anyhow::Result<Vec<RegisterRow<'ctx>>> {
-    let account = match scope {
-        RegisterScope::Single(account) => AccountFilter::single(account),
-        RegisterScope::Subtree(aggregate) => AccountFilter::descendants_of(ctx, aggregate),
-        RegisterScope::All => AccountFilter::All,
-    };
-    let query = RegisterQuery {
-        account,
-        date_range: template.date_range,
-        conversion: template.conversion,
-        sort: Sort::Date,
-    };
-    let mut entries = ledger.register_entries(ctx, &query)?;
-    let mut rows = Vec::new();
-    while let Some(entry) = entries.next()? {
-        rows.push(RegisterRow {
-            date: entry.date,
-            payee: entry.payee.to_owned(),
-            amount: entry.amount.clone(),
-            total: entry.total.clone(),
-        });
-    }
-    Ok(rows)
 }
 
 #[cfg(test)]
@@ -190,12 +154,13 @@ mod tests {
     use crate::ui::table::{NavCommand, TableNav};
 
     use super::super::balance::BalanceMessage;
+    use super::super::form::FormMessage;
     use super::super::overlay::{ScrollDelta, TextPopup};
-    use super::super::register::{RegisterMessage, RegisterView};
+    use super::super::register::{RegisterMessage, RegisterScope, RegisterView};
     use super::super::search::{
         Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase,
     };
-    use super::super::testing::{make_account, template};
+    use super::super::testing::{make_account, query_state};
 
     /// A single-account register screen for `account`, empty rows.
     fn register_screen<'ctx>(account: Account<'ctx>) -> Screen<'ctx> {
@@ -216,7 +181,7 @@ mod tests {
     }
 
     fn app<'ctx>() -> App<'ctx> {
-        App::new("test".to_owned(), Vec::new(), template())
+        App::new("test".to_owned(), Vec::new(), query_state())
     }
 
     #[test]
@@ -500,6 +465,77 @@ mod tests {
                 "{key:?}"
             );
         }
+    }
+
+    #[test]
+    fn dot_opens_the_query_options_on_both_screens() {
+        let arena = Bump::new();
+        let (_ctx, account) = make_account(&arena, "Assets:A");
+        let mut app = app();
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('.'))),
+            Some(Message::ShowOptions)
+        );
+        app.screen = register_screen(account);
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('.'))),
+            Some(Message::ShowOptions)
+        );
+    }
+
+    /// A `.` typed into a search is a `.` — the search owns every key while it
+    /// is being edited, the same way the options form does.
+    #[test]
+    fn dot_during_an_incremental_search_is_typed() {
+        let mut app = app();
+        app.update(Message::Balance(BalanceMessage::StartModalSearch));
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Char('.'))),
+            Some(Message::Balance(BalanceMessage::SearchPush('.')))
+        );
+    }
+
+    fn app_with_options_form<'ctx>() -> App<'ctx> {
+        let mut app = app();
+        app.update(Message::ShowOptions);
+        app
+    }
+
+    /// The form is typed into, so the keys that navigate and quit the screen
+    /// under it become text — which is why it has to take them all.
+    #[test]
+    fn options_form_takes_the_screen_keys_as_text() {
+        let app = app_with_options_form();
+        for c in ['j', 'k', 'q', 'r', 't', '/', '.'] {
+            assert_eq!(
+                key_to_message(&app, key(KeyCode::Char(c))),
+                Some(Message::Form(FormMessage::Push(c))),
+                "{c:?}"
+            );
+        }
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Tab)),
+            Some(Message::Form(FormMessage::FocusNext))
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Enter)),
+            Some(Message::Form(FormMessage::Submit))
+        );
+        assert_eq!(
+            key_to_message(&app, key(KeyCode::Esc)),
+            Some(Message::Form(FormMessage::Cancel))
+        );
+    }
+
+    /// The one key that still gets through: the session is quittable from
+    /// anywhere.
+    #[test]
+    fn ctrl_c_quits_through_the_options_form() {
+        let app = app_with_options_form();
+        assert_eq!(
+            key_to_message(&app, ctrl_key('c')),
+            Some(Message::QuitImmediate)
+        );
     }
 
     /// Typing `?` into a search is typing a `?`, not asking for help.

--- a/cli/src/ui/report/form.rs
+++ b/cli/src/ui/report/form.rs
@@ -1,0 +1,520 @@
+//! The query-options form opened with `.`.
+//!
+//! A modal form over [`QueryOptions`]: one row per option, edited in place and
+//! applied as a whole. It follows the same component shape as the screens —
+//! own state, own [`FormMessage`], own [`OptionsForm::key_to_message`] — and
+//! reports back to [`App`](super::app::App) with a [`FormAction`], which is
+//! where the effect of applying (re-querying the ledger) is decided.
+//!
+//! There is no editing *mode*: the focused row takes every printable key, and
+//! only the keys no text field wants (`Tab`, the arrows, `Enter`, `Esc`) move
+//! between rows and leave. That is what a dialog does everywhere else, and it
+//! keeps `j`/`k` — which are text here, not motions — from being stolen.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use crate::ui::keys::is_ctrl;
+
+use super::options::{QueryOptions, format_date, parse_date};
+
+/// The options the form edits, in the order they are drawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FieldId {
+    Exchange,
+    Historical,
+    Start,
+    End,
+    PriceDb,
+}
+
+impl FieldId {
+    /// Every field, top to bottom. The conversion first (the option most worth
+    /// changing mid-session), then the range, then the price DB — which is also
+    /// the only one whose change costs a reload.
+    const ALL: [FieldId; 5] = [
+        FieldId::Exchange,
+        FieldId::Historical,
+        FieldId::Start,
+        FieldId::End,
+        FieldId::PriceDb,
+    ];
+
+    /// The command-line flag this row stands for. Named after the flag rather
+    /// than described in prose: whoever reaches this form got here from a
+    /// command line that has the same options on it.
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            FieldId::Exchange => "-X, --exchange",
+            FieldId::Historical => "--historical",
+            FieldId::Start => "--start",
+            FieldId::End => "--end",
+            FieldId::PriceDb => "--price-db",
+        }
+    }
+
+    /// What an empty row shows: the shape the value takes, where there is one
+    /// to teach, and otherwise that the option is simply not set.
+    pub(super) fn placeholder(self) -> &'static str {
+        match self {
+            FieldId::Start | FieldId::End => "YYYY-MM-DD",
+            FieldId::Exchange | FieldId::PriceDb => "(none)",
+            // A flag is never empty.
+            FieldId::Historical => "",
+        }
+    }
+}
+
+/// One row's value: free text, or a flag toggled with `space`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Value {
+    Text(String),
+    Flag(bool),
+}
+
+/// One row of the form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Field {
+    id: FieldId,
+    value: Value,
+}
+
+impl Field {
+    pub(super) fn label(&self) -> &'static str {
+        self.id.label()
+    }
+
+    /// The value as drawn: the typed text, or the flag's state.
+    pub(super) fn text(&self) -> &str {
+        match &self.value {
+            Value::Text(text) => text,
+            Value::Flag(true) => "on",
+            Value::Flag(false) => "off",
+        }
+    }
+
+    /// The dim stand-in drawn when [`Self::text`] is empty.
+    pub(super) fn placeholder(&self) -> &'static str {
+        self.id.placeholder()
+    }
+
+    /// Whether this row is typed into (and so carries the cursor when focused).
+    pub(super) fn is_text(&self) -> bool {
+        matches!(self.value, Value::Text(_))
+    }
+
+    /// The trimmed text, or `None` when the option is left unset. Surrounding
+    /// space is never meaningful in any of these values, and a stray one is
+    /// easier to type than to see.
+    fn stated(&self) -> Option<&str> {
+        match &self.value {
+            Value::Text(text) => Some(text.trim()).filter(|t| !t.is_empty()),
+            Value::Flag(_) => None,
+        }
+    }
+
+    fn flag(&self) -> bool {
+        matches!(self.value, Value::Flag(true))
+    }
+}
+
+/// Messages handled by the form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormMessage {
+    /// Move the focus one row down (wrapping).
+    FocusNext,
+    /// Move the focus one row up (wrapping).
+    FocusPrev,
+    /// Append a character to the focused text row.
+    Push(char),
+    /// Delete the last character of the focused text row.
+    Pop,
+    /// Empty the focused row (`C-u`); a flag goes back to off.
+    Clear,
+    /// Flip the focused flag row (`space`).
+    Toggle,
+    /// Apply every row (`Enter`).
+    Submit,
+    /// Leave without applying anything (`Esc`).
+    Cancel,
+}
+
+/// What the form asks [`App`](super::app::App) to do; everything else it
+/// handles itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormAction {
+    /// Close the form and run the report under these options.
+    Apply(QueryOptions),
+    /// Close the form, changing nothing.
+    Cancel,
+}
+
+/// State of the `.` form: the rows, which one has the focus, and the complaint
+/// from the last refused [`FormMessage::Submit`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionsForm {
+    /// The options the form was opened on. Kept whole so applying carries the
+    /// fields the form does not draw (`--today`) through unchanged.
+    base: QueryOptions,
+    fields: Vec<Field>,
+    focus: usize,
+    /// Why the last submit did not go through, shown under the rows until the
+    /// next edit. The form stays open so it can be fixed where it was typed.
+    error: Option<String>,
+}
+
+impl OptionsForm {
+    /// Opens the form on the options currently in effect.
+    pub(super) fn new(options: &QueryOptions) -> Self {
+        let fields = FieldId::ALL
+            .iter()
+            .map(|&id| {
+                let value = match id {
+                    FieldId::Exchange => Value::Text(options.exchange.clone().unwrap_or_default()),
+                    FieldId::Historical => Value::Flag(options.historical),
+                    FieldId::Start => Value::Text(format_date(options.start)),
+                    FieldId::End => Value::Text(format_date(options.end)),
+                    FieldId::PriceDb => Value::Text(
+                        options
+                            .price_db
+                            .as_ref()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_default(),
+                    ),
+                };
+                Field { id, value }
+            })
+            .collect();
+        Self {
+            base: options.clone(),
+            fields,
+            focus: 0,
+            error: None,
+        }
+    }
+
+    pub(super) fn fields(&self) -> &[Field] {
+        &self.fields
+    }
+
+    pub(super) fn focus(&self) -> usize {
+        self.focus
+    }
+
+    pub(super) fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    fn focused(&mut self) -> &mut Field {
+        &mut self.fields[self.focus]
+    }
+
+    /// Applies a [`FormMessage`], returning a [`FormAction`] for the steps the
+    /// form cannot take itself (running the query, closing itself).
+    pub(super) fn update(&mut self, msg: FormMessage) -> Option<FormAction> {
+        let len = self.fields.len();
+        match msg {
+            FormMessage::FocusNext => self.focus = (self.focus + 1) % len,
+            FormMessage::FocusPrev => self.focus = (self.focus + len - 1) % len,
+            FormMessage::Push(c) => {
+                if let Value::Text(text) = &mut self.focused().value {
+                    text.push(c);
+                    self.error = None;
+                }
+            }
+            FormMessage::Pop => {
+                if let Value::Text(text) = &mut self.focused().value {
+                    text.pop();
+                    self.error = None;
+                }
+            }
+            FormMessage::Clear => {
+                // Emptying a flag is turning it off: that is its unset state.
+                self.focused().value = match self.focused().value {
+                    Value::Text(_) => Value::Text(String::new()),
+                    Value::Flag(_) => Value::Flag(false),
+                };
+                self.error = None;
+            }
+            FormMessage::Toggle => {
+                if let Value::Flag(on) = &mut self.focused().value {
+                    *on = !*on;
+                    self.error = None;
+                }
+            }
+            FormMessage::Submit => match self.to_options() {
+                Ok(options) => return Some(FormAction::Apply(options)),
+                // Nothing is applied and nothing is lost: the offending row is
+                // still there to fix, with the reason under it.
+                Err(err) => self.error = Some(err),
+            },
+            FormMessage::Cancel => return Some(FormAction::Cancel),
+        }
+        None
+    }
+
+    /// Translates a key event into a [`FormMessage`]. Every printable key is
+    /// text for the focused row (a flag row takes `space` as its toggle), so
+    /// only the keys below reach anything else — `Ctrl-C` included, which
+    /// [`super::event::key_to_message`] answers before the form is consulted.
+    pub(super) fn key_to_message(&self, key: KeyEvent) -> Option<FormMessage> {
+        let ctrl = is_ctrl(key.modifiers);
+        match key.code {
+            KeyCode::Esc => Some(FormMessage::Cancel),
+            KeyCode::Enter => Some(FormMessage::Submit),
+            KeyCode::Tab | KeyCode::Down => Some(FormMessage::FocusNext),
+            KeyCode::Char('n') if ctrl => Some(FormMessage::FocusNext),
+            KeyCode::BackTab | KeyCode::Up => Some(FormMessage::FocusPrev),
+            KeyCode::Char('p') if ctrl => Some(FormMessage::FocusPrev),
+            KeyCode::Backspace => Some(FormMessage::Pop),
+            KeyCode::Char('u') if ctrl => Some(FormMessage::Clear),
+            KeyCode::Char(' ') if !self.fields[self.focus].is_text() => Some(FormMessage::Toggle),
+            KeyCode::Char(c) if !ctrl => Some(FormMessage::Push(c)),
+            _ => None,
+        }
+    }
+
+    /// Reads every row back into options, or reports the first row that does
+    /// not parse. Rows the form does not draw are carried over from the options
+    /// it was opened on.
+    fn to_options(&self) -> Result<QueryOptions, String> {
+        let mut options = self.base.clone();
+        for field in &self.fields {
+            match field.id {
+                FieldId::Exchange => options.exchange = field.stated().map(str::to_owned),
+                FieldId::Historical => options.historical = field.flag(),
+                FieldId::Start => options.start = self.date_of(field)?,
+                FieldId::End => options.end = self.date_of(field)?,
+                FieldId::PriceDb => options.price_db = field.stated().map(Into::into),
+            }
+        }
+        Ok(options)
+    }
+
+    fn date_of(&self, field: &Field) -> Result<Option<chrono::NaiveDate>, String> {
+        field
+            .stated()
+            .map(|text| parse_date(text).map_err(|err| format!("{}: {err}", field.label())))
+            .transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use assert_matches::assert_matches;
+    use chrono::NaiveDate;
+    use crossterm::event::KeyModifiers;
+
+    use super::super::testing::options;
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    /// Types `text` into the focused row.
+    fn type_text(form: &mut OptionsForm, text: &str) {
+        for c in text.chars() {
+            form.update(FormMessage::Push(c));
+        }
+    }
+
+    /// Moves the focus onto `id`.
+    fn focus(form: &mut OptionsForm, id: FieldId) {
+        while form.fields[form.focus].id != id {
+            form.update(FormMessage::FocusNext);
+        }
+    }
+
+    fn submit(form: &mut OptionsForm) -> Option<FormAction> {
+        form.update(FormMessage::Submit)
+    }
+
+    #[test]
+    fn opens_on_the_current_options() {
+        let mut opts = options();
+        opts.exchange = Some("CHF".to_owned());
+        opts.historical = true;
+        opts.start = Some(date(2024, 1, 1));
+        opts.price_db = Some(PathBuf::from("prices.db"));
+        let form = OptionsForm::new(&opts);
+        let shown: Vec<&str> = form.fields().iter().map(Field::text).collect();
+        assert_eq!(shown, ["CHF", "on", "2024-01-01", "", "prices.db"]);
+    }
+
+    /// Submitting an untouched form yields exactly what it was opened on —
+    /// including `--today`, which it never draws.
+    #[test]
+    fn submitting_unchanged_is_the_identity() {
+        let mut opts = options();
+        opts.exchange = Some("CHF".to_owned());
+        opts.end = Some(date(2025, 1, 1));
+        let mut form = OptionsForm::new(&opts);
+        assert_eq!(submit(&mut form), Some(FormAction::Apply(opts)));
+    }
+
+    #[test]
+    fn typing_and_toggling_reach_the_applied_options() {
+        let mut form = OptionsForm::new(&options());
+        focus(&mut form, FieldId::Exchange);
+        type_text(&mut form, "CHF");
+        focus(&mut form, FieldId::Historical);
+        form.update(FormMessage::Toggle);
+        focus(&mut form, FieldId::Start);
+        type_text(&mut form, "2024-01-01");
+        focus(&mut form, FieldId::PriceDb);
+        type_text(&mut form, "prices.db");
+
+        assert_matches!(submit(&mut form), Some(FormAction::Apply(opts)) => {
+            assert_eq!(opts.exchange.as_deref(), Some("CHF"));
+            assert!(opts.historical);
+            assert_eq!(opts.start, Some(date(2024, 1, 1)));
+            assert_eq!(opts.end, None);
+            assert_eq!(opts.price_db, Some(PathBuf::from("prices.db")));
+            // Untouched, and untouchable from the form.
+            assert_eq!(opts.today, date(2024, 6, 1));
+        });
+    }
+
+    /// Emptying a row unsets the option, which is how a conversion or a range
+    /// is taken back off.
+    #[test]
+    fn clearing_a_row_unsets_the_option() {
+        let mut opts = options();
+        opts.exchange = Some("CHF".to_owned());
+        opts.historical = true;
+        opts.start = Some(date(2024, 1, 1));
+        let mut form = OptionsForm::new(&opts);
+
+        focus(&mut form, FieldId::Exchange);
+        form.update(FormMessage::Clear);
+        focus(&mut form, FieldId::Historical);
+        form.update(FormMessage::Clear);
+        focus(&mut form, FieldId::Start);
+        for _ in 0.."2024-01-01".len() {
+            form.update(FormMessage::Pop);
+        }
+
+        assert_matches!(submit(&mut form), Some(FormAction::Apply(opts)) => {
+            assert_eq!(opts.exchange, None);
+            assert!(!opts.historical);
+            assert_eq!(opts.start, None);
+        });
+    }
+
+    #[test]
+    fn whitespace_only_input_is_unset() {
+        let mut form = OptionsForm::new(&options());
+        focus(&mut form, FieldId::Exchange);
+        type_text(&mut form, "  ");
+        assert_matches!(submit(&mut form), Some(FormAction::Apply(opts)) => {
+            assert_eq!(opts.exchange, None);
+        });
+    }
+
+    /// A date that does not parse keeps the form open, says which row is wrong,
+    /// and applies nothing.
+    #[test]
+    fn a_bad_date_is_refused_in_place() {
+        let mut form = OptionsForm::new(&options());
+        focus(&mut form, FieldId::End);
+        type_text(&mut form, "2024/13/01");
+        assert_eq!(submit(&mut form), None);
+        let err = form.error().expect("the refused submit should say why");
+        assert!(err.contains("--end"), "{err}");
+        assert!(err.contains("YYYY-MM-DD"), "{err}");
+
+        // The typed text is still there to be fixed, and the next edit takes
+        // the complaint down.
+        assert_eq!(form.fields()[form.focus()].text(), "2024/13/01");
+        form.update(FormMessage::Pop);
+        assert_eq!(form.error(), None);
+    }
+
+    #[test]
+    fn focus_wraps_in_both_directions() {
+        let mut form = OptionsForm::new(&options());
+        assert_eq!(form.focus(), 0);
+        form.update(FormMessage::FocusPrev);
+        assert_eq!(form.focus(), FieldId::ALL.len() - 1);
+        form.update(FormMessage::FocusNext);
+        assert_eq!(form.focus(), 0);
+    }
+
+    #[test]
+    fn cancel_asks_to_close_without_applying() {
+        let mut form = OptionsForm::new(&options());
+        focus(&mut form, FieldId::Exchange);
+        type_text(&mut form, "CHF");
+        assert_eq!(form.update(FormMessage::Cancel), Some(FormAction::Cancel));
+    }
+
+    /// The rows are typed into with no editing mode: `j`, `k` and `q` are text
+    /// here, not the motions and the quit they are on the screens below.
+    #[test]
+    fn printable_keys_are_text_on_a_text_row() {
+        let form = OptionsForm::new(&options());
+        for c in ['j', 'k', 'q', 'r', '.', '/', '-', '5', ' '] {
+            assert_eq!(
+                form.key_to_message(key(KeyCode::Char(c))),
+                Some(FormMessage::Push(c)),
+                "{c:?}"
+            );
+        }
+    }
+
+    /// …except on the flag row, where `space` is the only way to change it.
+    #[test]
+    fn space_toggles_the_flag_row() {
+        let mut form = OptionsForm::new(&options());
+        focus(&mut form, FieldId::Historical);
+        assert_eq!(
+            form.key_to_message(key(KeyCode::Char(' '))),
+            Some(FormMessage::Toggle)
+        );
+        // Text keys on a flag row are simply ignored rather than mapped to
+        // something surprising.
+        assert_eq!(
+            form.key_to_message(key(KeyCode::Char('x'))),
+            Some(FormMessage::Push('x'))
+        );
+        form.update(FormMessage::Push('x'));
+        assert_eq!(form.fields()[form.focus()].text(), "off");
+    }
+
+    #[test]
+    fn navigation_and_control_keys_map() {
+        let form = OptionsForm::new(&options());
+        for (k, msg) in [
+            (key(KeyCode::Tab), FormMessage::FocusNext),
+            (key(KeyCode::Down), FormMessage::FocusNext),
+            (ctrl_key('n'), FormMessage::FocusNext),
+            (key(KeyCode::BackTab), FormMessage::FocusPrev),
+            (key(KeyCode::Up), FormMessage::FocusPrev),
+            (ctrl_key('p'), FormMessage::FocusPrev),
+            (key(KeyCode::Backspace), FormMessage::Pop),
+            (ctrl_key('u'), FormMessage::Clear),
+            (key(KeyCode::Enter), FormMessage::Submit),
+            (key(KeyCode::Esc), FormMessage::Cancel),
+        ] {
+            assert_eq!(form.key_to_message(k), Some(msg), "{k:?}");
+        }
+    }
+
+    #[test]
+    fn unmapped_keys_are_ignored() {
+        let form = OptionsForm::new(&options());
+        assert_eq!(form.key_to_message(key(KeyCode::F(5))), None);
+        assert_eq!(form.key_to_message(ctrl_key('z')), None);
+    }
+}

--- a/cli/src/ui/report/fulfill.rs
+++ b/cli/src/ui/report/fulfill.rs
@@ -1,0 +1,338 @@
+//! Fulfillment of the [`Command`]s [`App::update`] asks for — the one impure
+//! step of the loop, and the only place that touches the `Ledger` the pure
+//! state machine cannot.
+//!
+//! Every command here can fail against real data (a register the current
+//! conversion cannot express, options naming a commodity the file does not
+//! have), and none of those failures is a reason to tear the session down:
+//! they leave the shown report exactly as it was and say what happened in the
+//! footer, which is why [`fulfill`] is infallible.
+
+use lender::FallibleLender;
+use okane_core::report::ReportContext;
+use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
+
+use super::app::{App, Command};
+use super::options::QueryOptions;
+use super::register::{RegisterQueryTemplate, RegisterRow, RegisterScope};
+
+/// What the event loop should do after a command has been fulfilled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Fulfilled {
+    /// Keep the session running.
+    Continue,
+    /// Tear the session down and build a fresh one — the reload key, or an
+    /// options change that only a reprocess can apply.
+    Reload,
+}
+
+/// Carries out `cmd` against the live session.
+pub(super) fn fulfill<'ctx>(
+    cmd: Command<'ctx>,
+    app: &mut App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> Fulfilled {
+    match cmd {
+        Command::Reload => Fulfilled::Reload,
+        Command::LoadRegister { scope } => {
+            match load_register(ledger, ctx, &app.query.template, scope) {
+                Ok(rows) => app.show_register(scope, rows),
+                Err(err) => app.error_toast = Some(register_error(scope, err.as_ref())),
+            }
+            Fulfilled::Continue
+        }
+        Command::ApplyOptions(options) => apply_options(options, app, ledger, ctx),
+    }
+}
+
+/// Re-runs the report under `options`.
+///
+/// A different price DB is a different *book-keeping* of the source rather than
+/// a different query of it, so it goes back to the session loop to be built
+/// again; the options ride along on the app, which outlives this session's
+/// data. Everything else is re-queried against the ledger already in memory —
+/// no re-parse, and the file on disk is left alone, which is what keeps this
+/// distinct from a reload.
+fn apply_options<'ctx>(
+    options: QueryOptions,
+    app: &mut App<'ctx>,
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+) -> Fulfilled {
+    if options.needs_reprocess(&app.query.options) {
+        app.query.options = options;
+        return Fulfilled::Reload;
+    }
+    // The whole view is rebuilt from the new query and the old UI state, the
+    // same way a reload rebuilds it — including re-running an open register.
+    let snapshot = app.snapshot();
+    match super::build_app(ctx, ledger, &options, &app.source_display, Some(&snapshot)) {
+        Ok(next) => *app = next,
+        // Nothing was swapped in, so the report on screen is still the one its
+        // options describe.
+        Err(err) => {
+            app.error_toast = Some(format!(
+                "failed to apply the options: {}",
+                super::error_summary(err.as_ref())
+            ));
+        }
+    }
+    Fulfilled::Continue
+}
+
+/// Footer notice for a register that could not be loaded: which account, and
+/// why, on one line.
+pub(super) fn register_error(
+    scope: RegisterScope<'_>,
+    err: &(dyn std::error::Error + 'static),
+) -> String {
+    format!(
+        "failed to load register for {}: {}",
+        scope.display_name(),
+        super::error_summary(err)
+    )
+}
+
+/// Collects the register rows for `scope` into owned [`RegisterRow`]s so they
+/// can be displayed without keeping the `FallibleLender` alive.
+pub fn load_register<'ctx>(
+    ledger: &mut Ledger<'ctx>,
+    ctx: &ReportContext<'ctx>,
+    template: &RegisterQueryTemplate<'ctx>,
+    scope: RegisterScope<'ctx>,
+) -> anyhow::Result<Vec<RegisterRow<'ctx>>> {
+    let account = match scope {
+        RegisterScope::Single(account) => AccountFilter::single(account),
+        RegisterScope::Subtree(aggregate) => AccountFilter::descendants_of(ctx, aggregate),
+        RegisterScope::All => AccountFilter::All,
+    };
+    let query = RegisterQuery {
+        account,
+        date_range: template.date_range,
+        conversion: template.conversion,
+        sort: Sort::Date,
+    };
+    let mut entries = ledger.register_entries(ctx, &query)?;
+    let mut rows = Vec::new();
+    while let Some(entry) = entries.next()? {
+        rows.push(RegisterRow {
+            date: entry.date,
+            payee: entry.payee.to_owned(),
+            amount: entry.amount.clone(),
+            total: entry.total.clone(),
+        });
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use bumpalo::Bump;
+    use chrono::NaiveDate;
+    use indoc::indoc;
+
+    use super::super::app::Screen;
+    use super::super::testing::{options, process};
+
+    /// Two years of postings, so a date range has something to cut, in two
+    /// commodities — priced against each other — so a conversion has something
+    /// to do. `Assets:Bank` ends up holding 110 USD and 5 EUR.
+    const LEDGER: &str = indoc! {"
+        2024/01/01 Init
+            Assets:Bank    10 USD
+            Equity
+
+        2024/02/01 Exchange
+            Assets:Bank    5 EUR @ 2 USD
+            Equity
+
+        2025/01/01 Later
+            Assets:Bank    100 USD
+            Equity
+    "};
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    /// Builds the app the way a session does, from `options`.
+    fn app_with<'ctx>(
+        ctx: &ReportContext<'ctx>,
+        ledger: &mut Ledger<'ctx>,
+        options: &QueryOptions,
+    ) -> App<'ctx> {
+        super::super::build_app(ctx, ledger, options, "test.ledger", None).unwrap()
+    }
+
+    /// The balance rows as `name: amount` text, which is what an options change
+    /// is supposed to move.
+    fn rows_of(app: &App<'_>, ctx: &ReportContext<'_>) -> Vec<String> {
+        app.balance
+            .rows
+            .iter()
+            .map(|row| format!("{}: {}", row.full_name(), row.amount.as_inline_display(ctx)))
+            .collect()
+    }
+
+    #[test]
+    fn applying_a_date_range_requeries_in_place() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let mut app = app_with(&ctx, &mut ledger, &options());
+        assert!(
+            rows_of(&app, &ctx)
+                .iter()
+                .any(|row| row.contains("110 USD")),
+            "{:?}",
+            rows_of(&app, &ctx)
+        );
+
+        let mut next = options();
+        next.end = Some(date(2025, 1, 1));
+        assert_eq!(
+            fulfill(
+                Command::ApplyOptions(next.clone()),
+                &mut app,
+                &mut ledger,
+                &ctx
+            ),
+            Fulfilled::Continue
+        );
+
+        assert_eq!(app.error_toast, None);
+        assert_eq!(app.query.options, next);
+        // The 2025 posting is outside the range now.
+        let rows = rows_of(&app, &ctx);
+        assert!(
+            rows.iter().any(|row| row.contains("10 USD")),
+            "the 2024 postings should still be there: {rows:?}"
+        );
+        assert!(
+            rows.iter().all(|row| !row.contains("110 USD")),
+            "the 2025 posting should be gone: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn applying_an_exchange_converts_the_balance() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let mut app = app_with(&ctx, &mut ledger, &options());
+
+        let mut next = options();
+        next.exchange = Some("USD".to_owned());
+        next.historical = true;
+        fulfill(Command::ApplyOptions(next), &mut app, &mut ledger, &ctx);
+
+        assert_eq!(app.error_toast, None);
+        let rows = rows_of(&app, &ctx);
+        assert!(rows.iter().all(|row| !row.contains("EUR")), "{rows:?}");
+        // 110 USD plus 5 EUR at the 2 USD rate it was bought at.
+        assert!(rows.iter().any(|row| row.contains("120 USD")), "{rows:?}");
+    }
+
+    /// The selection, the tree state and the open register survive an options
+    /// change the same way they survive a reload.
+    #[test]
+    fn applying_options_keeps_the_ui_state() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let mut app = app_with(&ctx, &mut ledger, &options());
+        let scope = app
+            .balance
+            .rows
+            .iter()
+            .find(|row| row.full_name() == "Assets:Bank")
+            .map(|row| row.scope)
+            .expect("the fixture has Assets:Bank");
+        let rows = load_register(&mut ledger, &ctx, &app.query.template, scope).unwrap();
+        app.show_register(scope, rows);
+
+        let mut next = options();
+        next.end = Some(date(2025, 1, 1));
+        fulfill(Command::ApplyOptions(next), &mut app, &mut ledger, &ctx);
+
+        assert_eq!(app.error_toast, None);
+        assert_matches!(&app.screen, Screen::Register(view) => {
+            assert_eq!(view.title(), "Assets:Bank");
+            // Re-queried under the new range: the 2025 entry is gone.
+            assert_eq!(view.rows.len(), 2);
+        });
+    }
+
+    /// A commodity the file never mentions cannot be converted into. The
+    /// refusal leaves the report — and the options that describe it — alone.
+    #[test]
+    fn applying_an_unknown_commodity_keeps_the_old_report() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let before = options();
+        let mut app = app_with(&ctx, &mut ledger, &before);
+        let rows = rows_of(&app, &ctx);
+
+        let mut next = options();
+        next.exchange = Some("XYZ".to_owned());
+        assert_eq!(
+            fulfill(Command::ApplyOptions(next), &mut app, &mut ledger, &ctx),
+            Fulfilled::Continue
+        );
+
+        let toast = app.error_toast.as_deref().expect("a footer notice");
+        assert!(toast.contains("XYZ"), "{toast}");
+        assert_eq!(app.query.options, before);
+        assert_eq!(rows_of(&app, &ctx), rows);
+    }
+
+    /// The price DB is read while book-keeping, so a new one goes back to the
+    /// session loop — with the options attached, since the app is what crosses
+    /// that boundary.
+    #[test]
+    fn applying_a_price_db_asks_for_a_rebuild() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let mut app = app_with(&ctx, &mut ledger, &options());
+
+        let mut next = options();
+        next.price_db = Some("prices.db".into());
+        assert_eq!(
+            fulfill(
+                Command::ApplyOptions(next.clone()),
+                &mut app,
+                &mut ledger,
+                &ctx
+            ),
+            Fulfilled::Reload
+        );
+        assert_eq!(app.query.options, next);
+    }
+
+    /// A register the conversion cannot express is a notice, not the end of the
+    /// session: an up-to-date `-X` is unsupported there (see okane#313).
+    #[test]
+    fn a_register_the_conversion_cannot_express_only_warns() {
+        let arena = Bump::new();
+        let (ctx, mut ledger) = process(&arena, LEDGER);
+        let mut opts = options();
+        opts.exchange = Some("USD".to_owned()); // up-to-date, not historical
+        let mut app = app_with(&ctx, &mut ledger, &opts);
+        let scope = app
+            .balance
+            .rows
+            .iter()
+            .find(|row| row.full_name() == "Assets:Bank")
+            .map(|row| row.scope)
+            .expect("the fixture has Assets:Bank");
+
+        assert_eq!(
+            fulfill(Command::LoadRegister { scope }, &mut app, &mut ledger, &ctx),
+            Fulfilled::Continue
+        );
+        assert_matches!(&app.screen, Screen::Balance);
+        let toast = app.error_toast.as_deref().expect("a footer notice");
+        assert!(toast.contains("Assets:Bank"), "{toast}");
+    }
+}

--- a/cli/src/ui/report/help.rs
+++ b/cli/src/ui/report/help.rs
@@ -72,6 +72,7 @@ fn balance_sections() -> Vec<Section> {
             title: "Session",
             bindings: vec![
                 binding("r, F5", "reload the ledger from disk"),
+                binding(".", "change the query options"),
                 binding("?, F1", "this help"),
                 binding("q", "quit (asks to confirm)"),
                 binding("C-c", "quit immediately"),
@@ -87,6 +88,7 @@ fn register_sections() -> Vec<Section> {
             title: "Session",
             bindings: vec![
                 binding("r, F5", "reload the ledger from disk"),
+                binding(".", "change the query options"),
                 binding("?, F1", "this help"),
                 binding("q, Esc", "back to the balance screen"),
                 binding("C-c", "quit immediately"),
@@ -150,7 +152,7 @@ mod tests {
     use super::super::event::key_to_message;
     use super::super::register::RegisterScope;
     use super::super::search::{Search, SearchIntent, SearchMatch, SearchMode, SearchPhase};
-    use super::super::testing::{make_account, template};
+    use super::super::testing::{make_account, query_state};
 
     #[test]
     fn balance_help_lists_the_balance_only_keys() {
@@ -165,7 +167,7 @@ mod tests {
     fn register_help_omits_the_balance_only_keys() {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:Cash");
-        let mut app = App::new("test".to_owned(), Vec::new(), template());
+        let mut app = App::new("test".to_owned(), Vec::new(), query_state());
         app.show_register(RegisterScope::Single(account), Vec::new());
 
         let text = popup(&app.screen).lines.join("\n");
@@ -204,9 +206,9 @@ mod tests {
         let arena = Bump::new();
         let (_ctx, account) = make_account(&arena, "Assets:Cash");
 
-        let mut balance = App::new("test".to_owned(), Vec::new(), template());
+        let mut balance = App::new("test".to_owned(), Vec::new(), query_state());
         balance.balance.search = Some(fixed_search());
-        let mut register = App::new("test".to_owned(), Vec::new(), template());
+        let mut register = App::new("test".to_owned(), Vec::new(), query_state());
         register.show_register(RegisterScope::Single(account), Vec::new());
 
         for (app, sections) in [

--- a/cli/src/ui/report/options.rs
+++ b/cli/src/ui/report/options.rs
@@ -1,0 +1,316 @@
+//! The query the report session runs with: the owned [`QueryOptions`] the user
+//! states (on the command line, or in the `.` form) and the [`QueryState`] they
+//! resolve to against a session's [`ReportContext`].
+//!
+//! The two exist separately because they have different lifetimes. A
+//! [`Conversion`] names an interned commodity of one session's context, so it
+//! dies with the arena a reload resets; [`QueryOptions`] is plain owned data
+//! that crosses that boundary and is re-resolved against the session that
+//! follows — the same split [`UiSnapshot`](super::app::UiSnapshot) makes for
+//! the UI state.
+
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+use okane_core::report::query::{
+    AccountFilter, BalanceQuery, Conversion, ConversionStrategy, DateRange, QueryError,
+};
+use okane_core::report::{OwnedCommodity, ProcessOptions, ReportContext};
+
+use super::register::RegisterQueryTemplate;
+
+/// The report query as the user states it: the subset of the CLI's
+/// `EvalOptions` that decides *what the numbers are*, as fully owned data.
+///
+/// The TUI lets every field be changed mid-session through the `.` form. All
+/// but one are re-queried in place; [`Self::price_db`] feeds the book-keeping
+/// rather than the query, so changing it means processing the source again —
+/// see [`Self::needs_reprocess`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryOptions {
+    /// Path to the price DB, as `--price-db`.
+    pub price_db: Option<PathBuf>,
+    /// Commodity every amount is converted to, as `-X` / `--exchange`.
+    pub exchange: Option<String>,
+    /// Convert at the date of each transaction (`--historical`) rather than at
+    /// [`Self::today`]'s rate.
+    pub historical: bool,
+    /// The date "now" means, as `--today`. Not editable in the form: it is what
+    /// a non-historical conversion is dated at, and the CLI's default (the
+    /// local date) is the answer in a session someone is sitting in front of.
+    pub today: NaiveDate,
+    /// Start of the date range (inclusive), as `--start`.
+    pub start: Option<NaiveDate>,
+    /// End of the date range (exclusive), as `--end`.
+    pub end: Option<NaiveDate>,
+}
+
+impl QueryOptions {
+    pub fn to_process_options(&self) -> ProcessOptions {
+        ProcessOptions {
+            price_db_path: self.price_db.clone(),
+        }
+    }
+
+    pub fn date_range(&self) -> DateRange {
+        DateRange {
+            start: self.start,
+            end: self.end,
+        }
+    }
+
+    fn conversion_strategy(&self) -> ConversionStrategy {
+        if self.historical {
+            ConversionStrategy::Historical
+        } else {
+            ConversionStrategy::UpToDate { today: self.today }
+        }
+    }
+
+    /// Resolves these options against `ctx`, interning nothing: the target
+    /// commodity must already be known to the session, which it is for any
+    /// commodity the file (or its price DB) mentions. Fails with
+    /// [`QueryError::CommodityNotFound`] otherwise — the answer to `-X` on a
+    /// commodity that appears nowhere would be an empty report, not a report.
+    pub(super) fn resolve<'ctx>(
+        &self,
+        ctx: &ReportContext<'ctx>,
+    ) -> Result<QueryState<'ctx>, QueryError> {
+        let conversion = match &self.exchange {
+            None => None,
+            Some(commodity) => {
+                let target = ctx.commodity(commodity).ok_or_else(|| {
+                    QueryError::CommodityNotFound(OwnedCommodity::from_string(commodity.clone()))
+                })?;
+                Some(Conversion {
+                    strategy: self.conversion_strategy(),
+                    target,
+                })
+            }
+        };
+        Ok(QueryState {
+            options: self.clone(),
+            template: RegisterQueryTemplate {
+                conversion,
+                date_range: self.date_range(),
+            },
+        })
+    }
+
+    /// Whether moving from `current` to these options requires the source to be
+    /// processed again rather than merely re-queried. Only the price DB does:
+    /// the rates are read while book-keeping, so a session already built has no
+    /// way to acquire the new ones.
+    pub(super) fn needs_reprocess(&self, current: &Self) -> bool {
+        self.price_db != current.price_db
+    }
+
+    /// One-line summary for the status bar of the options that change what the
+    /// numbers *mean* — the conversion and the date range. `None` for the plain
+    /// report over the whole file, which needs no announcement.
+    ///
+    /// The price DB is deliberately left out: it is where the rates come from
+    /// rather than a lens on the report, and it only shows up here as the `-X`
+    /// it makes possible. The form is where to check it.
+    pub(super) fn summary(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(commodity) = &self.exchange {
+            parts.push(match self.historical {
+                true => format!("-X {commodity} (historical)"),
+                false => format!("-X {commodity}"),
+            });
+        }
+        if self.start.is_some() || self.end.is_some() {
+            parts.push(format!(
+                "{}..{}",
+                format_date(self.start),
+                format_date(self.end)
+            ));
+        }
+        (!parts.is_empty()).then(|| parts.join(" · "))
+    }
+}
+
+/// A date as the form types it and the status bar prints it; an open end of a
+/// range is left blank.
+pub(super) fn format_date(date: Option<NaiveDate>) -> String {
+    date.map(|d| d.format(DATE_FORMAT).to_string())
+        .unwrap_or_default()
+}
+
+/// The one date format, shared by the form's parser and its placeholder — the
+/// same ISO form `--start` / `--end` take on the command line.
+pub(super) const DATE_FORMAT: &str = "%Y-%m-%d";
+
+/// Parses a date the way the CLI flags do, reporting the expected shape.
+pub(super) fn parse_date(text: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(text, DATE_FORMAT)
+        .map_err(|_| format!("expected a date as YYYY-MM-DD, got `{text}`"))
+}
+
+/// [`QueryOptions`] resolved against one session's context: the options as
+/// stated, plus the `'ctx` query parameters derived from them.
+///
+/// Held by the [`App`](super::app::App) so the two can never drift: every path
+/// that changes the options builds a new state from them.
+#[derive(Debug, Clone)]
+pub struct QueryState<'ctx> {
+    pub options: QueryOptions,
+    /// Query parameters shared by every register lookup of the session.
+    pub template: RegisterQueryTemplate<'ctx>,
+}
+
+impl<'ctx> QueryState<'ctx> {
+    /// The state of a session that has no data to resolve against — the empty
+    /// session a failed reload leaves behind. The options are kept as stated
+    /// (the form opens on them, which is how a bad `--price-db` gets fixed),
+    /// but nothing is converted, since there is no context to intern against.
+    pub(super) fn unresolved(options: &QueryOptions) -> Self {
+        Self {
+            options: options.clone(),
+            template: RegisterQueryTemplate {
+                conversion: None,
+                date_range: options.date_range(),
+            },
+        }
+    }
+
+    /// The balance query for the whole ledger under these options. The account
+    /// filter is always [`AccountFilter::All`]: the balance screen shows every
+    /// account and narrows by folding and searching rather than by re-querying.
+    pub(super) fn balance_query(&self) -> BalanceQuery<'ctx> {
+        BalanceQuery {
+            account: AccountFilter::All,
+            conversion: self.template.conversion,
+            date_range: self.template.date_range,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use bumpalo::Bump;
+
+    use super::super::testing::{options, process};
+
+    fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    const LEDGER: &str = "2024/01/01 Init\n    Assets:Bank    10 USD\n    Equity\n";
+
+    #[test]
+    fn resolve_without_exchange_has_no_conversion() {
+        let arena = Bump::new();
+        let (ctx, _ledger) = process(&arena, LEDGER);
+        let state = options().resolve(&ctx).unwrap();
+        assert!(state.template.conversion.is_none());
+    }
+
+    #[test]
+    fn resolve_picks_the_strategy_from_historical() {
+        let arena = Bump::new();
+        let (ctx, _ledger) = process(&arena, LEDGER);
+
+        let mut opts = options();
+        opts.exchange = Some("USD".to_owned());
+        let state = opts.resolve(&ctx).unwrap();
+        assert_matches!(
+            state.template.conversion,
+            Some(Conversion {
+                strategy: ConversionStrategy::UpToDate { today },
+                ..
+            }) if today == date(2024, 6, 1)
+        );
+
+        opts.historical = true;
+        let state = opts.resolve(&ctx).unwrap();
+        assert_matches!(
+            state.template.conversion,
+            Some(Conversion {
+                strategy: ConversionStrategy::Historical,
+                ..
+            })
+        );
+    }
+
+    /// A commodity the ledger never mentions cannot be interned, and a report
+    /// converted into it would be empty rather than wrong — so it is refused.
+    #[test]
+    fn resolve_unknown_commodity_fails() {
+        let arena = Bump::new();
+        let (ctx, _ledger) = process(&arena, LEDGER);
+        let mut opts = options();
+        opts.exchange = Some("XYZ".to_owned());
+        assert_matches!(
+            opts.resolve(&ctx),
+            Err(QueryError::CommodityNotFound(commodity)) if commodity.to_string() == "XYZ"
+        );
+    }
+
+    #[test]
+    fn only_the_price_db_needs_a_reprocess() {
+        let current = options();
+        let mut next = current.clone();
+        next.exchange = Some("CHF".to_owned());
+        next.historical = true;
+        next.start = Some(date(2024, 1, 1));
+        next.end = Some(date(2025, 1, 1));
+        assert!(!next.needs_reprocess(&current));
+
+        next.price_db = Some(PathBuf::from("prices.db"));
+        assert!(next.needs_reprocess(&current));
+    }
+
+    #[test]
+    fn summary_of_the_plain_report_is_empty() {
+        let mut opts = options();
+        assert_eq!(opts.summary(), None);
+        // The price DB is a source of rates, not a lens: on its own it changes
+        // nothing about what the status bar has to explain.
+        opts.price_db = Some(PathBuf::from("prices.db"));
+        assert_eq!(opts.summary(), None);
+    }
+
+    #[test]
+    fn summary_names_the_conversion_and_the_range() {
+        let mut opts = options();
+        opts.exchange = Some("CHF".to_owned());
+        assert_eq!(opts.summary().as_deref(), Some("-X CHF"));
+        opts.historical = true;
+        assert_eq!(opts.summary().as_deref(), Some("-X CHF (historical)"));
+
+        opts.start = Some(date(2024, 1, 1));
+        assert_eq!(
+            opts.summary().as_deref(),
+            Some("-X CHF (historical) · 2024-01-01..")
+        );
+        opts.end = Some(date(2025, 1, 1));
+        assert_eq!(
+            opts.summary().as_deref(),
+            Some("-X CHF (historical) · 2024-01-01..2025-01-01")
+        );
+
+        let mut opts = options();
+        opts.end = Some(date(2025, 1, 1));
+        assert_eq!(opts.summary().as_deref(), Some("..2025-01-01"));
+    }
+
+    #[test]
+    fn parse_date_round_trips_the_printed_form() {
+        let d = date(2024, 12, 31);
+        assert_eq!(parse_date(&format_date(Some(d))), Ok(d));
+        assert_eq!(format_date(None), "");
+    }
+
+    #[test]
+    fn parse_date_rejects_other_shapes() {
+        // The ledger date style is not the flag's; be explicit about which one
+        // the form wants rather than guessing at the intent.
+        assert_matches!(parse_date("2024/12/31"), Err(msg) if msg.contains("YYYY-MM-DD"));
+        assert_matches!(parse_date("nonsense"), Err(_));
+    }
+}

--- a/cli/src/ui/report/overlay.rs
+++ b/cli/src/ui/report/overlay.rs
@@ -1,12 +1,15 @@
 //! Modal overlays drawn on top of the report screens.
 //!
-//! [`Overlay`] is the quit-confirmation prompt, or a scrollable [`TextPopup`]
-//! holding either the key help or a full error report — two bodies of text the
-//! user reads and dismisses, which is all the popup itself knows about them.
+//! [`Overlay`] is the quit-confirmation prompt, the query-options form, or a
+//! scrollable [`TextPopup`] holding either the key help or a full error report
+//! — two bodies of text the user reads and dismisses, which is all the popup
+//! itself knows about them.
 
 use std::cmp::{max, min};
 
 use crate::ui::table::NavCommand;
+
+use super::form::OptionsForm;
 
 /// A scroll request against a scrollable overlay body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -101,6 +104,8 @@ pub enum Overlay {
     Error(TextPopup),
     /// The key bindings of the screen it was opened from.
     Help(TextPopup),
+    /// The query options (`.`), open for editing.
+    Options(OptionsForm),
 }
 
 impl Overlay {
@@ -108,7 +113,7 @@ impl Overlay {
     pub fn scrollable_mut(&mut self) -> Option<&mut TextPopup> {
         match self {
             Overlay::Error(popup) | Overlay::Help(popup) => Some(popup),
-            Overlay::QuitConfirm => None,
+            Overlay::QuitConfirm | Overlay::Options(_) => None,
         }
     }
 }

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -34,10 +34,11 @@ use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::app::{App, Screen};
 use super::balance::{BalanceRow, BalanceView, DisplayMode};
+use super::form::{Field, OptionsForm};
 use super::overlay::{Overlay, TextPopup};
 use super::register::RegisterView;
 use super::search::{Search, SearchDirection, SearchMode, SearchPhase};
@@ -49,6 +50,13 @@ const STATUS_HELP_HINT: &str = " ? help ";
 const ERROR_POPUP_HINT: &str =
     " ↑/↓ scroll · PgUp/PgDn page · g/G top/end · r reload · Esc/Enter close · q quit ";
 const HELP_POPUP_HINT: &str = " ↑/↓ scroll · PgUp/PgDn page · Esc/q close ";
+const OPTIONS_POPUP_HINT: &str =
+    " Tab/↑↓ field · space toggle · C-u clear · Enter apply · Esc cancel ";
+
+/// Columns the form keeps for a value, wide enough for a date, a commodity and
+/// a short path — and, being fixed, wide enough that the highlighted row reads
+/// as the input box it is even when what is typed into it is short.
+const OPTIONS_VALUE_WIDTH: usize = 30;
 
 /// Colour that marks a redrawn (sticky) account label, so it never reads as a
 /// label the row itself owns.
@@ -88,6 +96,7 @@ pub fn draw<'ctx>(frame: &mut Frame, app: &mut App<'ctx>, ctx: &ReportContext<'c
         Some(Overlay::QuitConfirm) => draw_quit_confirm(frame, area),
         Some(Overlay::Error(popup)) => draw_text_popup(frame, area, popup, PopupKind::Error),
         Some(Overlay::Help(popup)) => draw_text_popup(frame, area, popup, PopupKind::Help),
+        Some(Overlay::Options(form)) => draw_options_form(frame, area, form),
         None => {}
     }
 }
@@ -401,6 +410,11 @@ fn draw_body_too_short(frame: &mut Frame, area: Rect, block: &Block) -> bool {
 /// `Register 12/40` — counted in accounts and register entries rather than in
 /// the table rows a multi-commodity one spans, which is what the reader is
 /// moving through with `J`/`K`.
+///
+/// Followed by the query the numbers were computed under, where it is not the
+/// plain one: a converted or date-bounded report looks exactly like a full one,
+/// and `.` can change it mid-session, so the line that says where you are also
+/// says what you are looking at.
 fn status_text(app: &App<'_>) -> String {
     let (label, nav) = match &app.screen {
         Screen::Balance => ("Account", &app.balance.nav),
@@ -409,7 +423,11 @@ fn status_text(app: &App<'_>) -> String {
     // The position is 1-based; an empty table has no position at all and says
     // so with a `0/0` rather than pretending to sit on a first item.
     let position = nav.selected_item().map_or(0, |item| item + 1);
-    format!(" {label} {position}/{} ", nav.item_count())
+    let count = nav.item_count();
+    match app.query.options.summary() {
+        Some(query) => format!(" {label} {position}/{count} · {query} "),
+        None => format!(" {label} {position}/{count} "),
+    }
 }
 
 /// The status bar: where the selection is, and — at the far end, where it
@@ -505,6 +523,117 @@ fn draw_quit_confirm(frame: &mut Frame, area: Rect) {
     ])
     .block(block);
     frame.render_widget(body, popup);
+}
+
+/// The query-options form (`.`): one row per option, the focused one drawn as
+/// the input box it is, and — where the last submit was refused — the reason
+/// under them in place of the key hint.
+///
+/// Unlike the text popups this is sized to its content in both directions and
+/// never scrolls: it has five rows, and a terminal too small for five rows is
+/// too small for the report behind them.
+fn draw_options_form(frame: &mut Frame, area: Rect, form: &OptionsForm) {
+    let label_width = form
+        .fields()
+        .iter()
+        .map(|field| layout_width(field.label()))
+        .max()
+        .unwrap_or(0);
+    // The rows are two columns and their gutters; the footer is one long line.
+    let body_width = label_width + OPTIONS_VALUE_WIDTH + 4;
+    let width = max(body_width, layout_width(OPTIONS_POPUP_HINT)) + 2; // borders
+    let height = form.fields().len() + 3; // borders + the footer line
+    let rect = centered_rect(area, saturating_u16(width), saturating_u16(height));
+    // Clear first so the popup paints over the table cleanly.
+    frame.render_widget(Clear, rect);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Query options ")
+        .style(Style::default().add_modifier(Modifier::BOLD));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    let layout = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+    let rows: Vec<Line> = form
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, field)| options_row(field, label_width, i == form.focus()))
+        .collect();
+    frame.render_widget(
+        Paragraph::new(rows).style(Style::default().remove_modifier(Modifier::BOLD)),
+        layout[0],
+    );
+
+    let footer = match form.error() {
+        Some(err) => Paragraph::new(format!(" {err} ")).style(Style::default().fg(Color::Red)),
+        None => {
+            Paragraph::new(OPTIONS_POPUP_HINT).style(Style::default().add_modifier(Modifier::DIM))
+        }
+    };
+    frame.render_widget(footer, layout[1]);
+
+    // The cursor sits after the last typed character of the focused row, which
+    // is also what tells a value apart from the placeholder standing in for it.
+    // A value too long for the box is scrolled, so the cursor stops at its end.
+    let field = &form.fields()[form.focus()];
+    if field.is_text() {
+        let typed = min(layout_width(field.text()), options_value_columns());
+        let x = layout[0].x + saturating_u16(label_width + 3 + typed);
+        let x = min(x, layout[0].x + layout[0].width.saturating_sub(1));
+        frame.set_cursor_position((x, layout[0].y + saturating_u16(form.focus())));
+    }
+}
+
+/// Columns of text the value box holds, inside its one-space padding.
+fn options_value_columns() -> usize {
+    OPTIONS_VALUE_WIDTH.saturating_sub(2)
+}
+
+/// One row of the form: `--flag   value`, with the value drawn as a
+/// fixed-width box so the focused row's highlight has a shape, and an unset
+/// value replaced by its dim placeholder.
+fn options_row(field: &Field, label_width: usize, focused: bool) -> Line<'static> {
+    let label = format!(
+        " {}{}  ",
+        field.label(),
+        " ".repeat(label_width.saturating_sub(layout_width(field.label())))
+    );
+    let (text, dim) = match field.text() {
+        "" => (field.placeholder(), true),
+        text => (text, false),
+    };
+    // A path longer than the box scrolls: the tail is where the typing is
+    // happening, and clipping it at the border would hide exactly that.
+    let text = tail(text, options_value_columns());
+    let value = format!(
+        " {text}{} ",
+        " ".repeat(options_value_columns().saturating_sub(layout_width(text)))
+    );
+    let mut value_style = Style::default();
+    if dim {
+        value_style = value_style.add_modifier(Modifier::DIM);
+    }
+    if focused {
+        value_style = value_style.add_modifier(Modifier::REVERSED);
+    }
+    Line::from(vec![Span::raw(label), Span::styled(value, value_style)])
+}
+
+/// The last `columns` display columns of `text`, cut on a character boundary.
+/// The whole of it when it already fits.
+fn tail(text: &str, columns: usize) -> &str {
+    let mut width = 0;
+    let mut start = text.len();
+    for (i, c) in text.char_indices().rev() {
+        width += UnicodeWidthChar::width(c).unwrap_or(0);
+        if width > columns {
+            break;
+        }
+        start = i;
+    }
+    &text[start..]
 }
 
 /// What a [`TextPopup`] is showing: it decides the frame color and the hint
@@ -770,9 +899,10 @@ mod tests {
 
     use super::super::app::Message;
     use super::super::balance::BalanceMessage;
+    use super::super::form::FormMessage;
     use super::super::overlay::ScrollDelta;
     use super::super::register::{RegisterMessage, RegisterQueryTemplate};
-    use super::super::testing::template;
+    use super::super::testing::{query_state, template};
     use crate::ui::table::NavCommand;
 
     #[test]
@@ -815,7 +945,7 @@ mod tests {
 
     #[test]
     fn status_of_an_empty_screen_has_no_position() {
-        let app = App::new("test.ledger".to_owned(), Vec::new(), template());
+        let app = App::new("test.ledger".to_owned(), Vec::new(), query_state());
         assert_eq!(status_text(&app), " Account 0/0 ");
     }
 
@@ -997,6 +1127,17 @@ mod tests {
         }
     }
 
+    /// A value longer than the form's box shows its end: that is where the
+    /// cursor is and what was just typed.
+    #[test]
+    fn tail_keeps_the_end_of_a_long_value() {
+        assert_eq!(tail("short", 10), "short");
+        assert_eq!(tail("/home/user/ledger/prices.db", 10), "/prices.db");
+        // Cut on a character boundary, never inside one.
+        assert_eq!(tail("ドルの価格", 4), "価格");
+        assert_eq!(tail("", 10), "");
+    }
+
     #[test]
     fn centered_rect_sits_in_the_middle() {
         let area = Rect {
@@ -1087,14 +1228,7 @@ mod tests {
 
     /// The state a failed reload leaves behind: no rows, error modal up.
     fn app_with_error_modal<'ctx>() -> App<'ctx> {
-        let mut app = App::new(
-            "test.ledger".to_owned(),
-            Vec::new(),
-            RegisterQueryTemplate {
-                conversion: None,
-                date_range: DateRange::default(),
-            },
-        );
+        let mut app = App::new("test.ledger".to_owned(), Vec::new(), query_state());
         let lines = (0..40).map(|i| format!("error line {i}")).collect();
         app.overlay = Some(Overlay::Error(TextPopup::new(
             " failed to load test.ledger ".to_owned(),
@@ -1135,12 +1269,57 @@ mod tests {
         golden(name).assert(&render(&mut app, &ctx));
     }
 
+    /// The query-options form over the balance screen: every option on its own
+    /// row, the focused one as an input box, and the placeholders standing in
+    /// for what is unset.
+    #[test]
+    fn render_options_form() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        app.update(Message::ShowOptions);
+        golden("render_options_form").assert(&render(&mut app, &ctx));
+    }
+
+    /// A refused submit keeps the form up and replaces the key hint with the
+    /// reason, so the row that is wrong is still on screen next to it.
+    #[test]
+    fn render_options_form_with_a_bad_date() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        app.update(Message::ShowOptions);
+        app.update(Message::Form(FormMessage::FocusNext)); // --historical
+        app.update(Message::Form(FormMessage::FocusNext)); // --start
+        for c in "last week".chars() {
+            app.update(Message::Form(FormMessage::Push(c)));
+        }
+        app.update(Message::Form(FormMessage::Submit));
+        golden("render_options_form_error").assert(&render(&mut app, &ctx));
+    }
+
+    /// A converted, date-bounded report looks exactly like a plain one, so the
+    /// status bar says which one it is.
+    #[test]
+    fn status_bar_names_a_non_default_query() {
+        let arena = Bump::new();
+        let (ctx, mut app) = many_commodities_balance(&arena);
+        assert!(!status_text(&app).contains('·'), "{}", status_text(&app));
+
+        app.query.options.exchange = Some("CHF".to_owned());
+        app.query.options.start = Some(chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        let out = render(&mut app, &ctx);
+        let status = out.lines().last().expect("a status line");
+        assert!(status.contains("-X CHF"), "{status:?}");
+        assert!(status.contains("2024-01-01.."), "{status:?}");
+        // The help hint keeps its place at the far end.
+        assert!(status.trim_end().ends_with("? help"), "{status:?}");
+    }
+
     /// The help is drawn without wrapping, so a description longer than the
     /// screen is silently cut. The popup sizes itself to its text, which means
     /// the check is that the text still fits a plain 80-column terminal.
     #[test]
     fn help_fits_an_eighty_column_terminal() {
-        let mut app = App::new("test.ledger".to_owned(), Vec::new(), template());
+        let mut app = App::new("test.ledger".to_owned(), Vec::new(), query_state());
         app.update(Message::ShowHelp);
         let Some(Overlay::Help(popup)) = &app.overlay else {
             panic!("expected the help overlay");
@@ -1173,14 +1352,7 @@ mod tests {
     fn render_error_modal_parses_ansi_colors() {
         let arena = Bump::new();
         let ctx = ReportContext::new(&arena);
-        let mut app = App::new(
-            "test.ledger".to_owned(),
-            Vec::new(),
-            RegisterQueryTemplate {
-                conversion: None,
-                date_range: DateRange::default(),
-            },
-        );
+        let mut app = App::new("test.ledger".to_owned(), Vec::new(), query_state());
         app.overlay = Some(Overlay::Error(TextPopup::new(
             " failed to load test.ledger ".to_owned(),
             vec!["\u{1b}[32mgreen\u{1b}[0m plain".to_owned()],
@@ -1254,7 +1426,7 @@ mod tests {
         };
         let balance = ledger.balance(&ctx, &query).unwrap().into_owned();
         let tree = BalanceTree::create(&ctx, balance).unwrap().into_nodes();
-        let app = App::new(source_display(input), tree, template());
+        let app = App::new(source_display(input), tree, query_state());
         (ctx, app)
     }
 
@@ -1282,8 +1454,8 @@ mod tests {
             .expect("fixture ledger has at least one account");
         let scope = RegisterScope::Single(account);
         let rows =
-            super::super::event::load_register(&mut ledger, &ctx, &template(), scope).unwrap();
-        let mut app = App::new(source_display(input), Vec::new(), template());
+            super::super::fulfill::load_register(&mut ledger, &ctx, &template(), scope).unwrap();
+        let mut app = App::new(source_display(input), Vec::new(), query_state());
         app.show_register(scope, rows);
         (ctx, app)
     }
@@ -1307,7 +1479,7 @@ mod tests {
         };
         let balance = ledger.balance(&ctx, &query).unwrap().into_owned();
         let tree = BalanceTree::create(&ctx, balance).unwrap().into_nodes();
-        let mut app = App::new(source_display(input), tree, template());
+        let mut app = App::new(source_display(input), tree, query_state());
         // Tree view is what turns balance rows into `RegisterScope::Subtree`.
         app.update(Message::Balance(BalanceMessage::ToggleTree));
         // The first parent row (a real ancestor) exercises `descendants_of`
@@ -1320,7 +1492,7 @@ mod tests {
             .map(|r| r.scope)
             .expect("fixture has at least one parent account");
         let rows =
-            super::super::event::load_register(&mut ledger, &ctx, &template(), scope).unwrap();
+            super::super::fulfill::load_register(&mut ledger, &ctx, &template(), scope).unwrap();
         app.show_register(scope, rows);
         (ctx, app)
     }
@@ -1564,9 +1736,10 @@ mod tests {
             date_range: DateRange::default(),
         };
         let scope = super::super::register::RegisterScope::Single(account);
-        let rows = super::super::event::load_register(&mut ledger, &ctx, &template, scope).unwrap();
+        let rows =
+            super::super::fulfill::load_register(&mut ledger, &ctx, &template, scope).unwrap();
         assert_eq!(rows.len(), n);
-        let mut app = App::new("test.ledger".to_owned(), Vec::new(), template);
+        let mut app = App::new("test.ledger".to_owned(), Vec::new(), query_state());
         app.show_register(scope, rows);
         (ctx, app)
     }

--- a/cli/src/ui/report/testing.rs
+++ b/cli/src/ui/report/testing.rs
@@ -7,11 +7,13 @@
 use std::path::PathBuf;
 
 use bumpalo::Bump;
+use chrono::NaiveDate;
 use maplit::hashmap;
 use okane_core::load;
 use okane_core::report::query::{DateRange, Ledger};
 use okane_core::report::{self, Account, ReportContext};
 
+use super::options::{QueryOptions, QueryState};
 use super::register::RegisterQueryTemplate;
 
 /// A register query template with no conversion over the full date range.
@@ -20,6 +22,24 @@ pub(super) fn template<'ctx>() -> RegisterQueryTemplate<'ctx> {
         conversion: None,
         date_range: DateRange::default(),
     }
+}
+
+/// The plain query — no conversion, no date bounds — dated at a fixed day, so
+/// nothing that renders it depends on when the test runs.
+pub(super) fn options() -> QueryOptions {
+    QueryOptions {
+        price_db: None,
+        exchange: None,
+        historical: false,
+        today: NaiveDate::from_ymd_opt(2024, 6, 1).expect("a valid date"),
+        start: None,
+        end: None,
+    }
+}
+
+/// [`options`] as the state an [`super::app::App`] is built with.
+pub(super) fn query_state<'ctx>() -> QueryState<'ctx> {
+    QueryState::unresolved(&options())
 }
 
 /// A [`load::Loader`] over a single in-memory `test.ledger` holding `content`.

--- a/testdata/report/ui/render_help_balance.txt
+++ b/testdata/report/ui/render_help_balance.txt
@@ -20,5 +20,5 @@
 │       │                                                              │ STOCKP│
 │       │ Session                                                      │ STOCKQ│
 │       │   r, F5                    reload the ledger from disk       │+9 more│
-└───────│ ↑/↓ scroll · PgUp/PgDn page · Esc/q close               1/24 │───────┘
+└───────│ ↑/↓ scroll · PgUp/PgDn page · Esc/q close               1/25 │───────┘
  Account└──────────────────────────────────────────────────────────────┘ ? help 

--- a/testdata/report/ui/render_help_register.txt
+++ b/testdata/report/ui/render_help_register.txt
@@ -12,12 +12,12 @@
 │          │                                                       │5000.00 CHF│
 │          │ Session                                               │0000.00 USD│
 │          │   r, F5                    reload the ledger from disk│8000.00 EUR│
-│          │   ?, F1                    this help                  │3000.00 AUD│
-│          │   q, Esc                   back to the balance screen │5000.00 TWD│
-│2024-01-27│   C-c                      quit immediately           │ 992000 JPY│
-│          │ ↑/↓ scroll · PgUp/PgDn page · Esc/q close        1/12 │5000.00 CHF│
-│          └───────────────────────────────────────────────────────┘9800.00 USD│
-│                                                                   8000.00 EUR│
+│          │   .                        change the query options   │3000.00 AUD│
+│          │   ?, F1                    this help                  │5000.00 TWD│
+│2024-01-27│   q, Esc                   back to the balance screen │ 992000 JPY│
+│          │   C-c                      quit immediately           │5000.00 CHF│
+│          │ ↑/↓ scroll · PgUp/PgDn page · Esc/q close        1/13 │9800.00 USD│
+│          └───────────────────────────────────────────────────────┘8000.00 EUR│
 │                                                                   3000.00 AUD│
 │                                                                 195000.00 TWD│
 └──────────────────────────────────────────────────────────────────────────────┘

--- a/testdata/report/ui/render_options_form.txt
+++ b/testdata/report/ui/render_options_form.txt
@@ -1,0 +1,24 @@
+ okane ui — many_commodities.ledger                                             
+┌──────────────────────────────────────────────────────────────────────────────┐
+│Account                                                        Amount         │
+│(total)                                                          -29250.00 USD│
+│                                                                     10 STOCKA│
+│                                                                     10 STOCKB│
+│                                                                     10 STOCKC│
+│                                                                     10 STOCKD│
+│    ┌ Query options ─────────────────────────────────────────────────────┐OCKE│
+│    │ -X, --exchange   (none)                                            │OCKF│
+│    │ --historical     off                                               │OCKG│
+│    │ --start          YYYY-MM-DD                                        │OCKH│
+│    │ --end            YYYY-MM-DD                                        │OCKI│
+│    │ --price-db       (none)                                            │OCKJ│
+│    │ Tab/↑↓ field · space toggle · C-u clear · Enter apply · Esc cancel │OCKK│
+│    └────────────────────────────────────────────────────────────────────┘OCKL│
+│                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                       +9 more│
+└──────────────────────────────────────────────────────────────────────────────┘
+ Account 1/9                                                             ? help 

--- a/testdata/report/ui/render_options_form_error.txt
+++ b/testdata/report/ui/render_options_form_error.txt
@@ -1,0 +1,24 @@
+ okane ui — many_commodities.ledger                                             
+┌──────────────────────────────────────────────────────────────────────────────┐
+│Account                                                        Amount         │
+│(total)                                                          -29250.00 USD│
+│                                                                     10 STOCKA│
+│                                                                     10 STOCKB│
+│                                                                     10 STOCKC│
+│                                                                     10 STOCKD│
+│    ┌ Query options ─────────────────────────────────────────────────────┐OCKE│
+│    │ -X, --exchange   (none)                                            │OCKF│
+│    │ --historical     off                                               │OCKG│
+│    │ --start          last week                                         │OCKH│
+│    │ --end            YYYY-MM-DD                                        │OCKI│
+│    │ --price-db       (none)                                            │OCKJ│
+│    │ --start: expected a date as YYYY-MM-DD, got `last week`            │OCKK│
+│    └────────────────────────────────────────────────────────────────────┘OCKL│
+│                                                                     10 STOCKM│
+│                                                                     10 STOCKN│
+│                                                                     10 STOCKO│
+│                                                                     10 STOCKP│
+│                                                                     10 STOCKQ│
+│                                                                       +9 more│
+└──────────────────────────────────────────────────────────────────────────────┘
+ Account 1/9                                                             ? help 


### PR DESCRIPTION
Closes #551.

`okane ui` could only be told what to report on the command line: to convert into another commodity, bound the dates, or point at a price DB you had to quit and start over. `.` now opens a form over those same options and `Enter` applies it.

```
┌ Query options ─────────────────────────────────────────────────────┐
│ -X, --exchange   CHF                                               │
│ --historical     on                                                │
│ --start          2024-01-01                                        │
│ --end            YYYY-MM-DD                                        │
│ --price-db       (none)                                            │
│ Tab/↑↓ field · space toggle · C-u clear · Enter apply · Esc cancel │
└────────────────────────────────────────────────────────────────────┘
```

## What it does

- `.` (on either screen) opens the form; there is no editing mode, so every printable key is text for the focused row and only `Tab`/arrows/`Enter`/`Esc` do anything else. `space` toggles `--historical`, `C-u` empties a row (which is how a conversion or a range is taken back off).
- Applying keeps your place: selection, flat/tree mode, fold state, search and an open register all survive, re-resolved against the new numbers exactly the way a reload restores them.
- The status bar names the options in effect (`Account 3/57 · -X CHF (historical) · 2024-01-01..`), because a converted or date-bounded report otherwise looks exactly like a full one.
- Refusals leave the report alone: an unparseable date keeps the form open on the offending row with the reason under it, and a commodity the file never mentions closes it with a footer notice while the previous report — and the options that describe it — stay put.

## How it works

Applying only *re-queries*: the balance is recomputed against the `Ledger` already in memory and the whole view rebuilt from it through the same snapshot/restore path a reload uses, so nothing is re-parsed (`build_app` is that shared step, factored out of `build_session`). `--price-db` is the one exception — the rates are read while book-keeping — so it goes back through the session loop as a rebuild, carrying the new options on the app the way the UI state already crosses that boundary.

`EvalOptions` gains `to_query_options()`; the UI's `SessionConfig` now takes one owned `QueryOptions` instead of three separate pieces, and `--current` is resolved into an explicit end date on the way in (the form shows dates).

## Fixed along the way

`-X` without `--historical` is unsupported for the register query (#313), and pressing `Enter` under it used to propagate the error out of the event loop and take the whole TUI down. Command fulfillment is now infallible: this is a footer notice like every other failure that leaves the report intact. Much easier to hit now that `-X` can be turned on from inside the session.

## On #425 / #426

- **#426** is addressed: the third `Command` variant landed, and `fulfill` moved out of `event.rs` into its own module, which is exactly what that issue asked for when it did. `Command::Recompute` is here as `ApplyOptions`; `WriteFile` / `OpenInPager` still have no caller, so they are still not built.
- **#425** looks already satisfied to me rather than pending: `App::update` is a ~40-line router and `BalanceView` / `RegisterView` are components with their own state, `update` and `key_to_message`. The form is a third one of the same shape (`OptionsForm` + `FormMessage` + `FormAction`), so this continues the pattern instead of needing a refactor. Happy to close it, or leave it for whenever a third *screen* shows up.

## Testing

`cargo test`, `cargo clippy --all-targets` clean. New unit tests cover the options data (resolution, reprocess detection, status summary), the form (typing, toggling, clearing, refused submits, key mapping), the fulfillment paths (in-place re-query, UI state kept, unknown commodity refused, price DB asking for a rebuild, register failure warning only), and the routing through `App`/`event`. Two new goldens draw the form and its error state; the help goldens gained the `.` line.

Also driven end to end through a real pty: `.` → `USD` → `Tab` → `space` → `Enter` converts `10 USD + 5 EUR @ 2 USD` to `20 USD` with `· -X USD (historical)` in the status bar, and the unknown-commodity case shows the notice instead of dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
