### PR TITLE
cli: recursive `okane format` with --check, driven by a core `Emitter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,48 @@
 
 ### Added
 
+* CLI: `okane format` (alias `fmt`) now formats recursively and in place, following `include`
+  directives (https://github.com/xkikeg/okane/issues/529). With `--check` it prints a unified diff
+  instead of writing, and exits with 1 if any file is not formatted, so it can be used as a Git
+  hook or a CI check. The previous single-file-to-stdout behaviour is available as
+  `okane primitive format`.
+* CLI: `okane primitive format` takes `--commodity-format '[COMMODITY=]SAMPLE'`, e.g.
+  `--commodity-format 'CHF=1,000.00'`, to say how an amount is printed. It does not follow
+  `include`, so the `commodity ... format` directives written elsewhere have to be given this way.
+* Core: added `format::format_recursively()`, formatting a file and everything it `include`s, and
+  reporting each result as a `format::FormattedFile` to a `format::Emitter`. The emitter decides
+  what happens to it — write it back, print the difference, count the files — which is what the two
+  modes of `okane format` are.
+* Core: added `load::Loader::list_files()`, returning every file reachable from the source through
+  `include`, deduplicated and in load order, and `load::Loader::scan_files()`, doing the same while
+  reporting every parsed entry on the way.
+* Core: added `syntax::display::DisplayContextBuilder`, deriving a `DisplayContext` out of the
+  `commodity ... format` directives and the amounts of the Ledger itself, and
+  `format::FormatOptions::with_display_context()` to format with it.
+
 ### Changed
 
+* Core: removed `format::FormatOptions::recursive()` and
+  `format::FormatError::UnsupportedRecursiveFormat`, which were stubs for this feature.
+  `FormatOptions` formats one file; the recursion lives in `format::format_recursively()`.
+* CLI: `okane format` decides how to print an amount per commodity, looking at the whole tree of
+  files first. Expect a large one-off diff on the first run.
+    * `commodity ... format` directives now take effect, wherever they are declared. They were
+      silently ignored before.
+    * A commodity without such a directive follows the amounts written for it: the widest scale
+      wins, so `1.5 CHF` becomes `1.50 CHF` if some other CHF amount has two decimals, and one
+      `1,234.00 CHF` anywhere makes every CHF amount over a thousand comma separated.
+    * Only the posting amounts and the balance assertions are looked at that way. The costs (`@`,
+      `@@`) and the lot prices are printed with the resulting format but do not decide it, as an
+      exchange rate routinely carries more digits than the commodity itself.
+    * The amounts without a commodity, e.g. `= 0`, are left alone.
+    * Consequently `okane format` and `okane primitive format` may print the same file differently,
+      which is what `--commodity-format` is for.
+
 ### Fixed
+
+* Core: comments under an `account` or `commodity` directive no longer gain a space on every
+  format, which kept formatting from being idempotent.
 
 ## [0.21.0] - 2026-08-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Winnow-based recursive-descent parser. `parse::parse_ledger()` is the public ent
 
 ### `core/src/load.rs`
 
-`Loader<F: FileSystem>` reads a file and resolves `include` directives recursively. A `FakeFileSystem` impl is provided for testing (avoids touching real disk). Arena-allocated via `bumpalo`.
+`Loader<F: FileSystem>` reads a file and resolves `include` directives recursively. `load()` reports every entry (swallowing the `include` directives themselves); `list_files()` / `scan_files()` instead report the reachable file paths, which is what `okane format` walks to format a whole tree. A `FakeFileSystem` impl is provided for testing (avoids touching real disk). Arena-allocated via `bumpalo`.
 
 ### `core/src/report/`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "serde_with",
  "shadow-rs",
  "shlex",
+ "similar",
  "soft-canonicalize",
  "strum",
  "tempfile",
@@ -2865,6 +2866,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ log = "0.4"
 pretty_decimal = { version = "0.2.1", features = ["bounded-static"] }
 regex = "1.12"
 rust_decimal = "1.42"
+similar = "2.7"
 strum = { version = "0.28", features = ["derive"] }
+tempfile = "3.27.0"
 thiserror = "2.0"
 unicode-width = "0.2"
 winnow = "1.0"

--- a/README.ja.md
+++ b/README.ja.md
@@ -73,9 +73,35 @@ $ okane ui --start 2024-01-01 --end 2025-01-01 /path/to/file.ledger
 
 ```shell
 $ okane format ~/ledger/account.ledger
+$ okane fmt ~/ledger/account.ledger      # 同じ意味です
 ```
 
-現在は整形済みのテキストを標準出力に吐くだけになっています。近々inplaceの置換やdiffモード、recursiveオプションを実装したいと思っています。
+指定したファイルと、そこから `include` で辿れるファイルすべてを、その場で書き換えます。
+
+金額の表示方法は通貨ごとに、ファイル全体を見た上で決まります。`commodity ... format` ディレクティブはどのファイルで宣言されていても効き、宣言のない通貨は実際に書かれている金額に合わせるので、同じ通貨はどこでも同じ見た目になります。
+
+```ledger
+commodity JPY
+    format 1,000 JPY
+```
+
+`--check` を付けると何も書き込まず、代わりに変更内容をunified diff形式で表示し、整形されていないファイルがあれば終了コード `1` を返します。Gitのhookやテストとして使えます。
+
+```shell
+$ okane format --check ~/ledger/account.ledger || echo "okane format を実行してください"
+```
+
+`include` を辿らずに、1ファイルだけ整形して標準出力に吐くには次のようにします。
+
+```shell
+$ okane primitive format ~/ledger/account.ledger
+```
+
+こちらは通貨の設定を一切探さず、金額は書かれたままの形式で出力します。指定したい場合はフラグを使ってください。
+
+```shell
+$ okane primitive format --commodity-format 'CHF=1,000.00' ~/ledger/account.ledger
+```
 
 ### CSV / ISO Camt053 XMLファイルの取り込み
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,43 @@ Whichever ones are in effect are shown in the status bar.
 
 ```shell
 $ okane format ~/ledger/account.ledger
