### PR TITLE
Release 0.21.1 with arm64 + glibc Linux binaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@
 
 ### Added
 
-* Release archives are now built for 64-bit ARM Linux (`aarch64-unknown-linux-musl`) as well, so
-  that Raspberry Pi and arm64 cloud hosts no longer have to build okane from source.
-* Release archives are now built against glibc (`x86_64-unknown-linux-gnu`,
-  `aarch64-unknown-linux-gnu`) next to the musl ones. musl's allocator makes the static binaries
-  1.2-1.5x slower on the report path, so glibc users are better served by a glibc archive;
-  `cargo binstall` picks the one matching the host automatically. The musl archives stay for
-  Alpine, for older distributions, and for anyone wanting a fully static binary.
-
 ### Changed
 
 ### Fixed
+
+## [0.21.1] - 2026-08-20
+
+### Added
+
+* Release archives are now built for 64-bit ARM Linux (`aarch64-unknown-linux-musl`) as well, so
+  that Raspberry Pi and arm64 cloud hosts no longer have to build okane from source
+  (https://github.com/xkikeg/okane/pull/559).
+* Release archives are now built against glibc (`x86_64-unknown-linux-gnu`,
+  `aarch64-unknown-linux-gnu`) next to the musl ones (https://github.com/xkikeg/okane/pull/562).
+  musl's allocator makes the static binaries 1.2-1.5x slower on the report path, so glibc users
+  are better served by a glibc archive; `cargo binstall` picks the one matching the host
+  automatically. The musl archives stay for Alpine, for older distributions, and for anyone wanting
+  a fully static binary.
 
 ## [0.21.0] - 2026-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "okane"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "okane-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "annotate-snippets",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 authors = ["kikeg"]
 edition = "2024"
 rust-version = "1.89.0"


### PR DESCRIPTION
This won't have any substantial change in features. Just release new prebuilt binaries.