### PR TITLE
ci: fix the dependabot config for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: increase-if-necessary
+    # Dependabot no longer accepts increase-if-necessary for cargo -- only
+    # lockfile-only and auto. auto keeps the behaviour we had: the manifest
+    # requirement is widened only when it does not already allow the new
+    # version, otherwise just the lock file moves.
+    versioning-strategy: auto


### PR DESCRIPTION
The Dependabot config check has been failing on every PR (seen on #375, but unrelated to it):

```
The property '#/updates/1/versioning-strategy' value "increase-if-necessary"
did not match one of the following values: lockfile-only, auto
```

`cargo` only accepts `lockfile-only` and `auto` now. `auto` keeps what `increase-if-necessary` did for us — the manifest requirement is widened only when it does not already allow the new version, otherwise just the lock file moves — so this is a rename, not a behaviour change.

Branched off `main`, independent of the binary-CI stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