+$ okane fmt ~/ledger/account.ledger      # same thing
 ```
 
-This command currently prints the formatted output into standard output.
-In future in-place format would be provided, also to emit diffs to be used as Git hook.
+This rewrites the given file in place, together with every file it pulls in through
+`include` directives.
+
+How an amount is printed is decided per commodity, over the whole set of files: the
+`commodity ... format` directives are honoured wherever they are declared, and a
+commodity without one follows the amounts written for it, so that the same commodity
+looks the same everywhere.
+
+```ledger
+commodity JPY
+    format 1,000 JPY
+```
+
+With `--check` it writes nothing and instead prints a unified diff of the changes it
+would make, exiting with `1` if any file is not formatted. That makes it usable as a
+Git hook or a CI check:
+
+```shell
+$ okane format --check ~/ledger/account.ledger || echo "run okane format"
+```
+
+To format a single file and print the result to standard output instead, without
+following `include`:
+
+```shell
+$ okane primitive format ~/ledger/account.ledger
+```
+
+That one does not look for the commodity settings at all, and prints every amount the
+way it is written, unless it is told how to:
+
+```shell
+$ okane primitive format --commodity-format 'CHF=1,000.00' ~/ledger/account.ledger
+```
 
 ### Import CSV or ISO Camt053 XML files
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,8 +41,10 @@ rust_decimal.workspace = true
 serde = { version = "1.0", features = [ "derive" ] }
 serde_with = { version = "3.21", features = [ "chrono" ] }
 shadow-rs = { version = "2.0.0", default-features = false }
+similar.workspace = true
 soft-canonicalize = { version = "0.5.6", features = [ "dunce" ] }
 strum.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
 winnow.workspace = true
@@ -61,7 +63,7 @@ rstest.workspace = true
 rust_decimal_macros.workspace = true
 serde_test = "1.0"
 shlex = "2.0"
-tempfile = "3.27.0"
+tempfile.workspace = true
 
 [build-dependencies]
 shadow-rs = "2.0.0"

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use anyhow::Context as _;
 use bumpalo::Bump;
@@ -10,7 +12,7 @@ use clap::{Args, Subcommand};
 use lender::FallibleLender;
 use okane_core::report::query;
 use okane_core::syntax::Separation;
-use okane_core::syntax::display::DisplayContext;
+use okane_core::syntax::display::{CommodityDisplayOption, DisplayContext, DisplayContextBuilder};
 use okane_core::syntax::plain::LedgerEntry;
 use okane_core::{load, report};
 
@@ -36,7 +38,7 @@ impl Cli {
         self.command.validate()
     }
 
-    pub fn run<W>(self, w: &mut W) -> anyhow::Result<()>
+    pub fn run<W>(self, w: &mut W) -> anyhow::Result<ExitCode>
     where
         W: std::io::Write,
     {
@@ -48,7 +50,8 @@ impl Cli {
 pub enum Command {
     /// Import other format into ledger.
     Import(ImportCmd),
-    /// Format the given file (in future it'll work without file arg)
+    /// Format the ledger file and all the files it includes, in place.
+    #[command(alias = "fmt")]
     Format(FormatCmd),
     /// List all accounts in the file.
     Accounts(AccountsCmd),
@@ -74,20 +77,23 @@ impl Command {
         }
     }
 
-    pub fn run<W>(self, w: &mut W) -> anyhow::Result<()>
+    pub fn run<W>(self, w: &mut W) -> anyhow::Result<ExitCode>
     where
         W: std::io::Write,
     {
+        // `format --check` is the only command reporting its outcome through
+        // the exit code; everything else fails by returning an error.
         match self {
+            Command::Format(cmd) => return cmd.run(w),
             Command::Import(cmd) => cmd.run(w),
-            Command::Format(cmd) => cmd.run(w),
             Command::Accounts(cmd) => cmd.run(w),
             Command::Tags(cmd) => cmd.run(w),
             Command::Balance(cmd) => cmd.run(w),
             Command::Register(cmd) => cmd.run(w),
             Command::Ui(cmd) => cmd.run(),
             Command::Primitive(cmd) => cmd.run(w),
-        }
+        }?;
+        Ok(ExitCode::SUCCESS)
     }
 }
 
@@ -199,10 +205,87 @@ impl ImportCmd {
 
 #[derive(Args, Debug)]
 pub struct FormatCmd {
+    /// Ledger file to format, together with every file it includes.
     pub source: PathBuf,
+
+    /// Print a unified diff of the changes instead of writing them,
+    /// and exit with 1 if any file is not formatted.
+    #[arg(long)]
+    pub check: bool,
 }
 
 impl FormatCmd {
+    pub fn run<W>(&self, w: &mut W) -> anyhow::Result<ExitCode>
+    where
+        W: std::io::Write,
+    {
+        let loader = load::new_loader(self.source.clone());
+        if !self.check {
+            okane_core::format::format_recursively(&loader, &mut format::WriteBack)?;
+            return Ok(ExitCode::SUCCESS);
+        }
+        let mut emitter = format::WriteDiff::new(w);
+        okane_core::format::format_recursively(&loader, &mut emitter)?;
+        if emitter.has_diff() {
+            Ok(ExitCode::FAILURE)
+        } else {
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct PrimitiveFormatCmd {
+    pub source: PathBuf,
+
+    /// How to print the amount of a commodity, given as a sample amount,
+    /// e.g. `--commodity-format 'CHF=1,000.00'` prints CHF with a thousands
+    /// separator and two decimals.
+    ///
+    /// Without the `COMMODITY=` prefix the sample applies to every commodity,
+    /// including the amounts written without one. The flag can be repeated, and
+    /// the last sample given for a commodity wins.
+    ///
+    /// Note a sample without decimals, e.g. `CHF=1000`, does drop the trailing
+    /// zeros of the amounts having them.
+    ///
+    /// Unlike `okane format`, this command does not follow `include`, so the
+    /// `commodity ... format` directives declared in another file have no
+    /// effect here and have to be given through this flag.
+    #[arg(long, value_name = "[COMMODITY=]SAMPLE", value_parser = parse_commodity_format)]
+    pub commodity_format: Vec<CommodityFormat>,
+}
+
+/// One `--commodity-format` value, where `commodity` `None` means the default.
+#[derive(Clone, Debug)]
+pub struct CommodityFormat {
+    commodity: Option<String>,
+    option: CommodityDisplayOption,
+}
+
+/// Parses a `[COMMODITY=]SAMPLE` value of the `--commodity-format` flag.
+///
+/// A commodity can't contain `=`, so the first one always separates the two.
+fn parse_commodity_format(value: &str) -> Result<CommodityFormat, String> {
+    let (commodity, sample) = match value.split_once('=') {
+        Some(("", _)) => return Err("commodity must not be empty".to_string()),
+        Some((commodity, sample)) => (Some(commodity.to_string()), sample),
+        None => (None, value),
+    };
+    let sample: pretty_decimal::PrettyDecimal = sample
+        .parse()
+        .map_err(|err| format!("invalid sample amount {:?}: {}", sample, err))?;
+    Ok(CommodityFormat {
+        commodity,
+        option: CommodityDisplayOption {
+            format: sample.format,
+            // Decimal caps the scale at 28, so the conversion can't fail.
+            min_scale: Some(sample.scale().try_into().unwrap_or(u8::MAX)),
+        },
+    })
+}
+
+impl PrimitiveFormatCmd {
     pub fn run<W>(&self, w: &mut W) -> anyhow::Result<()>
     where
         W: std::io::Write,
@@ -211,8 +294,32 @@ impl FormatCmd {
             File::open(&self.source)
                 .with_context(|| format!("failed to open {}", self.source.display()))?,
         );
-        format::format(&mut r, w)?;
+        self.format_options().format(&mut r, w)?;
         Ok(())
+    }
+
+    /// Returns the options out of the `--commodity-format` flags alone.
+    ///
+    /// Deliberately no scan pass here: this command works on the given file
+    /// only, so the caller is the one to know the commodity formats.
+    fn format_options(&self) -> okane_core::format::FormatOptions {
+        // A later flag overrides the earlier one for the same commodity,
+        // instead of the two being combined as the directives would be.
+        let mut default_commodity = CommodityDisplayOption::default();
+        let mut given_formats = HashMap::new();
+        for given in &self.commodity_format {
+            match &given.commodity {
+                None => default_commodity = given.option,
+                Some(commodity) => {
+                    given_formats.insert(commodity.as_str(), given.option);
+                }
+            }
+        }
+        let mut builder = DisplayContextBuilder::new().with_default_commodity(default_commodity);
+        for (commodity, option) in given_formats {
+            builder.declare(commodity, option);
+        }
+        okane_core::format::FormatOptions::new().with_display_context(builder.build())
     }
 }
 
@@ -234,7 +341,7 @@ impl Primitives {
 #[derive(Subcommand, Debug)]
 enum PrimitiveCmd {
     /// Format the given one ledger file, to stdout.
-    Format(FormatCmd),
+    Format(PrimitiveFormatCmd),
     /// Read the given one ledger file, recursively resolves include directives and print to stdout.
     Flatten(FlattenCmd),
     /// Evaluates the given value under given condition.
@@ -275,7 +382,8 @@ impl FlattenCmd {
             Write(#[from] std::io::Error),
         }
 
-        // TODO: Pick DisplayContext from load results.
+        // TODO: Derive the DisplayContext with Loader::scan_files and
+        // DisplayContextBuilder, the way `okane format` does.
         let ctx = DisplayContext::default();
         let mut prev_path: Option<PathBuf> = None;
         load::new_loader(self.source).load(

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -1,12 +1,201 @@
-use okane_core::format;
+//! Emitters deciding what happens to the result of `okane format`.
+//!
+//! [`okane_core::format::format_recursively`] only computes what every file
+//! should look like; whether that is written back or shown as a diff is up to
+//! the [`Emitter`] given to it.
 
-use std::io::{Read, Write};
+use std::io::Write;
+use std::path::Path;
 
-/// Converts given string into formatted string.
-pub fn format<R, W>(r: &mut R, w: &mut W) -> Result<(), format::FormatError>
-where
-    R: Read,
-    W: Write,
-{
-    format::FormatOptions::new().recursive(false).format(r, w)
+use anyhow::Context as _;
+use okane_core::format::{Emitter, FormattedFile};
+
+/// [`Emitter`] rewriting each file in place.
+///
+/// The content goes through a temporary file in the same directory first, so an
+/// interrupted run cannot leave a half-written ledger behind.
+#[derive(Debug, Default)]
+pub struct WriteBack;
+
+impl Emitter for WriteBack {
+    type Error = anyhow::Error;
+
+    fn emit(&mut self, file: FormattedFile<'_>) -> anyhow::Result<()> {
+        if file.is_formatted() {
+            return Ok(());
+        }
+        let path = file.path();
+        let dir = path
+            .parent()
+            .with_context(|| format!("{} does not have a parent directory", path.display()))?;
+        let mut temp = tempfile::NamedTempFile::new_in(dir)
+            .with_context(|| format!("failed to create a temporary file in {}", dir.display()))?;
+        temp.write_all(file.formatted().as_bytes())
+            .with_context(|| format!("failed to write the formatted {}", path.display()))?;
+        // Temporary files are created with restrictive permissions, so the
+        // original mode has to be carried over explicitly.
+        let permissions = std::fs::metadata(path)
+            .with_context(|| format!("failed to stat {}", path.display()))?
+            .permissions();
+        temp.as_file()
+            .set_permissions(permissions)
+            .with_context(|| format!("failed to set permissions of {}", path.display()))?;
+        temp.persist(path)
+            .with_context(|| format!("failed to replace {}", path.display()))?;
+        log::info!("formatted {}", display_path(path));
+        Ok(())
+    }
+}
+
+/// [`Emitter`] printing what [`WriteBack`] would do, without touching any file.
+///
+/// Remembers whether anything would change, so that the caller can report it
+/// through the exit code.
+#[derive(Debug)]
+pub struct WriteDiff<W> {
+    out: W,
+    has_diff: bool,
+}
+
+impl<W: Write> WriteDiff<W> {
+    /// Creates an instance writing the diffs into `out`.
+    pub fn new(out: W) -> Self {
+        Self {
+            out,
+            has_diff: false,
+        }
+    }
+
+    /// Returns `true` if any file reported so far was not formatted.
+    pub fn has_diff(&self) -> bool {
+        self.has_diff
+    }
+}
+
+impl<W: Write> Emitter for WriteDiff<W> {
+    type Error = anyhow::Error;
+
+    fn emit(&mut self, file: FormattedFile<'_>) -> anyhow::Result<()> {
+        if file.is_formatted() {
+            return Ok(());
+        }
+        self.has_diff = true;
+        let display = display_path(file.path());
+        write!(
+            self.out,
+            "{}",
+            similar::TextDiff::from_lines(file.original(), file.formatted())
+                .unified_diff()
+                .header(&display, &display)
+        )
+        .with_context(|| format!("failed to write the diff of {}", file.path().display()))
+    }
+}
+
+/// Renders the path the way it is shown to the user.
+///
+/// [`okane_core::load::Loader`] canonicalizes, so paths are absolute;
+/// shortening them against the current directory keeps the output readable, and
+/// keeps it independent of where the ledger tree happens to live.
+fn display_path(path: &Path) -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(cwd).ok())
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    fn diff_of(original: &str, formatted: &str) -> String {
+        let mut emitter = WriteDiff::new(Vec::new());
+        emitter
+            .emit(FormattedFile::new(
+                Path::new("main.ledger"),
+                original,
+                formatted,
+            ))
+            .expect("emit must succeed");
+        assert_eq!(original != formatted, emitter.has_diff());
+        String::from_utf8(emitter.out).expect("diff must be valid UTF-8")
+    }
+
+    #[test]
+    fn write_diff_renders_the_unified_diff() {
+        assert_eq!(
+            indoc::indoc! {"
+                --- main.ledger
+                +++ main.ledger
+                @@ -1,2 +1,2 @@
+                 account Assets:Bank
+                - alias  Bank
+                +    alias Bank
+            "},
+            diff_of(
+                "account Assets:Bank\n alias  Bank\n",
+                "account Assets:Bank\n    alias Bank\n"
+            )
+        );
+    }
+
+    #[test]
+    fn write_diff_stays_quiet_on_the_formatted_file() {
+        let content = "account Assets:Bank\n";
+        assert_eq!("", diff_of(content, content));
+    }
+
+    #[test]
+    fn write_back_replaces_the_file_content_only_when_needed() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("main.ledger");
+        std::fs::write(&path, "account Assets:Bank\n alias  Bank\n")?;
+
+        WriteBack.emit(FormattedFile::new(
+            &path,
+            "account Assets:Bank\n alias  Bank\n",
+            "account Assets:Bank\n    alias Bank\n",
+        ))?;
+        assert_eq!(
+            "account Assets:Bank\n    alias Bank\n",
+            std::fs::read_to_string(&path)?
+        );
+
+        // An already formatted file is left alone, mtime included.
+        let before = std::fs::metadata(&path)?.modified()?;
+        WriteBack.emit(FormattedFile::new(
+            &path,
+            "account Assets:Bank\n    alias Bank\n",
+            "account Assets:Bank\n    alias Bank\n",
+        ))?;
+        assert_eq!(before, std::fs::metadata(&path)?.modified()?);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_back_keeps_the_file_permissions() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("main.ledger");
+        std::fs::write(&path, "account Assets:Bank\n")?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))?;
+
+        WriteBack.emit(FormattedFile::new(
+            &path,
+            "account Assets:Bank\n",
+            "account Assets:Bank\n; formatted\n",
+        ))?;
+
+        assert_eq!(
+            0o644,
+            std::fs::metadata(&path)?.permissions().mode() & 0o777
+        );
+        Ok(())
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,19 +19,22 @@ shadow!(build);
 
 use clap::Parser as _;
 
-fn main() {
+fn main() -> std::process::ExitCode {
     env_logger::init();
     let cli = cmd::Cli::parse();
     if let Err(err) = cli.validate() {
         eprintln!("{}", err);
         std::process::exit(2);
     }
-    if let Err(err) = cli.run(&mut std::io::stdout().lock()) {
-        eprintln!("{}", err);
-        for cause in err.chain().skip(1) {
-            eprintln!("Caused by {}", cause);
+    match cli.run(&mut std::io::stdout().lock()) {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("{}", err);
+            for cause in err.chain().skip(1) {
+                eprintln!("Caused by {}", cause);
+            }
+            std::process::exit(1);
         }
-        std::process::exit(1);
     }
 }
 

--- a/cli/tests/test_format.rs
+++ b/cli/tests/test_format.rs
@@ -1,0 +1,214 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub mod testing;
+
+#[ctor::ctor(unsafe)]
+fn init() {
+    env_logger::init();
+}
+
+/// Every file of the fixture tree, relative to its root.
+const FIXTURE_FILES: [&str; 3] = ["main.ledger", "sub/child.ledger", "sub/commodities.ledger"];
+
+/// Copies the fixture tree into a fresh temporary directory, so that formatting
+/// in place never touches the files in the repository.
+fn fixture_dir() -> tempfile::TempDir {
+    let src = testing::TESTDATA_DIR.join("format");
+    let dir = tempfile::tempdir().expect("failed to create a temporary directory");
+    for relative in FIXTURE_FILES {
+        let dest = dir.path().join(relative);
+        std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::fs::copy(src.join(relative), &dest)
+            .unwrap_or_else(|e| panic!("failed to copy {} : {}", relative, e));
+    }
+    dir
+}
+
+fn okane(dir: &Path) -> assert_cmd::Command {
+    let mut cmd = assert_cmd::Command::new(&*testing::BIN_PATH);
+    // Run from the fixture directory and pass relative paths, so the diff
+    // headers do not contain the temporary directory name.
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn golden(name: &str) -> okane_golden::Golden {
+    let path = testing::TESTDATA_DIR
+        .join("format")
+        .join("golden")
+        .join(name);
+    okane_golden::Golden::new(path).unwrap()
+}
+
+fn read(dir: &Path, relative: &str) -> String {
+    std::fs::read_to_string(dir.join(relative))
+        .unwrap_or_else(|e| panic!("failed to read {} : {}", relative, e))
+}
+
+/// Golden file name for a fixture file's formatted content.
+fn formatted_golden_name(relative: &str) -> String {
+    format!("{}.golden.format.txt", relative.replace('/', "_"))
+}
+
+#[test]
+fn format_check_reports_diff_and_fails() {
+    let dir = fixture_dir();
+    let before: Vec<String> = FIXTURE_FILES.iter().map(|f| read(dir.path(), f)).collect();
+
+    let result = okane(dir.path())
+        .args(["format", "--check", "main.ledger"])
+        .assert()
+        .code(1);
+
+    let output = result.get_output();
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    // Windows renders the included path with a backslash.
+    golden("check.golden.diff.txt").assert(&stdout.replace('\\', "/"));
+
+    let after: Vec<String> = FIXTURE_FILES.iter().map(|f| read(dir.path(), f)).collect();
+    assert_eq!(before, after, "--check must not modify any file");
+}
+
+#[test]
+fn format_rewrites_every_included_file_in_place() {
+    let dir = fixture_dir();
+
+    let result = okane(dir.path())
+        .args(["format", "main.ledger"])
+        .assert()
+        .success();
+    let output = result.get_output();
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    assert_eq!(
+        "",
+        std::str::from_utf8(&output.stdout).unwrap(),
+        "in-place format must not write to stdout"
+    );
+
+    for relative in FIXTURE_FILES {
+        golden(&formatted_golden_name(relative)).assert(&read(dir.path(), relative));
+    }
+}
+
+#[test]
+fn format_is_idempotent_and_check_passes_afterwards() {
+    let dir = fixture_dir();
+    okane(dir.path())
+        .args(["format", "main.ledger"])
+        .assert()
+        .success();
+    let once: Vec<String> = FIXTURE_FILES.iter().map(|f| read(dir.path(), f)).collect();
+
+    okane(dir.path())
+        .args(["format", "main.ledger"])
+        .assert()
+        .success();
+    let twice: Vec<String> = FIXTURE_FILES.iter().map(|f| read(dir.path(), f)).collect();
+    assert_eq!(once, twice, "formatting twice must be a no-op");
+
+    okane(dir.path())
+        .args(["format", "--check", "main.ledger"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn format_accepts_fmt_alias() {
+    let dir = fixture_dir();
+    okane(dir.path())
+        .args(["fmt", "main.ledger"])
+        .assert()
+        .success();
+    golden(&formatted_golden_name("main.ledger")).assert(&read(dir.path(), "main.ledger"));
+}
+
+#[test]
+fn format_reports_the_file_it_cannot_read() {
+    let dir = fixture_dir();
+
+    let result = okane(dir.path())
+        .args(["format", "not_found.ledger"])
+        .assert()
+        .failure();
+
+    let stderr = std::str::from_utf8(&result.get_output().stderr).unwrap();
+    assert!(stderr.contains("not_found.ledger"), "got:\n{}", stderr);
+}
+
+#[test]
+fn primitive_format_prints_one_file_without_touching_it() {
+    let dir = fixture_dir();
+    let before = read(dir.path(), "main.ledger");
+
+    let result = okane(dir.path())
+        .args(["primitive", "format", "main.ledger"])
+        .assert()
+        .success();
+
+    let output = result.get_output();
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    // Not the golden of the recursive format: the commodities declared in the
+    // included files are not picked up here, and the amounts stay as written.
+    golden("main.ledger.golden.primitive-format.txt").assert(stdout);
+
+    assert_eq!(
+        before,
+        read(dir.path(), "main.ledger"),
+        "primitive format must not modify the file"
+    );
+    let child: PathBuf = dir.path().join("sub/child.ledger");
+    assert_eq!(
+        std::fs::read_to_string(&child).unwrap(),
+        read(&testing::TESTDATA_DIR.join("format"), "sub/child.ledger"),
+        "primitive format must not follow include"
+    );
+}
+
+#[test]
+fn primitive_format_applies_commodity_format() {
+    let dir = fixture_dir();
+
+    let result = okane(dir.path())
+        .args([
+            "primitive",
+            "format",
+            "--commodity-format",
+            "JPY=1,000",
+            "--commodity-format",
+            "OKANE=1.0000",
+            "main.ledger",
+        ])
+        .assert()
+        .success();
+
+    let output = result.get_output();
+    std::io::stderr().write_all(&output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.contains("1,234 JPY"), "got:\n{}", stdout);
+    assert!(stdout.contains("2.0000 OKANE"), "got:\n{}", stdout);
+    // Not given, so it stays the way it is written.
+    assert!(stdout.contains("12.30 CHF"), "got:\n{}", stdout);
+}
+
+#[test]
+fn primitive_format_rejects_invalid_commodity_format() {
+    let dir = fixture_dir();
+
+    let result = okane(dir.path())
+        .args([
+            "primitive",
+            "format",
+            "--commodity-format",
+            "CHF=oops",
+            "main.ledger",
+        ])
+        .assert()
+        .failure();
+
+    let stderr = std::str::from_utf8(&result.get_output().stderr).unwrap();
+    assert!(stderr.contains("invalid sample amount"), "got:\n{}", stderr);
+}

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -1,11 +1,17 @@
 //! format functionalities of Ledger format files.
 
 use crate::{
+    load::{self, LoadError, Loader},
     parse::{ParseError, ParseOptions, parse_ledger},
-    syntax::{self, display::DisplayContext},
+    syntax::{
+        self,
+        display::{DisplayContext, DisplayContextBuilder},
+    },
 };
 
+use std::fmt::Write as _;
 use std::io::{Read, Write};
+use std::path::Path;
 
 /// Error occured during Format.
 #[derive(thiserror::Error, Debug)]
@@ -14,29 +20,45 @@ pub enum FormatError {
     IO(#[from] std::io::Error),
     #[error("failed to parse the file")]
     Parse(#[from] ParseError),
-    // TODO: Remove this once supported.
-    #[error("recursive format isn't supported yet")]
-    UnsupportedRecursiveFormat,
+    #[error("failed to walk the ledger files")]
+    Load(#[from] LoadError),
 }
 
 /// Options to control format functionalities.
+///
+/// This formats one file at a time, with the given [`DisplayContext`].
+/// Use [`format_recursively`] to format a whole tree of files instead,
+/// which derives the context out of the tree itself.
 #[derive(Debug, Default)]
 pub struct FormatOptions {
-    recursive: bool,
+    context: DisplayContext,
 }
 
 impl FormatOptions {
     /// Create a default FormatOptions instance.
-    /// All options are initially set to `false`.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Sets `recursive` option to given value.
-    /// If `recursive` is set to `true`, it'll try to follow `include` directive.
-    pub fn recursive(&mut self, recursive: bool) -> &mut Self {
-        self.recursive = recursive;
-        self
+    /// Sets how the amount of each commodity is rendered.
+    ///
+    /// Without this, every amount is printed the way it was written, as the
+    /// commodity settings can't be known from one file alone. Usually the
+    /// context comes from a [`DisplayContextBuilder`] fed with every entry of
+    /// the ledger, which is what [`format_recursively`] does.
+    pub fn with_display_context(self, context: DisplayContext) -> Self {
+        Self { context }
+    }
+
+    /// Formats the given `input`, and returns the formatted content.
+    pub fn format_str(&self, input: &str) -> Result<String, ParseError> {
+        let mut ret = String::with_capacity(input.len());
+        for parsed in parse_ledger(&ParseOptions::default(), input) {
+            let (_, entry): (_, syntax::plain::LedgerEntry) = parsed?;
+            // Writing into a String never fails.
+            write!(ret, "{}", self.context.as_display(&entry)).expect("write! into String failed");
+        }
+        Ok(ret)
     }
 
     /// Formats given `Read` instance and write it back to `Write`.
@@ -45,20 +67,107 @@ impl FormatOptions {
         R: Read,
         W: Write,
     {
-        // TODO: Implement recursive formatting.
-        if self.recursive {
-            return Err(FormatError::UnsupportedRecursiveFormat);
-        }
         let mut buf = String::new();
         r.read_to_string(&mut buf)?;
-        // TODO: Grab DisplayContext externally, or from LedgerEntry.
-        let ctx = DisplayContext::default();
-        for parsed in parse_ledger(&ParseOptions::default(), &buf) {
-            let (_, entry): (_, syntax::plain::LedgerEntry) = parsed?;
-            write!(w, "{}", ctx.as_display(&entry))?;
-        }
+        w.write_all(self.format_str(&buf)?.as_bytes())?;
         Ok(())
     }
+}
+
+/// One file of the ledger, formatted: what is on disk, and what it should be.
+///
+/// This is a pure diff, carrying no decision about what to do with it. Which is
+/// [`Emitter`]'s job: writing the file back, printing the difference, counting
+/// the files to be formatted, ... whatever the caller is after.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FormattedFile<'a> {
+    path: &'a Path,
+    original: &'a str,
+    formatted: &'a str,
+}
+
+impl<'a> FormattedFile<'a> {
+    /// Creates a new instance out of the file content and its formatted form.
+    pub fn new(path: &'a Path, original: &'a str, formatted: &'a str) -> Self {
+        Self {
+            path,
+            original,
+            formatted,
+        }
+    }
+
+    /// Returns the path of the file, as the [`Loader`] resolved it.
+    pub fn path(&self) -> &'a Path {
+        self.path
+    }
+
+    /// Returns the content currently on the disk.
+    pub fn original(&self) -> &'a str {
+        self.original
+    }
+
+    /// Returns the content the file should have.
+    pub fn formatted(&self) -> &'a str {
+        self.formatted
+    }
+
+    /// Returns `true` if the file is already formatted, i.e. there is nothing to apply.
+    pub fn is_formatted(&self) -> bool {
+        self.original == self.formatted
+    }
+}
+
+/// Applies whatever action the caller has in mind on every formatted file.
+///
+/// [`format_recursively`] reports *every* file it walked, formatted or not, so
+/// an emitter interested in the changes alone has to skip the ones with
+/// [`FormattedFile::is_formatted`].
+pub trait Emitter {
+    /// Error the action may fail with.
+    ///
+    /// It must be able to carry the formatter's own errors as well, so that the
+    /// caller has a single error type to deal with.
+    type Error: From<FormatError>;
+
+    /// Applies the action on the given file.
+    fn emit(&mut self, file: FormattedFile<'_>) -> Result<(), Self::Error>;
+}
+
+/// Formats the file the `loader` points at and every file it `include`s,
+/// reporting each of them to the `emitter` in load order.
+///
+/// The tree is walked twice, as how an amount is printed is a property of its
+/// commodity, and the commodity may well be declared in another file than the
+/// one being printed. So nothing can be printed before every file has been
+/// looked at.
+///
+/// 1. [`Loader::scan_files`] parses every file to follow the `include`
+///    directives, and the entries it reports on the way feed a
+///    [`DisplayContextBuilder`].
+/// 2. Every file found is parsed again, and printed with the resulting
+///    [`DisplayContext`].
+pub fn format_recursively<F, E>(loader: &Loader<F>, emitter: &mut E) -> Result<(), E::Error>
+where
+    F: load::FileSystem,
+    E: Emitter,
+{
+    let mut builder = DisplayContextBuilder::new();
+    // `?` converts the errors into `E::Error`, as `Emitter` requires.
+    let paths = loader
+        .scan_files(|_, entry| builder.observe(entry))
+        .map_err(FormatError::from)?;
+    let options = FormatOptions::new().with_display_context(builder.build());
+    for path in paths {
+        let original = loader
+            .filesystem()
+            .file_content_utf8(&path)
+            .map_err(|err| FormatError::from(LoadError::IO(err, path.clone())))?;
+        let formatted = options
+            .format_str(&original)
+            .map_err(|err| FormatError::from(LoadError::Parse(err, path.clone())))?;
+        emitter.emit(FormattedFile::new(&path, &original, &formatted))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -69,11 +178,29 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn format_str(input: &str) -> String {
+        format_with(&FormatOptions::new(), input)
+    }
+
+    fn format_with(options: &FormatOptions, input: &str) -> String {
         let mut output = Vec::new();
-        FormatOptions::new()
+        options
             .format(&mut input.as_bytes(), &mut output)
             .expect("format() should succeeds");
         String::from_utf8(output).expect("output should be valid UTF-8")
+    }
+
+    /// Formats the input with the context derived from the input itself,
+    /// the way [`format_recursively`] does over a whole tree of files.
+    fn format_with_inferred_context(input: &str) -> String {
+        let mut builder = DisplayContextBuilder::new();
+        for parsed in parse_ledger::<syntax::plain::Ident>(&ParseOptions::default(), input) {
+            let (_, entry) = parsed.expect("input should be parsed");
+            builder.observe(&entry);
+        }
+        format_with(
+            &FormatOptions::new().with_display_context(builder.build()),
+            input,
+        )
     }
 
     #[test]
@@ -120,18 +247,100 @@ mod tests {
             #comment
 
             account  Foo\t
+             ; a comment about Foo
              alias Bar
+
+            commodity USD
+             ; a comment about USD
+             alias $
 
             apply    tag   foo
             end  apply   tag
 
             2021/05/14 !(#txn-1) My Grocery
+                ; a comment about the transaction
                 Expenses:Grocery\t10 CHF
                 Assets:Bank  -10 CHF
         "};
 
         let once = format_str(input);
-        assert_eq!(once, format_str(&once));
+        assert_eq!(once, format_str(&once), "formatting must be idempotent");
+        // The comment prefixes must not accumulate spaces across runs.
+        assert!(
+            once.contains("    ; a comment about Foo\n"),
+            "got:\n{}",
+            once
+        );
+        assert!(
+            once.contains("    ; a comment about USD\n"),
+            "got:\n{}",
+            once
+        );
+    }
+
+    #[test]
+    fn format_applies_the_display_context() {
+        let input = indoc! {"
+            2021/05/14 My Grocery
+                Expenses:Grocery                       1234.5 CHF
+                Assets:Bank                           -1234.5 CHF
+        "};
+        let mut builder = DisplayContextBuilder::new();
+        builder.declare(
+            "CHF",
+            syntax::display::CommodityDisplayOption {
+                format: Some(pretty_decimal::Format::Comma3Dot),
+                min_scale: Some(2),
+            },
+        );
+        let want = indoc! {"
+            2021/05/14 My Grocery
+                Expenses:Grocery                        1,234.50 CHF
+                Assets:Bank                            -1,234.50 CHF
+        "};
+
+        assert_eq!(
+            want,
+            format_with(
+                &FormatOptions::new().with_display_context(builder.build()),
+                input
+            )
+        );
+    }
+
+    #[test]
+    fn format_with_inferred_context_is_a_fixed_point() {
+        let input = indoc! {"
+            commodity JPY
+                format 1,000 JPY
+
+            2021/05/14 My Grocery
+                Expenses:Grocery       1234 JPY
+                Expenses:Household     12.30 CHF
+                Expenses:Commissions   1,000 CHF
+                Assets:Broker          2 SPINX {1.23456 CHF} @ 1.23456 CHF
+                Assets:Complex         (-10 * 2.1 CHF) = 0
+                Assets:Bank            -5678.9 CHF
+        "};
+
+        let once = format_with_inferred_context(input);
+        assert_eq!(
+            once,
+            format_with_inferred_context(&once),
+            "formatting must be a fixed point"
+        );
+        // The declared format applies, even though the amount has no comma.
+        assert!(once.contains("1,234 JPY"), "got:\n{}", once);
+        // The widest CHF amount decides the scale, and the comma spreads.
+        assert!(once.contains("1,000.00 CHF"), "got:\n{}", once);
+        assert!(once.contains("-5,678.90 CHF"), "got:\n{}", once);
+        // The cost keeps its own precision, and the bare number is untouched.
+        assert!(
+            once.contains("{1.23456 CHF} @ 1.23456 CHF"),
+            "got:\n{}",
+            once
+        );
+        assert!(once.contains("= 0\n"), "got:\n{}", once);
     }
 
     #[test]
@@ -242,5 +451,141 @@ mod tests {
             .expect("format() should succeeds");
         let got = std::str::from_utf8(&output).expect("output should be valid UTF-8");
         assert_eq!(want, got);
+    }
+}
+
+#[cfg(test)]
+mod format_recursively_tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use indoc::indoc;
+    use maplit::hashmap;
+    use pretty_assertions::assert_eq;
+
+    use crate::load::FakeFileSystem;
+
+    /// Error of the test emitters.
+    #[derive(thiserror::Error, Debug)]
+    enum TestError {
+        #[error(transparent)]
+        Format(#[from] FormatError),
+        #[error("emit refused {0}")]
+        Refused(PathBuf),
+    }
+
+    /// [`Emitter`] keeping every reported file, applying nothing.
+    #[derive(Default)]
+    struct Recorder(Vec<(PathBuf, String, bool)>);
+
+    impl Emitter for Recorder {
+        type Error = TestError;
+
+        fn emit(&mut self, file: FormattedFile<'_>) -> Result<(), TestError> {
+            self.0.push((
+                file.path().to_owned(),
+                file.formatted().to_string(),
+                file.is_formatted(),
+            ));
+            Ok(())
+        }
+    }
+
+    fn loader_of(files: HashMap<PathBuf, Vec<u8>>) -> Loader<FakeFileSystem> {
+        Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            FakeFileSystem::from(files),
+        )
+    }
+
+    #[test]
+    fn format_recursively_reports_every_file_with_the_context_of_the_whole_tree() {
+        let loader = loader_of(hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                include child.ledger
+
+                2024/01/01 Lunch
+                    Expenses:Grocery       1234 JPY
+                    Assets:Bank
+            "}.as_bytes().to_vec(),
+            // Already formatted, and the only place JPY is declared.
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                commodity JPY
+                    format 1,000 JPY
+            "}.as_bytes().to_vec(),
+        });
+        let mut recorder = Recorder::default();
+
+        format_recursively(&loader, &mut recorder).expect("format_recursively must succeed");
+
+        assert_eq!(
+            vec![
+                (
+                    PathBuf::from("path/to/root.ledger"),
+                    indoc! {"
+                        include child.ledger
+
+                        2024/01/01 Lunch
+                            Expenses:Grocery                           1,234 JPY
+                            Assets:Bank
+                    "}
+                    .to_string(),
+                    // The commodity is declared in the included file, yet it
+                    // applies to the amount written in the root file.
+                    false,
+                ),
+                (
+                    PathBuf::from("path/to/child.ledger"),
+                    "commodity JPY\n    format 1,000 JPY\n".to_string(),
+                    true,
+                ),
+            ],
+            recorder.0
+        );
+    }
+
+    #[test]
+    fn format_recursively_returns_the_emitter_error() {
+        let loader = loader_of(hashmap! {
+            PathBuf::from("path/to/root.ledger") => "account Expenses:Grocery\n".as_bytes().to_vec(),
+        });
+        struct Refuse;
+        impl Emitter for Refuse {
+            type Error = TestError;
+
+            fn emit(&mut self, file: FormattedFile<'_>) -> Result<(), TestError> {
+                Err(TestError::Refused(file.path().to_owned()))
+            }
+        }
+
+        let got = format_recursively(&loader, &mut Refuse).expect_err("emit must fail");
+
+        assert!(
+            matches!(&got, TestError::Refused(p) if p == Path::new("path/to/root.ledger")),
+            "unexpected error: {:?}",
+            got
+        );
+    }
+
+    #[test]
+    fn format_recursively_reports_the_unreadable_file() {
+        let loader = loader_of(hashmap! {
+            PathBuf::from("path/to/other.ledger") => "".as_bytes().to_vec(),
+        });
+
+        let got = format_recursively(&loader, &mut Recorder::default())
+            .expect_err("format_recursively must fail");
+
+        assert!(
+            matches!(
+                &got,
+                TestError::Format(FormatError::Load(LoadError::IO(_, p)))
+                    if p == Path::new("path/to/root.ledger")
+            ),
+            "unexpected error: {:?}",
+            got
+        );
     }
 }

--- a/core/src/load.rs
+++ b/core/src/load.rs
@@ -9,7 +9,7 @@ pub use annotate_snippets::Renderer;
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{self, Path, PathBuf},
 };
 
@@ -111,37 +111,120 @@ impl<F: FileSystem> Loader<F> {
                 parsed.map_err(|e| LoadError::Parse(e, path.clone().into_owned()))?;
             match &entry.statement {
                 syntax::LedgerStatement::Include(p) => {
-                    let include_path: PathBuf = p.0.as_ref().into();
-                    let target: String = path
-                        .as_ref()
-                        .parent()
-                        .ok_or_else(|| LoadError::RootLoadingPath(path.as_ref().to_owned()))?
-                        .join(include_path)
-                        .into_os_string()
-                        .into_string()
-                        .map_err(|x| {
-                            LoadError::InvalidUnicodePath(format!("{}", PathBuf::from(x).display()))
-                        })?;
-                    let mut paths: Vec<PathBuf> = self.filesystem.glob(&target)?;
-                    if paths.is_empty() {
-                        return Err(LoadError::IO(
-                            std::io::Error::new(
-                                std::io::ErrorKind::NotFound,
-                                format!("glob {} does not hit any files", target),
-                            ),
-                            PathBuf::from(target),
-                        )
-                        .into());
-                    }
-                    log::debug!("glob {} hit {} files", target, paths.len());
-                    paths.sort_unstable();
-                    for path in &paths {
-                        self.load_impl(parse_options, path, callback)?;
+                    for included in self.resolve_include(&path, p)? {
+                        self.load_impl(parse_options, &included, callback)?;
                     }
                     Ok(())
                 }
                 _ => callback(&path, &ctx, &entry),
             }?;
+        }
+        Ok(())
+    }
+
+    /// Resolves the `include` directive found in `path` into the files it refers to,
+    /// sorted so that the load order is deterministic.
+    fn resolve_include(
+        &self,
+        path: &Path,
+        include: &syntax::IncludeFile<'_>,
+    ) -> Result<Vec<PathBuf>, LoadError> {
+        let include_path: PathBuf = include.0.as_ref().into();
+        let target: String = path
+            .parent()
+            .ok_or_else(|| LoadError::RootLoadingPath(path.to_owned()))?
+            .join(include_path)
+            .into_os_string()
+            .into_string()
+            .map_err(|x| {
+                LoadError::InvalidUnicodePath(format!("{}", PathBuf::from(x).display()))
+            })?;
+        let mut paths: Vec<PathBuf> = self.filesystem.glob(&target)?;
+        if paths.is_empty() {
+            return Err(LoadError::IO(
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("glob {} does not hit any files", target),
+                ),
+                PathBuf::from(target),
+            ));
+        }
+        log::debug!("glob {} hit {} files", target, paths.len());
+        paths.sort_unstable();
+        Ok(paths)
+    }
+
+    /// Returns every file reachable from the source, in load order.
+    ///
+    /// The source itself comes first, then the files its `include` directives
+    /// refer to, recursively. A file reached more than once (included twice, or
+    /// matched by overlapping globs) appears only once, which also keeps an
+    /// `include` cycle from recursing forever.
+    ///
+    /// Unlike [`Self::load`] this does not report the entries, so it is the way
+    /// to work on the files themselves, e.g. to format them. Use
+    /// [`Self::scan_files`] to look at the entries on the way.
+    pub fn list_files(&self) -> Result<Vec<PathBuf>, LoadError> {
+        self.scan_files(|_, _| ())
+    }
+
+    /// Walks every file reachable from the source in load order, reporting
+    /// every parsed entry to `observer`, and returns the files walked.
+    ///
+    /// This is [`Self::list_files`] with a look at the content: the walk has to
+    /// parse each file anyway to find its `include` directives, so an observer
+    /// gets the entries for free. It is what lets a formatter learn the ledger
+    /// wide settings, e.g. the `commodity` formats, before printing anything.
+    ///
+    /// Two differences against [`Self::load`]: `include` entries are reported
+    /// as well, and a file reached twice is parsed only once, which also
+    /// terminates on an `include` cycle.
+    pub fn scan_files<O>(&self, mut observer: O) -> Result<Vec<PathBuf>, LoadError>
+    where
+        O: FnMut(&Path, &syntax::plain::LedgerEntry<'_>),
+    {
+        let popts = parse::ParseOptions::default().with_error_style(self.error_style.clone());
+        let mut found = Vec::new();
+        let mut visited = HashSet::new();
+        self.scan_files_impl(
+            &popts,
+            &self.source,
+            &mut found,
+            &mut visited,
+            &mut observer,
+        )?;
+        Ok(found)
+    }
+
+    fn scan_files_impl<O>(
+        &self,
+        parse_options: &parse::ParseOptions,
+        path: &Path,
+        found: &mut Vec<PathBuf>,
+        visited: &mut HashSet<PathBuf>,
+        observer: &mut O,
+    ) -> Result<(), LoadError>
+    where
+        O: FnMut(&Path, &syntax::plain::LedgerEntry<'_>),
+    {
+        let path: Cow<'_, Path> = F::canonicalize_path(path);
+        if !visited.insert(path.as_ref().to_owned()) {
+            log::debug!("skipping already visited file {}", path.display());
+            return Ok(());
+        }
+        found.push(path.as_ref().to_owned());
+        let content = self
+            .filesystem
+            .file_content_utf8(&path)
+            .map_err(|err| LoadError::IO(err, path.clone().into_owned()))?;
+        for parsed in parse::parse_ledger::<syntax::plain::Ident>(parse_options, &content) {
+            let (_, entry) = parsed.map_err(|e| LoadError::Parse(e, path.clone().into_owned()))?;
+            observer(&path, &entry);
+            if let syntax::LedgerStatement::Include(p) = &entry.statement {
+                for included in self.resolve_include(&path, p)? {
+                    self.scan_files_impl(parse_options, &included, found, visited, observer)?;
+                }
+            }
         }
         Ok(())
     }
@@ -314,6 +397,176 @@ mod tests {
             Ok::<(), LoadError>(())
         })?;
         Ok(ret)
+    }
+
+    #[test]
+    fn list_files_returns_reachable_files_in_load_order() {
+        let mut testdata_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        assert!(testdata_dir.pop());
+        testdata_dir.push("testdata/load");
+        testdata_dir = dunce::canonicalize(testdata_dir).unwrap();
+        let root = testdata_dir.join("recursive.ledger");
+
+        let got = new_loader(root.clone())
+            .list_files()
+            .expect("list_files must succeed");
+
+        assert_eq!(
+            vec![
+                root,
+                // recursive.ledger includes child1.ledger, which globs sub/child*.ledger.
+                testdata_dir.join("child1.ledger"),
+                testdata_dir.join("sub").join("child2.ledger"),
+                // child2.ledger includes ../child3.ledger.
+                testdata_dir.join("child3.ledger"),
+                testdata_dir.join("sub").join("child4.ledger"),
+            ],
+            got
+        );
+    }
+
+    #[test]
+    fn list_files_visits_a_file_included_twice_only_once() {
+        let fake = hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                include child.ledger
+                include child.ledger
+            "}.as_bytes().to_vec(),
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                ; nothing to include
+            "}.as_bytes().to_vec(),
+        };
+
+        let got = Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            FakeFileSystem::from(fake),
+        )
+        .list_files()
+        .expect("list_files must succeed");
+
+        assert_eq!(
+            vec![
+                PathBuf::from("path/to/root.ledger"),
+                PathBuf::from("path/to/child.ledger"),
+            ],
+            got
+        );
+    }
+
+    #[test]
+    fn list_files_terminates_on_include_cycle() {
+        let fake = hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                include child.ledger
+            "}.as_bytes().to_vec(),
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                include root.ledger
+            "}.as_bytes().to_vec(),
+        };
+
+        let got = Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            FakeFileSystem::from(fake),
+        )
+        .list_files()
+        .expect("list_files must succeed");
+
+        assert_eq!(
+            vec![
+                PathBuf::from("path/to/root.ledger"),
+                PathBuf::from("path/to/child.ledger"),
+            ],
+            got
+        );
+    }
+
+    /// Renders every entry `scan_files` reports, to keep the assertions short.
+    fn scan_into_vec<F>(loader: &Loader<F>) -> Result<Vec<(PathBuf, String)>, LoadError>
+    where
+        F: FileSystem,
+    {
+        let ctx = syntax::display::DisplayContext::default();
+        let mut ret = Vec::new();
+        loader.scan_files(|path, entry| {
+            ret.push((path.to_owned(), ctx.as_display(entry).to_string()));
+        })?;
+        Ok(ret)
+    }
+
+    #[test]
+    fn scan_files_reports_every_entry_including_include() {
+        let fake = hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                account Expenses:Grocery
+                include child.ledger
+            "}.as_bytes().to_vec(),
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                commodity CHF
+                    format 1,000.00 CHF
+            "}.as_bytes().to_vec(),
+        };
+        let loader = Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            FakeFileSystem::from(fake),
+        );
+
+        let got = scan_into_vec(&loader).expect("scan_files must succeed");
+
+        // Unlike load(), the `include` directive is reported as well.
+        assert_eq!(
+            vec![
+                (
+                    PathBuf::from("path/to/root.ledger"),
+                    "account Expenses:Grocery\n".to_string()
+                ),
+                (
+                    PathBuf::from("path/to/root.ledger"),
+                    "include child.ledger\n".to_string()
+                ),
+                (
+                    PathBuf::from("path/to/child.ledger"),
+                    "commodity CHF\n    format 1,000.00 CHF\n".to_string()
+                ),
+            ],
+            got
+        );
+    }
+
+    #[test]
+    fn scan_files_reports_a_file_included_twice_only_once() {
+        let fake = hashmap! {
+            PathBuf::from("path/to/root.ledger") => indoc! {"
+                include child.ledger
+                include child.ledger
+            "}.as_bytes().to_vec(),
+            PathBuf::from("path/to/child.ledger") => indoc! {"
+                account Expenses:Grocery
+            "}.as_bytes().to_vec(),
+        };
+        let loader = Loader::new(
+            PathBuf::from("path/to/root.ledger"),
+            FakeFileSystem::from(fake),
+        );
+
+        let got = scan_into_vec(&loader).expect("scan_files must succeed");
+
+        assert_eq!(
+            vec![
+                (
+                    PathBuf::from("path/to/root.ledger"),
+                    "include child.ledger\n".to_string()
+                ),
+                (
+                    PathBuf::from("path/to/child.ledger"),
+                    "account Expenses:Grocery\n".to_string()
+                ),
+                (
+                    PathBuf::from("path/to/root.ledger"),
+                    "include child.ledger\n".to_string()
+                ),
+            ],
+            got
+        );
     }
 
     #[test]

--- a/core/src/syntax/display.rs
+++ b/core/src/syntax/display.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use std::collections::HashMap;
+use std::convert::Infallible;
 
 use decoration::AsUndecorated;
 use expr::Visitable;
@@ -57,10 +58,232 @@ impl DisplayContext {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct CommodityDisplayOption {
     pub format: Option<pretty_decimal::Format>,
     pub min_scale: Option<u8>,
+}
+
+/// Derives a [`DisplayContext`] out of the Ledger itself.
+///
+/// How an amount should be printed is a property of its commodity, not of the
+/// particular literal, and the commodity may well be declared in another file
+/// than the one being printed. So a formatter has to walk the whole tree first,
+/// feeding every entry into this builder, and only then start printing.
+///
+/// Two sources are combined, and the declared one wins per field:
+///
+/// 1. `commodity ... format` directives, an explicit statement of intent.
+/// 2. The amounts actually written in the files, for the commodities without
+///    such a directive. Precision only ever grows: the widest literal wins,
+///    and the "most formatted" style wins, so the result doesn't depend on
+///    which file happened to be read first.
+///
+/// Costs (`@` / `@@`) and lot prices are deliberately *not* observed, as an
+/// exchange rate routinely carries more digits than the commodity's own
+/// precision, which would otherwise inflate every amount of that commodity.
+#[derive(Debug, Default, Clone)]
+pub struct DisplayContextBuilder {
+    default_commodity: CommodityDisplayOption,
+    commodities: HashMap<String, CommodityEstimate>,
+}
+
+/// What we know about one commodity, before deciding which source wins.
+#[derive(Debug, Default, Clone, Copy)]
+struct CommodityEstimate {
+    /// Taken from a `commodity ... format` directive, or given by the caller.
+    declared: CommodityDisplayOption,
+    /// Inferred from the amount literals.
+    observed: CommodityDisplayOption,
+}
+
+impl DisplayContextBuilder {
+    /// Creates an empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the fallback used for the commodities the builder never saw.
+    ///
+    /// Note this also applies to the amounts without a commodity, so leave it
+    /// alone unless the caller really means to touch those.
+    pub fn with_default_commodity(self, default_commodity: CommodityDisplayOption) -> Self {
+        Self {
+            default_commodity,
+            ..self
+        }
+    }
+
+    /// Declares the `commodity` format explicitly, as a `commodity ... format`
+    /// directive would do.
+    pub fn declare<T>(&mut self, commodity: T, option: CommodityDisplayOption)
+    where
+        T: Into<String>,
+    {
+        let declared = &mut self
+            .commodities
+            .entry(commodity.into())
+            .or_default()
+            .declared;
+        *declared = join_option(*declared, option);
+    }
+
+    /// Records the `commodity` directives and the amounts within the `entry`.
+    pub fn observe<Deco: Decoration>(&mut self, entry: &LedgerEntry<'_, Deco>) {
+        match &entry.statement {
+            LedgerStatement::Txn(txn) => {
+                for posting in &txn.posts {
+                    self.observe_posting(posting.as_undecorated());
+                }
+            }
+            LedgerStatement::Commodity(declaration) => {
+                for detail in &declaration.details {
+                    if let CommodityDetail::Format(amount) = detail {
+                        self.declare_amount(&declaration.name, amount);
+                    }
+                }
+            }
+            // `apply tag` may hold an amount, but only as an unparsed string.
+            LedgerStatement::Comment(_)
+            | LedgerStatement::ApplyTag(_)
+            | LedgerStatement::EndApplyTag
+            | LedgerStatement::Include(_)
+            | LedgerStatement::Account(_) => {}
+        }
+    }
+
+    /// Returns the [`DisplayContext`] out of everything observed so far.
+    pub fn build(self) -> DisplayContext {
+        DisplayContext::new(
+            self.default_commodity,
+            self.commodities
+                .into_iter()
+                .map(|(commodity, estimate)| {
+                    (
+                        commodity,
+                        CommodityDisplayOption {
+                            format: estimate.declared.format.or(estimate.observed.format),
+                            min_scale: estimate.declared.min_scale.or(estimate.observed.min_scale),
+                        },
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn observe_posting<Deco: Decoration>(&mut self, posting: &Posting<'_, Deco>) {
+        if let Some(posting_amount) = &posting.amount {
+            // Note the cost and the lot price are not observed on purpose,
+            // see the type level comment.
+            self.observe_value_expr(posting_amount.amount.as_undecorated());
+        }
+        if let Some(balance) = &posting.balance {
+            self.observe_value_expr(balance.as_undecorated());
+        }
+    }
+
+    /// Records every amount literal within the `value` expression.
+    fn observe_value_expr(&mut self, value: &expr::ValueExpr<'_>) {
+        match value.accept(self) {
+            Ok(()) => (),
+        }
+    }
+
+    /// Declares the format given as a `commodity ... format` sample amount.
+    ///
+    /// The sample carries its own commodity, and that is what the declaration
+    /// applies to: the `format` line is printed through the very same context,
+    /// so keying it on anything else would make the file grow on every format.
+    fn declare_amount(&mut self, declared_name: &str, sample: &expr::Amount<'_>) {
+        let commodity = if sample.commodity.is_empty() {
+            declared_name
+        } else {
+            sample.commodity.as_ref()
+        };
+        let option = as_display_option(&sample.value);
+        if let Some(previous) = self.commodities.get(commodity).map(|x| x.declared)
+            && (previous.format.is_some() && previous.format != option.format
+                || previous.min_scale.is_some() && previous.min_scale != option.min_scale)
+        {
+            log::warn!(
+                "conflicting format declared for the commodity {}: {:?} and {:?}",
+                commodity,
+                previous,
+                option
+            );
+        }
+        self.declare(commodity, option);
+    }
+}
+
+/// Collects the amount literals out of an expression, ignoring the operators.
+///
+/// Only [`ExprVisitor::visit_amount`] carries information here, so the operator
+/// nodes just recurse and the dispatching nodes keep their default.
+impl<'i> expr::ExprVisitor<'i> for DisplayContextBuilder {
+    type Output = ();
+    type Error = Infallible;
+
+    fn visit_amount(&mut self, amount: &expr::Amount<'i>) -> Result<(), Infallible> {
+        // An amount without a commodity is a plain number, `= 0` or an operand
+        // in an expression. Formatting those after some unrelated commodity
+        // would be nonsense.
+        if amount.commodity.is_empty() {
+            return Ok(());
+        }
+        let observed = &mut self
+            .commodities
+            .entry(amount.commodity.as_ref().to_owned())
+            .or_default()
+            .observed;
+        *observed = join_option(*observed, as_display_option(&amount.value));
+        Ok(())
+    }
+
+    fn visit_unary(&mut self, expr: &expr::UnaryOpExpr<'i>) -> Result<(), Infallible> {
+        self.visit_expr(&expr.expr)
+    }
+
+    fn visit_binary(&mut self, expr: &expr::BinaryOpExpr<'i>) -> Result<(), Infallible> {
+        self.visit_expr(&expr.lhs)?;
+        self.visit_expr(&expr.rhs)
+    }
+}
+
+/// Returns the display option the given literal implies.
+fn as_display_option(value: &PrettyDecimal) -> CommodityDisplayOption {
+    CommodityDisplayOption {
+        format: value.format,
+        // Decimal caps the scale at 28, so the conversion can't fail.
+        min_scale: Some(value.scale().try_into().unwrap_or(u8::MAX)),
+    }
+}
+
+/// Combines the two options so that the result never renders less than either.
+fn join_option(x: CommodityDisplayOption, y: CommodityDisplayOption) -> CommodityDisplayOption {
+    CommodityDisplayOption {
+        format: join_format(x.format, y.format),
+        min_scale: std::cmp::max(x.min_scale, y.min_scale),
+    }
+}
+
+/// Combines the two formats, preferring the one carrying more information.
+///
+/// `pretty_decimal::Format` is `non_exhaustive`, so an unknown variant is
+/// assumed to be more specific than the ones we know.
+fn join_format(
+    x: Option<pretty_decimal::Format>,
+    y: Option<pretty_decimal::Format>,
+) -> Option<pretty_decimal::Format> {
+    fn rank(format: Option<pretty_decimal::Format>) -> u8 {
+        match format {
+            None => 0,
+            Some(pretty_decimal::Format::Plain) => 1,
+            Some(pretty_decimal::Format::Comma3Dot) => 2,
+            Some(_) => 3,
+        }
+    }
+    if rank(y) > rank(x) { y } else { x }
 }
 
 /// Object combined with the `DisplayContext`.
@@ -156,7 +379,10 @@ impl fmt::Display for AccountDeclaration<'_> {
 impl fmt::Display for AccountDetail<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AccountDetail::Comment(v) => LineWrapStr::wrap("    ; ", v).fmt(f),
+            // The parser keeps the space after the comment prefix as part of the
+            // content, so the prefix must not add one back (that would grow by a
+            // space on every format).
+            AccountDetail::Comment(v) => LineWrapStr::wrap("    ;", v).fmt(f),
             AccountDetail::Note(v) => LineWrapStr::wrap("    note ", v).fmt(f),
             AccountDetail::Alias(v) => writeln!(f, "    alias {}", v),
         }
@@ -175,7 +401,10 @@ impl fmt::Display for WithContext<'_, CommodityDeclaration<'_>> {
 impl fmt::Display for WithContext<'_, CommodityDetail<'_>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.value {
-            CommodityDetail::Comment(v) => LineWrapStr::wrap("    ; ", v).fmt(f),
+            // The parser keeps the space after the comment prefix as part of the
+            // content, so the prefix must not add one back (that would grow by a
+            // space on every format).
+            CommodityDetail::Comment(v) => LineWrapStr::wrap("    ;", v).fmt(f),
             CommodityDetail::Note(v) => LineWrapStr::wrap("    note ", v).fmt(f),
             CommodityDetail::Alias(v) => writeln!(f, "    alias {}", v),
             CommodityDetail::Format(v) => writeln!(f, "    format {}", self.pass_context(v)),
@@ -811,5 +1040,195 @@ mod tests {
             .unwrap();
         assert_eq!("((1.20 + 2.67) * 3.1 USD + 5 USD)", got.as_str());
         assert_eq!(Alignment::Complete(20), alignment);
+    }
+}
+
+#[cfg(test)]
+mod display_context_builder_tests {
+    use super::*;
+
+    use crate::parse::{self, ParseOptions};
+
+    use pretty_assertions::assert_eq;
+
+    /// Returns the context derived out of the given Ledger content.
+    fn context_of(input: &str) -> DisplayContext {
+        let mut builder = DisplayContextBuilder::new();
+        for parsed in parse::parse_ledger::<plain::Ident>(&ParseOptions::default(), input) {
+            let (_, entry) = parsed.expect("test input must be parsed");
+            builder.observe(&entry);
+        }
+        builder.build()
+    }
+
+    /// Returns the option resolved for the `commodity`.
+    fn option_of(context: &DisplayContext, commodity: &str) -> CommodityDisplayOption {
+        CommodityDisplayOption {
+            format: context.decimal_format(commodity),
+            min_scale: context.min_scale(commodity),
+        }
+    }
+
+    fn option(format: Option<pretty_decimal::Format>, min_scale: u8) -> CommodityDisplayOption {
+        CommodityDisplayOption {
+            format,
+            min_scale: Some(min_scale),
+        }
+    }
+
+    #[test]
+    fn observe_takes_the_widest_scale_of_the_literals() {
+        let context = context_of(indoc::indoc! {"
+            2024/01/01 Widen
+                Expenses:Grocery       1 CHF
+                Expenses:Household     2.345 CHF
+                Assets:Bank           -3.34 CHF
+        "});
+
+        assert_eq!(option(None, 3), option_of(&context, "CHF"));
+    }
+
+    #[test]
+    fn observe_prefers_the_style_carrying_more_information() {
+        let context = context_of(indoc::indoc! {"
+            2024/01/01 Mixed
+                Expenses:Grocery       1234.00 CHF
+                Expenses:Household     5,678.00 CHF
+                Assets:Bank           -6912.00 CHF
+        "});
+
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Comma3Dot), 2),
+            option_of(&context, "CHF")
+        );
+    }
+
+    #[test]
+    fn observe_skips_the_amount_without_commodity() {
+        let context = context_of(indoc::indoc! {"
+            2024/01/01 No commodity
+                Expenses:Grocery       (-10 * 2.100)
+                Assets:Bank            = 0
+        "});
+
+        assert_eq!(CommodityDisplayOption::default(), option_of(&context, ""));
+        assert_eq!(
+            CommodityDisplayOption::default(),
+            option_of(&context, "CHF")
+        );
+    }
+
+    #[test]
+    fn observe_takes_the_balance_but_not_the_cost_nor_the_lot_price() {
+        let context = context_of(indoc::indoc! {"
+            2024/01/01 Exchange
+                Assets:Broker          2 SPINX {1.2345 USD} @ 1.6789 USD
+                Assets:Bank           -3.3 USD = 1234.56 USD
+        "});
+
+        // Neither the lot price nor the cost widens USD beyond the balance.
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Plain), 2),
+            option_of(&context, "USD")
+        );
+        assert_eq!(option(None, 0), option_of(&context, "SPINX"));
+    }
+
+    #[test]
+    fn observe_walks_into_the_expressions() {
+        let context = context_of(indoc::indoc! {"
+            2024/01/01 Expression
+                Expenses:Grocery       (-(1.20 EUR) + 2.6700 EUR * 2)
+                Assets:Bank            -4.14 EUR
+        "});
+
+        assert_eq!(option(None, 4), option_of(&context, "EUR"));
+    }
+
+    #[test]
+    fn observe_prefers_the_declared_format_over_the_observed_one() {
+        let context = context_of(indoc::indoc! {"
+            commodity CHF
+                format 1,000.00 CHF
+
+            2024/01/01 Precise
+                Expenses:Grocery       1.23456 CHF
+                Assets:Bank           -1.23456 CHF
+        "});
+
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Comma3Dot), 2),
+            option_of(&context, "CHF")
+        );
+    }
+
+    #[test]
+    fn observe_binds_the_declaration_to_the_sample_commodity() {
+        // A weird declaration, but the `format` line is printed through the
+        // very same context, so it must be keyed on the sample's commodity.
+        let context = context_of(indoc::indoc! {"
+            commodity CHF
+                format 1,000.00 USD
+        "});
+
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Comma3Dot), 2),
+            option_of(&context, "USD")
+        );
+        assert_eq!(
+            CommodityDisplayOption::default(),
+            option_of(&context, "CHF")
+        );
+    }
+
+    #[test]
+    fn observe_joins_the_declarations_regardless_of_the_order() {
+        let plain_first = context_of(indoc::indoc! {"
+            commodity CHF
+                format 1000.00 CHF
+
+            commodity CHF
+                format 1,000.000 CHF
+        "});
+        let comma_first = context_of(indoc::indoc! {"
+            commodity CHF
+                format 1,000.000 CHF
+
+            commodity CHF
+                format 1000.00 CHF
+        "});
+
+        let want = option(Some(pretty_decimal::Format::Comma3Dot), 3);
+        assert_eq!(want, option_of(&plain_first, "CHF"));
+        assert_eq!(want, option_of(&comma_first, "CHF"));
+    }
+
+    #[test]
+    fn declare_overrides_what_is_observed() {
+        let mut builder = DisplayContextBuilder::new();
+        for parsed in parse::parse_ledger::<plain::Ident>(
+            &ParseOptions::default(),
+            "2024/01/01 Observed\n    Assets:Bank  1.234 JPY\n",
+        ) {
+            let (_, entry) = parsed.expect("test input must be parsed");
+            builder.observe(&entry);
+        }
+        builder.declare("JPY", option(Some(pretty_decimal::Format::Comma3Dot), 0));
+
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Comma3Dot), 0),
+            option_of(&builder.build(), "JPY")
+        );
+    }
+
+    #[test]
+    fn default_commodity_applies_to_the_unseen_commodity() {
+        let builder = DisplayContextBuilder::new()
+            .with_default_commodity(option(Some(pretty_decimal::Format::Comma3Dot), 2));
+
+        assert_eq!(
+            option(Some(pretty_decimal::Format::Comma3Dot), 2),
+            option_of(&builder.build(), "CHF")
+        );
     }
 }

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -137,6 +137,15 @@ commodity-note ::= sp+ "note" sp+ no-new-line* new-line
 ; Declares alias of the commodity.
 commodity-alias ::= sp+ "alias" sp+ commodity new-line
 
+; Declares how the amount of the commodity is printed,
+; given as a sample amount such as `format 1,000.00 CHF`.
+; The sample tells the number of the decimals, and whether
+; the thousands are separated with a comma.
+; `okane format` prints the amounts of the commodity that way,
+; keeping the ones having more decimals as they are.
+; The report commands use the decimals to round the balance.
+commodity-format ::= sp+ "format" sp+ amount new-line
+
 ; Comment is pure no-op comment.
 commodity-comment ::= sp+ comment-prefix no-new-line* new-line
 ```

