### PR TITLE
ci: build the release archive for arm64 Linux

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -34,6 +34,11 @@ jobs:
           - build: linux-x86_64-musl
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+          # Built on a native arm64 runner, free for public repositories, so
+          # that no cross toolchain is needed.
+          - build: linux-aarch64-musl
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
           - build: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+* Release archives are now built for 64-bit ARM Linux (`aarch64-unknown-linux-musl`) as well, so
+  that Raspberry Pi and arm64 cloud hosts no longer have to build okane from source.
+
 ### Changed
 
 ### Fixed

--- a/about.toml
+++ b/about.toml
@@ -24,6 +24,7 @@ accepted = [
 # archive only lists the crates actually linked into that archive's binary.
 targets = [
     "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",


### PR DESCRIPTION
Stacked on #375 — review that one first; the diff here is only the arm64 part.

Adds `aarch64-unknown-linux-musl` to the build matrix, so arm64 Linux users (Raspberry Pi, arm64 cloud hosts) get an archive instead of having to build from source.

It builds on a native `ubuntu-24.04-arm` runner, free for public repositories, which sidesteps the cross toolchain the target would otherwise need: `musl-tools` and the stable toolchain are installed the same way as on x86_64.

`about.toml` gains the target as well, so the `cargo-about` job in ci-linter checks its license notice along with the others — verified locally, both with `--target aarch64-unknown-linux-musl` and over the full target list.

The Binary workflow from #375 is what actually proves the build works; a local cross-check was not possible here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
