### PR TITLE
ci: build glibc release archives next to the musl ones

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -39,6 +39,20 @@ jobs:
           - build: linux-aarch64-musl
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
+          # glibc archives ship next to the musl ones because musl's
+          # allocator costs 1.2-1.5x on the report path (#561). musl stays for
+          # Alpine, for distributions older than the runners below, and for
+          # anyone who wants a fully static binary; cargo-binstall picks the
+          # archive matching the host triple, so glibc users get the faster
+          # build without asking for it. Built on the oldest still-supported
+          # runner, since a glibc binary only runs on a glibc at least as new
+          # as the one it was linked against.
+          - build: linux-x86_64-gnu
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - build: linux-aarch64-gnu
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
           - build: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -56,7 +70,14 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+      # One cache per matrix entry. rust-cache keys on the job id plus
+      # `Linux`/`x64`, which does not tell the runner images apart, so the
+      # 24.04 musl job and the 22.04 glibc job would otherwise share a target/
+      # directory. The host build scripts cached by the newer image then fail
+      # to run on the older one with `GLIBC_2.39 not found`.
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: ${{ matrix.build }}
       - name: Install cargo-about
         uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Release archives are now built for 64-bit ARM Linux (`aarch64-unknown-linux-musl`) as well, so
   that Raspberry Pi and arm64 cloud hosts no longer have to build okane from source.
+* Release archives are now built against glibc (`x86_64-unknown-linux-gnu`,
+  `aarch64-unknown-linux-gnu`) next to the musl ones. musl's allocator makes the static binaries
+  1.2-1.5x slower on the report path, so glibc users are better served by a glibc archive;
+  `cargo binstall` picks the one matching the host automatically. The musl archives stay for
+  Alpine, for older distributions, and for anyone wanting a fully static binary.
 
 ### Changed
 

--- a/about.toml
+++ b/about.toml
@@ -25,6 +25,8 @@ accepted = [
 targets = [
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
     "x86_64-pc-windows-msvc",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",


### PR DESCRIPTION
Adds `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` to the release binary matrix, so the Linux archives are no longer musl-only.

Closes #561.

### Why

musl's allocator (mallocng) costs okane 1.2–1.5x end-to-end and ~2x on the report hot path, measured same-machine against an otherwise identical glibc build:

| command | glibc | musl | musl/glibc |
|---|---|---|---|
| `okane balance` (80k tx) | 267 ms | 375 ms | 1.40x |
| `okane register` (80k tx) | 373 ms | 550 ms | 1.47x |
| `report::process` (criterion) | 22.3 ms | 46.0 ms | 2.06x |

A dependency-free microbench pins it on the allocator rather than codegen: pure compute and small `memcpy` are identical between the targets, while `Vec` growth is 17x, `format!` 5.7x and small malloc churn 2.9x on musl. `parse` is bumpalo-arena allocated and barely moves; `process` and the query paths churn `HashMap`/`Vec`/`String` outside the arena and take the hit. Full numbers and method in #561.

### What this does not change

The musl archives stay exactly as they are. They are what works on Alpine, on distributions older than the runners, and for anyone who wants a fully static binary — musl also still starts ~0.5 ms faster, since a static-pie runs no dynamic loader.

`cargo binstall` resolves the archive matching the host triple, so a glibc user picks up the faster build without having to choose, and a musl user is unaffected.

### Runner choice

Both glibc targets build on the 22.04 runners rather than `ubuntu-latest`. A glibc binary requires a glibc at least as new as the one it linked against, so the runner's version becomes the floor for every user: 22.04 gives glibc 2.35 (Ubuntu 22.04+, Debian 12+) instead of 24.04's 2.39. If `ubuntu-22.04-arm` turns out not to be available, the arm64 entry can fall back to `ubuntu-24.04-arm`.

### Also updated

- `about.toml` — both new triples added to the shipped-target list, keeping it in sync as the linter comment asks. `cargo about generate --target <triple>` was run locally against both and produces the notice fine.
- `CHANGELOG.md` — entry under Unreleased.

### Note on the base

Stacked on #559 (`feat/ci_binary_arm64`), which adds the arm64 musl entry to the same matrix block and the same CHANGELOG section. Rebase onto main once that merges.

Note that both `Binary` and `CI` only trigger on `pull_request: branches: [main]`, so **this PR gets no workflow run while it is based on #559** — the new matrix entries are unverified until it is rebased onto main. The one thing worth watching then is the `ubuntu-22.04-arm` runner label; everything else in the job is target-independent, and the `cargo about` step was checked locally for both triples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