--- a/testdata/format/golden/check.golden.diff.txt
+++ b/testdata/format/golden/check.golden.diff.txt
@@ -1,0 +1,70 @@
+--- main.ledger
++++ main.ledger
+@@ -1,23 +1,22 @@
+ ; Explains the account below.
+ account Assets:Bank:ZKB
+- ; ZKB is a bank in Zürich.
+- alias  Bank
++    ; ZKB is a bank in Zürich.
++    alias Bank
+ 
+-include  sub/*.ledger
++include sub/*.ledger
+ 
+-apply tag  foo
+-apply tag  bar:  baz
+-end  apply  tag
++apply tag foo
++apply tag bar: baz
++end apply tag
+ end apply tag
+-
+ 
+-2024/1/2 Grocery
+-  Expenses:Grocery   12.30 CHF
+-  Assets:Bank:ZKB
++2024/01/02 Grocery
++    Expenses:Grocery                           12.30 CHF
++    Assets:Bank:ZKB
+ ; Explains the transaction above.
+ 
+-2024/1/3 Cross-file formats
+-  Expenses:Grocery   1234 JPY
+-  Expenses:Books  2 OKANE
+-  Expenses:Travel   1,234.56 USD
+-  Assets:Bank:ZKB   = 0
++2024/01/03 Cross-file formats
++    Expenses:Grocery                           1,234 JPY
++    Expenses:Books                            2.0000 OKANE
++    Expenses:Travel                         1,234.56 USD
++    Assets:Bank:ZKB                                  = 0
+--- sub/child.ledger
++++ sub/child.ledger
+@@ -1,12 +1,12 @@
+ commodity CHF
+- ; Swiss franc.
+- alias  Fr.
++    ; Swiss franc.
++    alias Fr.
+ 
+-2024/2/3 * Salary
+-    Income:Salary    -1,000.00 CHF
+-    Assets:Bank:ZKB   1,000.00 CHF
++2024/02/03 * Salary
++    Income:Salary                          -1,000.00 CHF
++    Assets:Bank:ZKB                         1,000.00 CHF
+ 
+-2024/2/4 Precision
+-    Expenses:Books     1.2345 OKANE
+-    Expenses:Travel   12345.67 USD
++2024/02/04 Precision
++    Expenses:Books                            1.2345 OKANE
++    Expenses:Travel                        12,345.67 USD
+     Assets:Bank:ZKB
+--- sub/commodities.ledger
++++ sub/commodities.ledger
+@@ -1,2 +1,2 @@
+-commodity  JPY
+-   format   1,000 JPY
++commodity JPY
++    format 1,000 JPY

--- a/testdata/format/golden/main.ledger.golden.format.txt
+++ b/testdata/format/golden/main.ledger.golden.format.txt
@@ -1,0 +1,22 @@
+; Explains the account below.
+account Assets:Bank:ZKB
+    ; ZKB is a bank in Zürich.
+    alias Bank
+
+include sub/*.ledger
+
+apply tag foo
+apply tag bar: baz
+end apply tag
+end apply tag
+
+2024/01/02 Grocery
+    Expenses:Grocery                           12.30 CHF
+    Assets:Bank:ZKB
+; Explains the transaction above.
+
+2024/01/03 Cross-file formats
+    Expenses:Grocery                           1,234 JPY
+    Expenses:Books                            2.0000 OKANE
+    Expenses:Travel                         1,234.56 USD
+    Assets:Bank:ZKB                                  = 0

--- a/testdata/format/golden/main.ledger.golden.primitive-format.txt
+++ b/testdata/format/golden/main.ledger.golden.primitive-format.txt
@@ -1,0 +1,22 @@
+; Explains the account below.
+account Assets:Bank:ZKB
+    ; ZKB is a bank in Zürich.
+    alias Bank
+
+include sub/*.ledger
+
+apply tag foo
+apply tag bar: baz
+end apply tag
+end apply tag
+
+2024/01/02 Grocery
+    Expenses:Grocery                           12.30 CHF
+    Assets:Bank:ZKB
+; Explains the transaction above.
+
+2024/01/03 Cross-file formats
+    Expenses:Grocery                            1234 JPY
+    Expenses:Books                                 2 OKANE
+    Expenses:Travel                         1,234.56 USD
+    Assets:Bank:ZKB                                  = 0

--- a/testdata/format/golden/sub_child.ledger.golden.format.txt
+++ b/testdata/format/golden/sub_child.ledger.golden.format.txt
@@ -1,0 +1,12 @@
+commodity CHF
+    ; Swiss franc.
+    alias Fr.
+
+2024/02/03 * Salary
+    Income:Salary                          -1,000.00 CHF
+    Assets:Bank:ZKB                         1,000.00 CHF
+
+2024/02/04 Precision
+    Expenses:Books                            1.2345 OKANE
+    Expenses:Travel                        12,345.67 USD
+    Assets:Bank:ZKB

--- a/testdata/format/golden/sub_commodities.ledger.golden.format.txt
+++ b/testdata/format/golden/sub_commodities.ledger.golden.format.txt
@@ -1,0 +1,2 @@
+commodity JPY
+    format 1,000 JPY

--- a/testdata/format/main.ledger
+++ b/testdata/format/main.ledger
@@ -1,0 +1,23 @@
+; Explains the account below.
+account Assets:Bank:ZKB
+ ; ZKB is a bank in Zürich.
+ alias  Bank
+
+include  sub/*.ledger
+
+apply tag  foo
+apply tag  bar:  baz
+end  apply  tag
+end apply tag
+
+
+2024/1/2 Grocery
+  Expenses:Grocery   12.30 CHF
+  Assets:Bank:ZKB
+; Explains the transaction above.
+
+2024/1/3 Cross-file formats
+  Expenses:Grocery   1234 JPY
+  Expenses:Books  2 OKANE
+  Expenses:Travel   1,234.56 USD
+  Assets:Bank:ZKB   = 0

--- a/testdata/format/sub/child.ledger
+++ b/testdata/format/sub/child.ledger
@@ -1,0 +1,12 @@
+commodity CHF
+ ; Swiss franc.
+ alias  Fr.
+
+2024/2/3 * Salary
+    Income:Salary    -1,000.00 CHF
+    Assets:Bank:ZKB   1,000.00 CHF
+
+2024/2/4 Precision
+    Expenses:Books     1.2345 OKANE
+    Expenses:Travel   12345.67 USD
+    Assets:Bank:ZKB

--- a/testdata/format/sub/commodities.ledger
+++ b/testdata/format/sub/commodities.ledger
@@ -1,0 +1,2 @@
+commodity  JPY
+   format   1,000 JPY


### PR DESCRIPTION
Alternative to #526, addressing #529. Same feature, same output — **every golden file is byte
identical to #526** — but the recursion lives in `okane-core` behind an `Emitter` trait, and the CLI
only provides the two actions.

Open both and compare; #526 stays untouched.

## The shape

`core` computes a pure diff per file and hands it over; what happens to it is the caller's business.

```rust
/// One file of the ledger, formatted: what is on disk, and what it should be.
pub struct FormattedFile<'a> {
    path: &'a Path,
    original: &'a str,
    formatted: &'a str,
}
impl FormattedFile<'_> {
    pub fn path(&self) -> &Path;
    pub fn original(&self) -> &str;
    pub fn formatted(&self) -> &str;
    pub fn is_formatted(&self) -> bool;
}

/// Applies whatever action the caller has in mind on every formatted file.
pub trait Emitter {
    type Error: From<FormatError>;
    fn emit(&mut self, file: FormattedFile<'_>) -> Result<(), Self::Error>;
}

pub fn format_recursively<F: load::FileSystem, E: Emitter>(
    loader: &Loader<F>,
    emitter: &mut E,
) -> Result<(), E::Error>;
```

`format_recursively` reports **every** file it walked, formatted or not, so an emitter that only
cares about the changes skips on `is_formatted()`. The associated `Error: From<FormatError>` follows
what `Loader::load` already does, and is loose enough for the CLI to use `anyhow::Error` directly.

`cli/src/format.rs` is now nothing but the two emitters:

* `WriteBack` — replaces the file through a temporary file in the same directory, carrying the
  original permissions over.
* `WriteDiff<W>` — renders the unified diff through `similar` and remembers `has_diff()`, which
  becomes the exit code.

So `FormatCmd::run` is the whole of the wiring:

```rust
let loader = load::new_loader(self.source.clone());
if !self.check {
    okane_core::format::format_recursively(&loader, &mut format::WriteBack)?;
    return Ok(ExitCode::SUCCESS);
}
let mut emitter = format::WriteDiff::new(w);
okane_core::format::format_recursively(&loader, &mut emitter)?;
if emitter.has_diff() { Ok(ExitCode::FAILURE) } else { Ok(ExitCode::SUCCESS) }
```

Which is what makes the third case cheap: an emitter counting the files, or one feeding an LSP, is a
dozen lines and needs nothing from the CLI.

## Two passes, as concluded in #529

Not fought against. It is not even an extra parse:

* **Pass 1** is the walk that follows `include` anyway. It parsed every file and threw the entries
  away; it now reports them, as `Loader::scan_files(observer)`, and `list_files()` is a thin wrapper
  over it. The entries feed `DisplayContextBuilder`. This is the "provide just the `include`
  resolution as a library" part of the issue.
* **Pass 2** parses and prints each file with the resulting `DisplayContext`.

Per-file parse count stays at 2, exactly what `okane format` did before.

## How the format is decided

`syntax::display::DisplayContextBuilder` combines two sources and prefers the declared one **per
field** (`format`, `min_scale`):

1. `commodity … format` directives.
2. The amounts actually written, for the commodities without such a directive.

Both slots use the same monotone join — widest scale wins, and `None < Plain < Comma3Dot` — so the
result cannot depend on which file a glob happened to sort first, and two conflicting declarations
join rather than last-one-wins (with a `log::warn!`).

Deliberate carve-outs:

* **Costs (`@`, `@@`) and lot prices are printed with the commodity's format but do not decide it.**
  An exchange rate routinely carries more digits than the commodity's natural precision, and letting
  one `@ 0.00123 CHF` inflate every CHF amount to five decimals would be nonsense. Only posting
  amounts and balance assertions feed inference.
* **Amounts without a commodity are never touched** (`= 0`, operands like `(-10 * 2.1 $)`).
* **A declaration binds to the sample's commodity**, not the enclosing declaration name. The
  `format` line is printed through the very same context, so `commodity CHF` + `format 1,000.00 USD`
  keyed on `CHF` would make the file change on every run.

Formatting stays a fixed point: inference emits every observed amount at exactly the max scale it
saw, so the second run observes the same thing.

## `primitive format --commodity-format`

`okane primitive format` skips the scan pass entirely — "primitive skips the first pass and the user
specifies the format", as #529 puts it — and prints amounts as written unless told otherwise:

```console
$ okane primitive format --commodity-format 'JPY=1,000' --commodity-format 'OKANE=1.00' main.ledger
    Expenses:Grocery                           1,234 JPY
    Expenses:Books                              2.00 OKANE
```

The value is a sample amount — the same thing the `format` directive takes — so it carries both the
style and the scale. Without the `COMMODITY=` prefix it sets the default for every commodity.
Repeatable; the last value for a commodity wins.

## Behaviour changes worth flagging

* Expect a **large one-off diff** on the first run after upgrading, and `--check` newly failing in
  CI on files that were clean before.
* `1.5 CHF` becomes `1.50 CHF` if another CHF amount has two decimals; one `1,234.00 CHF` anywhere
  makes every CHF amount over a thousand comma-separated.
* Inference alone never drops digits. A `commodity … format` directive with fewer decimals does
  (`1.500` → `1.50` under `format 1,000.00`), since `rescale()` normalizes first.
* `okane format` and `okane primitive format` can now print the same file differently — which is
  what `--commodity-format` is for.

## Other bits

* **Exit code**: `Cli::run` / `Command::run` now return `anyhow::Result<ExitCode>` and `main`
  returns `ExitCode`. `format` is the only command producing a non-success code; the rest keep
  returning `anyhow::Result<()>` and are wrapped in one place. Validation failure still exits 2, an
  `Err` still prints the `Caused by` chain and exits 1.
* **`FormatOptions::format_str(&str) -> Result<String, ParseError>`** is the primitive both paths
  wanted; `format(r, w)` is now a wrapper over it.
* **Dead code removed**: `FormatOptions::recursive()` and `FormatError::UnsupportedRecursiveFormat`
  were stubs for exactly this feature.
* **Bug fixed along the way**: formatting was not idempotent — comments under an `account` /
  `commodity` directive gained a space on every run, because the parser keeps the space after the
  prefix as part of the content while `Display` added another. Harmless for stdout, fatal for
  in-place formatting.
* `doc/syntax.md` referenced `commodity-format` in the grammar without ever defining the production;
  it is defined now that the directive means something.

## Tests

`cli/tests/test_format.rs` over the fixture tree in `testdata/format/` (copied into a tempdir per
test): `--check` reports a golden diff, exits 1 and modifies nothing; in-place rewrites every
included file including a glob include; formatting twice is a no-op and `--check` passes afterwards;
the `fmt` alias works; a missing file is reported by name; `primitive format` prints to stdout,
follows no `include`, and applies `--commodity-format`.

In core: `format_recursively` over `FakeFileSystem` with a recording emitter (cross-file context,
already-formatted files reported as such, emitter error propagated, unreadable file named),
`DisplayContextBuilder` unit tests, `scan_files` tests, and a fixed-point test in
`core/src/format.rs`. In cli: unit tests for both emitters, permissions included.

`cargo test`, `cargo clippy --all-targets`, `cargo fmt --check` and `cargo deny check licenses` (for
the `similar` dep, Apache-2.0) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
