### PR TITLE
cli: search the balance UI by romaji through migemo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+* CLI: `ui` can now search accounts written in Japanese by romaji, through
+  [migemo](https://www.kaoriya.net/software/cmigemo/). Pass the tool as
+  `--migemo='cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict'` and `/`, `C-s` and `C-r` expand
+  what you type into the regex matching the Japanese it stands for, so `ginkou` finds `資産:銀行`.
+  The process is spawned once and kept for the whole session (reloads included), so an incremental
+  search does not pay the dictionary load per keystroke. Without the flag the query is used as the
+  regex, as before.
+
 ### Changed
 
 ### Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,6 +59,12 @@ $ okane ui /path/to/file.ledger
 
 最初の画面はフラットなアカウントごとの残高リストです。`t` でアカウントの親子関係を考慮したツリー表示に切り替わり、`space` で選択中のサブツリーを、`x` で全体を折りたたみます。`/`, `C-s`, `C-r` でアカウント名を検索でき (それぞれ Vim 風、Emacs 風になっています)、`Enter` で選択したアカウントの仕訳帳を開きます。`r` でファイルを読み込み直すので、UIを開いたままファイルを編集できます。終了は `q` です。`?` で各種操作を確認できます。
 
+`--migemo` に [cmigemo](https://www.kaoriya.net/software/cmigemo/) のコマンドを渡すと、日本語のアカウント名をローマ字で検索できます。入力した文字列は cmigemo が正規表現に展開するので、`ginkou` で `資産:銀行` が見つかります。コマンドライン全体で1つの値なので、次のように引用符でくくって渡します。
+
+```shell
+$ okane ui --migemo='cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict' /path/to/file.ledger
+```
+
 `balance` や `register` と同じ評価用オプションが使えるので、通貨換算や日付指定も可能です。
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ accounts, where `space` folds the selected subtree and `x` folds everything.
 selected account, and `r` reloads the file from disk so you can keep the UI open
 while editing. `q` quits. `?` lists every key binding of the screen you are on.
 
+Accounts written in Japanese can be searched by romaji with `--migemo`, which
+points at a [cmigemo](https://www.kaoriya.net/software/cmigemo/) command: what
+you type is expanded into the regex matching the Japanese it stands for, so
+`ginkou` finds `資産:銀行`. The whole command line is one flag value, so quote
+it:
+
+```shell
+$ okane ui --migemo='cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict' /path/to/file.ledger
+```
+
 It takes the same evaluation flags as `balance` and `register`, so the amounts
 can be converted into a single commodity, or filtered by the time range:
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,6 +41,7 @@ rust_decimal.workspace = true
 serde = { version = "1.0", features = [ "derive" ] }
 serde_with = { version = "3.21", features = [ "chrono" ] }
 shadow-rs = { version = "2.0.0", default-features = false }
+shlex = "2.0"
 soft-canonicalize = { version = "0.5.6", features = [ "dunce" ] }
 strum.workspace = true
 thiserror.workspace = true
@@ -60,7 +61,6 @@ pretty_assertions.workspace = true
 rstest.workspace = true
 rust_decimal_macros.workspace = true
 serde_test = "1.0"
-shlex = "2.0"
 tempfile = "3.27.0"
 
 [build-dependencies]

--- a/cli/src/cmd.rs
+++ b/cli/src/cmd.rs
@@ -18,6 +18,7 @@ use crate::build::CLAP_LONG_VERSION;
 use crate::format;
 use crate::import;
 use crate::ui;
+use crate::ui::migemo::{Migemo, MigemoCommand};
 
 #[derive(thiserror::Error, Debug)]
 #[error("invalid flag: {0}")]
@@ -460,6 +461,19 @@ pub struct UiCmd {
     #[command(flatten)]
     eval_options: EvalOptions,
 
+    /// Command running migemo, used to expand the account search query.
+    ///
+    /// Given a migemo command, `/` and `C-s` search take a romaji query and
+    /// match the Japanese it stands for: typing `ginkou` finds `資産:銀行`.
+    /// Without it the query is used as the regex, as typed.
+    ///
+    /// The value is one shell-quoted command line, so quote it as a whole:
+    /// `--migemo='cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict'`.
+    /// The command must read a query per line on stdin and write the regex it
+    /// expands to on stdout, which is what `cmigemo` does.
+    #[arg(long, value_name = "COMMAND")]
+    migemo: Option<String>,
+
     /// Path to the Ledger file.
     source: PathBuf,
 }
@@ -474,10 +488,17 @@ impl UiCmd {
         // All report data is built inside `run_ui`: its session loop resets
         // the arena on reload (`r` / `F5`), which requires that nothing out
         // here borrows it.
-        let config = ui::report::SessionConfig::new(
+        let mut config = ui::report::SessionConfig::new(
             load::new_loader(self.source.clone()),
             self.eval_options.to_query_options()?,
         );
+        if let Some(command) = &self.migemo {
+            // Spawned before the terminal is taken over, so a command that
+            // cannot even start says so on the normal terminal.
+            let command = MigemoCommand::parse(command)?;
+            let migemo = Migemo::spawn(command).context("failed to start migemo")?;
+            config = config.with_translator(ui::report::Translator::Migemo(migemo));
+        }
         let mut arena = Bump::new();
         ui::report::run_ui(&mut arena, self.source.display().to_string(), &config)
             .context("failed to run TUI")

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -2,5 +2,6 @@
 
 pub mod import;
 mod keys;
+pub mod migemo;
 pub mod report;
 mod table;

--- a/cli/src/ui/migemo.rs
+++ b/cli/src/ui/migemo.rs
@@ -1,0 +1,335 @@
+//! [migemo](https://www.kaoriya.net/software/cmigemo/) integration for the
+//! search bars: a long-lived `cmigemo` process that turns a romaji query into
+//! a regex matching the Japanese it stands for.
+//!
+//! The tool speaks a line protocol over a pipe — one query per line in, one
+//! pattern per line out — so [`Migemo`] keeps the process alive for the whole
+//! session instead of paying the dictionary load (tens of milliseconds) on
+//! every keystroke of an incremental search.
+//!
+//! Only the pipe protocol lives here; what the resulting pattern is matched
+//! against is up to the caller (see
+//! [`Translator`](super::report::search::Translator)).
+
+use std::cell::RefCell;
+use std::fmt;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+/// Anything that can go wrong talking to the migemo process.
+#[derive(thiserror::Error, Debug)]
+pub enum MigemoError {
+    #[error("--migemo needs a command to run")]
+    EmptyCommand,
+    #[error("--migemo command is not a valid shell word list (unbalanced quotes?): {0}")]
+    UnparsableCommand(String),
+    #[error("failed to spawn the migemo command `{command}`")]
+    Spawn {
+        command: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to talk to the migemo process")]
+    Io(#[from] std::io::Error),
+    #[error("the migemo process closed its output")]
+    Closed,
+    #[error("the migemo process returned no pattern for `{0}`")]
+    NoPattern(String),
+}
+
+impl MigemoError {
+    /// Short tag for the search bar, which has one line to say what is wrong
+    /// and still has the match count to show.
+    pub fn label(&self) -> &'static str {
+        match self {
+            MigemoError::Closed => "[migemo exited]",
+            MigemoError::NoPattern(_) => "[no migemo pattern]",
+            MigemoError::Io(_) => "[migemo I/O error]",
+            // The startup failures, which never reach a search bar.
+            MigemoError::EmptyCommand
+            | MigemoError::UnparsableCommand(_)
+            | MigemoError::Spawn { .. } => "[migemo failed]",
+        }
+    }
+}
+
+/// The `--migemo` command line: the program plus its arguments, as split out
+/// of the single string the flag takes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigemoCommand {
+    program: String,
+    args: Vec<String>,
+}
+
+impl MigemoCommand {
+    /// Splits `command` the way a shell would, so a dictionary path with
+    /// spaces can be quoted: `--migemo='cmigemo -d "/some dir/migemo-dict"'`.
+    pub fn parse(command: &str) -> Result<Self, MigemoError> {
+        let mut words = shlex::split(command)
+            .ok_or_else(|| MigemoError::UnparsableCommand(command.to_owned()))?
+            .into_iter();
+        let program = words.next().ok_or(MigemoError::EmptyCommand)?;
+        Ok(Self {
+            program,
+            args: words.collect(),
+        })
+    }
+}
+
+impl fmt::Display for MigemoCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.program)?;
+        for arg in &self.args {
+            write!(f, " {arg}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A running migemo process, queried through its stdin/stdout pipe.
+///
+/// [`Self::query`] takes `&self` so the client can sit behind a shared handle
+/// on the UI state: the pipe is the mutable part and it is guarded here.
+#[derive(Debug)]
+pub struct Migemo {
+    child: RefCell<Child>,
+    pipe: RefCell<Pipe<ChildStdin, BufReader<ChildStdout>>>,
+}
+
+impl Migemo {
+    /// Spawns `command` with its stdin and stdout piped. Its stderr is left
+    /// alone deliberately: it would land on the alternate screen mid-session,
+    /// but a dictionary that fails to load is worth seeing once the TUI exits.
+    pub fn spawn(command: MigemoCommand) -> Result<Self, MigemoError> {
+        let mut child = Command::new(&command.program)
+            .args(&command.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(|source| MigemoError::Spawn {
+                command: command.to_string(),
+                source,
+            })?;
+        // Both are `Some`: `spawn` succeeded with the pipes requested above.
+        let stdin = child.stdin.take().expect("stdin was piped");
+        let stdout = child.stdout.take().expect("stdout was piped");
+        Ok(Self {
+            child: RefCell::new(child),
+            pipe: RefCell::new(Pipe::new(stdin, BufReader::new(stdout))),
+        })
+    }
+
+    /// The regex `input` stands for, as migemo expands it.
+    pub fn query(&self, input: &str) -> Result<String, MigemoError> {
+        self.pipe.borrow_mut().query(input)
+    }
+}
+
+impl Drop for Migemo {
+    fn drop(&mut self) {
+        // The process outlives us otherwise: it is blocked reading a query
+        // that will never come. Kill rather than close the pipe and wait, so
+        // that a command which is not migemo at all cannot hang the exit.
+        let mut child = self.child.borrow_mut();
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+/// The line protocol itself, over any pair of streams so it can be exercised
+/// without a process.
+#[derive(Debug)]
+struct Pipe<W, R> {
+    stdin: W,
+    stdout: R,
+    /// Reused between queries; the pattern is copied out of it.
+    buf: String,
+}
+
+impl<W: Write, R: BufRead> Pipe<W, R> {
+    fn new(stdin: W, stdout: R) -> Self {
+        Self {
+            stdin,
+            stdout,
+            buf: String::new(),
+        }
+    }
+
+    /// Writes one query and reads back the pattern it produced.
+    ///
+    /// A newline in `input` would desynchronize the protocol (the tail would
+    /// be answered as a second query), so it is dropped: the search bars never
+    /// produce one, and a stray one is not worth failing a keystroke over.
+    fn query(&mut self, input: &str) -> Result<String, MigemoError> {
+        let query: String = input.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+        writeln!(self.stdin, "{query}")?;
+        self.stdin.flush()?;
+        loop {
+            self.buf.clear();
+            if self.stdout.read_line(&mut self.buf)? == 0 {
+                return Err(MigemoError::Closed);
+            }
+            let line = self.buf.trim_end_matches(['\n', '\r']);
+            if is_banner(line) {
+                continue;
+            }
+            let pattern = strip_prompt(line);
+            if pattern.is_empty() {
+                return Err(MigemoError::NoPattern(query));
+            }
+            return Ok(pattern.to_owned());
+        }
+    }
+}
+
+/// Whether `line` is one of the notices `cmigemo` prints on startup when it is
+/// not run in quiet mode (`-q`), which precede the first answer.
+fn is_banner(line: &str) -> bool {
+    line.starts_with("migemo_open(") || line.starts_with("clock")
+}
+
+/// Strips the prompt `cmigemo` writes ahead of an answer without `-q`. The
+/// prompt has no newline of its own, so it arrives on the answer's line:
+/// `QUERY: PATTERN: (ケンサク|検索|...)`.
+fn strip_prompt(line: &str) -> &str {
+    let mut rest = line;
+    loop {
+        rest = match rest
+            .strip_prefix("QUERY: ")
+            .or_else(|| rest.strip_prefix("PATTERN: "))
+        {
+            Some(stripped) => stripped,
+            None => return rest,
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+
+    use assert_matches::assert_matches;
+    use pretty_assertions::assert_eq;
+
+    fn pipe(stdout: &str) -> Pipe<Vec<u8>, Cursor<Vec<u8>>> {
+        Pipe::new(Vec::new(), Cursor::new(stdout.as_bytes().to_vec()))
+    }
+
+    #[test]
+    fn parse_splits_the_command_like_a_shell() {
+        assert_eq!(
+            MigemoCommand::parse("cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict").unwrap(),
+            MigemoCommand {
+                program: "cmigemo".to_owned(),
+                args: vec![
+                    "-q".to_owned(),
+                    "-d".to_owned(),
+                    "/usr/share/cmigemo/utf-8/migemo-dict".to_owned(),
+                ],
+            }
+        );
+        assert_eq!(
+            MigemoCommand::parse(r#"cmigemo -d "/some dir/migemo-dict""#)
+                .unwrap()
+                .args,
+            vec!["-d".to_owned(), "/some dir/migemo-dict".to_owned()]
+        );
+    }
+
+    #[test]
+    fn parse_rejects_nothing_to_run() {
+        assert_matches!(MigemoCommand::parse(""), Err(MigemoError::EmptyCommand));
+        assert_matches!(MigemoCommand::parse("   "), Err(MigemoError::EmptyCommand));
+        assert_matches!(
+            MigemoCommand::parse("cmigemo -d \"unbalanced"),
+            Err(MigemoError::UnparsableCommand(_))
+        );
+    }
+
+    #[test]
+    fn display_round_trips_into_parse() {
+        let command = MigemoCommand::parse("cmigemo -q -d dict").unwrap();
+        assert_eq!(command.to_string(), "cmigemo -q -d dict");
+        assert_eq!(MigemoCommand::parse(&command.to_string()).unwrap(), command);
+    }
+
+    #[test]
+    fn query_writes_a_line_and_reads_the_pattern() {
+        let mut pipe = pipe("(ケンサク|検索|kensaku)\n(ギンコウ|銀行|ginkou)\n");
+        assert_eq!(pipe.query("kensaku").unwrap(), "(ケンサク|検索|kensaku)");
+        assert_eq!(pipe.query("ginkou").unwrap(), "(ギンコウ|銀行|ginkou)");
+        assert_eq!(pipe.stdin, b"kensaku\nginkou\n");
+    }
+
+    /// Without `-q`, cmigemo greets with two notices and prefixes every answer
+    /// with its (newline-less) prompt. Both are the user's choice of command,
+    /// so both are understood rather than refused.
+    #[test]
+    fn query_skips_the_banner_and_the_prompt() {
+        let mut pipe = pipe(concat!(
+            "migemo_open(\"/usr/share/cmigemo/utf-8/migemo-dict\")=0x55d0\n",
+            "clock()=0.052280\n",
+            "QUERY: PATTERN: (ケンサク|検索|kensaku)\n",
+            "QUERY: PATTERN: (ギンコウ|銀行|ginkou)\n",
+        ));
+        assert_eq!(pipe.query("kensaku").unwrap(), "(ケンサク|検索|kensaku)");
+        assert_eq!(pipe.query("ginkou").unwrap(), "(ギンコウ|銀行|ginkou)");
+    }
+
+    #[test]
+    fn query_strips_a_trailing_carriage_return() {
+        let mut pipe = pipe("(ケンサク|検索|kensaku)\r\n");
+        assert_eq!(pipe.query("kensaku").unwrap(), "(ケンサク|検索|kensaku)");
+    }
+
+    /// A newline would be answered as two queries and leave an extra pattern
+    /// in the pipe for the next keystroke to read.
+    #[test]
+    fn query_never_writes_more_than_one_line() {
+        let mut pipe = pipe("(ケンサク|検索|kensaku)\n");
+        assert_eq!(pipe.query("kensa\nku").unwrap(), "(ケンサク|検索|kensaku)");
+        assert_eq!(pipe.stdin, b"kensaku\n");
+    }
+
+    #[test]
+    fn query_reports_a_dead_process() {
+        let mut pipe = pipe("");
+        assert_matches!(pipe.query("kensaku"), Err(MigemoError::Closed));
+    }
+
+    /// An empty pattern would match every account rather than none, which is
+    /// the opposite of what an unanswered query means.
+    #[test]
+    fn query_reports_an_empty_answer() {
+        let mut pipe = pipe("QUERY: \n");
+        assert_matches!(pipe.query("kensaku"), Err(MigemoError::NoPattern(q)) if q == "kensaku");
+    }
+    /// Round trip against a real migemo, exercising the pipe protocol as an
+    /// actual tool speaks it — including the startup banner and the prompt of
+    /// a command run without `-q`. Skipped unless a command is given, since
+    /// neither the tool nor a dictionary is something CI has:
+    ///
+    /// ```shell
+    /// OKANE_TEST_MIGEMO='cmigemo -d /usr/share/cmigemo/utf-8/migemo-dict' cargo test
+    /// ```
+    #[test]
+    fn real_migemo_expands_a_romaji_query() {
+        let Ok(command) = std::env::var("OKANE_TEST_MIGEMO") else {
+            eprintln!("skipped: set OKANE_TEST_MIGEMO to a migemo command to run this");
+            return;
+        };
+        let migemo = Migemo::spawn(MigemoCommand::parse(&command).unwrap()).unwrap();
+        // The same process answers every query of a session, so check that the
+        // second one is not the first one's leftovers.
+        for (query, account) in [("ginkou", "資産:銀行"), ("shisan", "資産")] {
+            let pattern = migemo.query(query).unwrap();
+            let re = regex::RegexBuilder::new(&pattern)
+                .case_insensitive(true)
+                .build()
+                .unwrap_or_else(|err| panic!("{query} expanded to `{pattern}`: {err}"));
+            assert!(re.is_match(account), "{query} expanded to `{pattern}`");
+        }
+    }
+}

--- a/cli/src/ui/report.rs
+++ b/cli/src/ui/report.rs
@@ -29,6 +29,9 @@ mod testing;
 
 pub use app::App;
 pub use options::QueryOptions;
+pub use search::Translator;
+
+use std::rc::Rc;
 
 use bumpalo::Bump;
 use okane_core::load;
@@ -54,12 +57,26 @@ pub struct SessionConfig<F: load::FileSystem> {
     /// replaces it for the rest of the session, so the loop below tracks the
     /// current options separately.
     options: QueryOptions,
+    /// How the search bar turns what is typed into a regex. Held here, next to
+    /// the loader, because it owns the migemo process: spawning it once per
+    /// session config keeps it alive across the reloads that rebuild the app.
+    translator: Rc<Translator>,
 }
 
 impl<F: load::FileSystem> SessionConfig<F> {
     /// Wraps a loader for the source plus the query the session opens with.
     pub fn new(loader: load::Loader<F>, options: QueryOptions) -> Self {
-        Self { loader, options }
+        Self {
+            loader,
+            options,
+            translator: Rc::default(),
+        }
+    }
+
+    /// Replaces the plain-regex search translation, as `--migemo` does.
+    pub fn with_translator(mut self, translator: Translator) -> Self {
+        self.translator = Rc::new(translator);
+        self
     }
 }
 
@@ -124,7 +141,8 @@ fn session_loop<F: load::FileSystem>(
                     source_display.to_owned(),
                     Vec::new(),
                     QueryState::unresolved(&options),
-                );
+                )
+                .with_translator(Rc::clone(&config.translator));
                 app.overlay = Some(error_overlay(source_display, err.as_ref()));
                 (Ledger::empty(&ctx), app, false)
             }
@@ -162,7 +180,14 @@ fn build_session<'ctx, F: load::FileSystem>(
     snapshot: Option<&UiSnapshot>,
 ) -> anyhow::Result<SessionData<'ctx>> {
     let mut ledger = report::process(ctx, &config.loader, &options.to_process_options())?;
-    let app = build_app(ctx, &mut ledger, options, source_display, snapshot)?;
+    let app = build_app(
+        ctx,
+        &mut ledger,
+        options,
+        source_display,
+        &config.translator,
+        snapshot,
+    )?;
     Ok(SessionData { ledger, app })
 }
 
@@ -184,12 +209,14 @@ fn build_app<'ctx>(
     ledger: &mut Ledger<'ctx>,
     options: &QueryOptions,
     source_display: &str,
+    translator: &Rc<Translator>,
     snapshot: Option<&UiSnapshot>,
 ) -> anyhow::Result<App<'ctx>> {
     let query = options.resolve(ctx)?;
     let balance = ledger.balance(ctx, &query.balance_query())?.into_owned();
     let tree = report::BalanceTree::create(ctx, balance)?.into_nodes();
-    let mut app = App::new(source_display.to_owned(), tree, query);
+    let mut app =
+        App::new(source_display.to_owned(), tree, query).with_translator(Rc::clone(translator));
     if let Some(snapshot) = snapshot
         && let Some((scope, index)) = app.restore(snapshot)
     {

--- a/cli/src/ui/report/app.rs
+++ b/cli/src/ui/report/app.rs
@@ -13,6 +13,7 @@
 //! the reload snapshot.
 
 use std::cmp::min;
+use std::rc::Rc;
 
 use okane_core::report::BalanceTreeNode;
 
@@ -24,6 +25,7 @@ use super::overlay::{Overlay, ScrollDelta};
 use super::register::{
     RegisterAction, RegisterMessage, RegisterRow, RegisterScope, RegisterSnapshot, RegisterView,
 };
+use super::search::Translator;
 
 /// Top-level screen the user is currently looking at.
 #[derive(Debug)]
@@ -128,6 +130,13 @@ impl<'ctx> App<'ctx> {
             query,
             should_quit: false,
         }
+    }
+
+    /// Points the balance search at `translator`, the shared translation the
+    /// session was configured with (plain regex, or migemo).
+    pub fn with_translator(mut self, translator: Rc<Translator>) -> Self {
+        self.balance.translator = translator;
+        self
     }
 
     /// Builds an app from pre-derived balance rows, with no backing tree.

--- a/cli/src/ui/report/balance.rs
+++ b/cli/src/ui/report/balance.rs
@@ -10,6 +10,7 @@
 
 use std::cmp::min;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 use crossterm::event::{KeyCode, KeyEvent};
 #[cfg(test)]
@@ -21,7 +22,9 @@ use crate::ui::table::{NavCommand, TableNav, key_to_nav};
 
 use super::register::{OwnedRegisterScope, RegisterScope};
 use super::render::amount_line_count;
-use super::search::{Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase};
+use super::search::{
+    Search, SearchDirection, SearchIntent, SearchMatch, SearchMode, SearchPhase, Translator,
+};
 
 /// Whether the balance screen shows a flat account list or the account tree.
 ///
@@ -201,6 +204,10 @@ pub struct BalanceView<'ctx> {
     /// search via `C-s`/`C-r`. Shared across modal and interactive searches.
     /// Not `Option` because empty string can represent empty state.
     pub last_search: String,
+    /// How a typed pattern becomes the regex the rows are matched against.
+    /// Shared with the session rather than owned, so the migemo process is
+    /// spawned once and survives the reloads that rebuild this view.
+    pub translator: Rc<Translator>,
 }
 
 impl<'ctx> BalanceView<'ctx> {
@@ -217,6 +224,7 @@ impl<'ctx> BalanceView<'ctx> {
             amount_width: None,
             search: None,
             last_search: String::new(),
+            translator: Rc::default(),
         };
         view.rebuild_rows();
         view
@@ -237,6 +245,7 @@ impl<'ctx> BalanceView<'ctx> {
             amount_width: None,
             search: None,
             last_search: String::new(),
+            translator: Rc::default(),
         }
     }
 
@@ -650,7 +659,7 @@ impl<'ctx> BalanceView<'ctx> {
         if let Some(intent) = &snapshot.search {
             let mut intent = intent.clone();
             intent.origin = min(intent.origin, self.rows.len().saturating_sub(1));
-            let matches = SearchMatch::compute(&intent.input, &self.rows);
+            let matches = SearchMatch::compute(&intent.input, &self.rows, &self.translator);
             self.search = Some(Search { intent, matches });
         }
     }
@@ -811,7 +820,7 @@ impl<'ctx> BalanceView<'ctx> {
             SearchMode::Modal(_) => origin,
             SearchMode::Interactive => self.nav.selected_item().unwrap_or(origin),
         };
-        let matches = SearchMatch::compute(&intent.input, &self.rows);
+        let matches = SearchMatch::compute(&intent.input, &self.rows, &self.translator);
         let jump = match &matches {
             Some(Ok(m)) => m.first_match(reference, intent.dir),
             _ => None,

--- a/cli/src/ui/report/fulfill.rs
+++ b/cli/src/ui/report/fulfill.rs
@@ -8,6 +8,8 @@
 //! they leave the shown report exactly as it was and say what happened in the
 //! footer, which is why [`fulfill`] is infallible.
 
+use std::rc::Rc;
+
 use lender::FallibleLender;
 use okane_core::report::ReportContext;
 use okane_core::report::query::{AccountFilter, Ledger, RegisterQuery, Sort};
@@ -67,7 +69,17 @@ fn apply_options<'ctx>(
     // The whole view is rebuilt from the new query and the old UI state, the
     // same way a reload rebuilds it — including re-running an open register.
     let snapshot = app.snapshot();
-    match super::build_app(ctx, ledger, &options, &app.source_display, Some(&snapshot)) {
+    // The migemo process is the session's, not this app's: hand it to the app
+    // that replaces this one.
+    let translator = Rc::clone(&app.balance.translator);
+    match super::build_app(
+        ctx,
+        ledger,
+        &options,
+        &app.source_display,
+        &translator,
+        Some(&snapshot),
+    ) {
         Ok(next) => *app = next,
         // Nothing was swapped in, so the report on screen is still the one its
         // options describe.
@@ -165,7 +177,7 @@ mod tests {
         ledger: &mut Ledger<'ctx>,
         options: &QueryOptions,
     ) -> App<'ctx> {
-        super::super::build_app(ctx, ledger, options, "test.ledger", None).unwrap()
+        super::super::build_app(ctx, ledger, options, "test.ledger", &Rc::default(), None).unwrap()
     }
 
     /// The balance rows as `name: amount` text, which is what an options change

--- a/cli/src/ui/report/render.rs
+++ b/cli/src/ui/report/render.rs
@@ -452,7 +452,7 @@ fn draw_error(frame: &mut Frame, area: Rect, message: &str) {
 }
 
 /// Renders the balance search bar in the footer slot: a prompt + the typed
-/// pattern (red on an invalid regex) plus a dim hint suffix. While editing it
+/// pattern (red when it yields no usable regex) plus a dim hint suffix. While editing it
 /// also places the terminal cursor at the end of the pattern.
 fn draw_search_bar(frame: &mut Frame, area: Rect, search: &Search) {
     let count = search.matched_rows().len();
@@ -476,8 +476,8 @@ fn draw_search_bar(frame: &mut Frame, area: Rect, search: &Search) {
         }
     };
     let alert = match (search.err(), search.intent.no_previous) {
-        (Some(_), _) => Span::styled(
-            "  [invalid regex]".to_string(),
+        (Some(err), _) => Span::styled(
+            format!("  {}", err.label()),
             Style::default().fg(Color::Red),
         ),
         (None, true) => Span::styled(

--- a/cli/src/ui/report/search.rs
+++ b/cli/src/ui/report/search.rs
@@ -5,9 +5,57 @@
 //! [`Search`] pairs the two. The orchestration that mutates these against a
 //! live balance view lives on [`super::balance::BalanceView`].
 
+use std::borrow::Cow;
+
 use regex::RegexBuilder;
 
+use crate::ui::migemo::{Migemo, MigemoError};
+
 use super::balance::BalanceRow;
+
+/// How the text typed in the search bar becomes the regex the rows are matched
+/// against.
+///
+/// [`Self::Plain`] is what a session without `--migemo` uses: the pattern is
+/// the regex, exactly as typed. [`Self::Migemo`] runs it through a migemo
+/// process first, so `ginkou` matches the accounts written 銀行 — the typed
+/// text is still in migemo's output as one alternative, so plain ASCII
+/// searching keeps working.
+#[derive(Debug, Default)]
+pub enum Translator {
+    #[default]
+    Plain,
+    Migemo(Migemo),
+}
+
+impl Translator {
+    /// The regex `input` stands for under this translation.
+    fn to_regex<'a>(&self, input: &'a str) -> Result<Cow<'a, str>, SearchError> {
+        match self {
+            Translator::Plain => Ok(Cow::Borrowed(input)),
+            Translator::Migemo(migemo) => Ok(Cow::Owned(migemo.query(input)?)),
+        }
+    }
+}
+
+/// Why the typed pattern produced no matches to show.
+#[derive(thiserror::Error, Debug)]
+pub enum SearchError {
+    #[error("invalid regex: {0}")]
+    Regex(#[from] regex::Error),
+    #[error("migemo failed: {0}")]
+    Migemo(#[from] MigemoError),
+}
+
+impl SearchError {
+    /// Short tag for the search bar, which has one line to say what went wrong.
+    pub(super) fn label(&self) -> &'static str {
+        match self {
+            SearchError::Regex(_) => "[invalid regex]",
+            SearchError::Migemo(err) => err.label(),
+        }
+    }
+}
 
 /// Phase of the modal (`/`) account search.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,26 +138,34 @@ impl SearchMatch {
         Some(rows[idx])
     }
 
-    /// Computes matching row indices for `input` as a case-insensitive regex.
-    /// Returns `None` for empty input, `Err` for an invalid pattern.
-    pub fn compute(input: &str, rows: &[BalanceRow<'_>]) -> Option<Result<Self, regex::Error>> {
+    /// Computes matching row indices for `input`, translated by `translator`
+    /// and compiled as a case-insensitive regex. Returns `None` for empty
+    /// input, `Err` for a pattern that cannot be built.
+    pub fn compute(
+        input: &str,
+        rows: &[BalanceRow<'_>],
+        translator: &Translator,
+    ) -> Option<Result<Self, SearchError>> {
         if input.is_empty() {
             return None;
         }
-        Some(
-            RegexBuilder::new(input)
-                .case_insensitive(true)
-                .build()
-                .map(|re| {
-                    Self(
-                        rows.iter()
-                            .enumerate()
-                            .filter(|(_, row)| re.is_match(row.full_name()))
-                            .map(|(i, _)| i)
-                            .collect(),
-                    )
-                }),
-        )
+        Some(Self::compute_nonempty(input, rows, translator))
+    }
+
+    fn compute_nonempty(
+        input: &str,
+        rows: &[BalanceRow<'_>],
+        translator: &Translator,
+    ) -> Result<Self, SearchError> {
+        let pattern = translator.to_regex(input)?;
+        let re = RegexBuilder::new(&pattern).case_insensitive(true).build()?;
+        Ok(Self(
+            rows.iter()
+                .enumerate()
+                .filter(|(_, row)| re.is_match(row.full_name()))
+                .map(|(i, _)| i)
+                .collect(),
+        ))
     }
 
     /// Row index of the next/previous match relative to `current` (wrapping).
@@ -135,18 +191,18 @@ impl SearchMatch {
 
 /// Account-name search state on the balance screen.
 ///
-/// Not `PartialEq` because `regex::Error` doesn't implement it — tests inspect
+/// Not `PartialEq` because [`SearchError`] doesn't implement it — tests inspect
 /// the individual fields.
 #[derive(Debug)]
 pub struct Search {
     pub intent: SearchIntent,
     /// `None` when `input` is empty; `Ok` with matching row indices; `Err` when
-    /// the pattern fails to compile as a regex.
-    pub matches: Option<Result<SearchMatch, regex::Error>>,
+    /// the pattern cannot be turned into a regex.
+    pub matches: Option<Result<SearchMatch, SearchError>>,
 }
 
 impl Search {
-    pub(super) fn err(&self) -> Option<&regex::Error> {
+    pub(super) fn err(&self) -> Option<&SearchError> {
         self.matches.as_ref()?.as_ref().err()
     }
     pub(super) fn matched_rows(&self) -> &[usize] {
@@ -181,8 +237,12 @@ mod tests {
     #[test]
     fn compute_matches_classifies_input() {
         let rows: &[BalanceRow<'_>] = &[];
-        assert_matches!(SearchMatch::compute("", rows), None);
-        assert_matches!(SearchMatch::compute("assets", rows), Some(Ok(_)));
-        assert_matches!(SearchMatch::compute("[", rows), Some(Err(_)));
+        let plain = Translator::Plain;
+        assert_matches!(SearchMatch::compute("", rows, &plain), None);
+        assert_matches!(SearchMatch::compute("assets", rows, &plain), Some(Ok(_)));
+        assert_matches!(
+            SearchMatch::compute("[", rows, &plain),
+            Some(Err(SearchError::Regex(_)))
+        );
     }
 }


### PR DESCRIPTION
## What

`okane ui --migemo='cmigemo -q -d /usr/share/cmigemo/utf-8/migemo-dict'` runs the account search through the given [migemo](https://www.kaoriya.net/software/cmigemo/) command: what is typed in `/`, `C-s` and `C-r` is expanded into the regex matching the Japanese it stands for, so `ginkou` finds `資産:銀行`.

Without the flag nothing changes — the query is compiled as the regex, exactly as it is today.

The whole command line is one flag value (shell-split with `shlex`), so it needs quoting as a whole; that keeps a dictionary path with spaces expressible and leaves the positional ledger argument alone.

## How

* `cli/src/ui/migemo.rs` — the pipe protocol: one query per line into stdin, one pattern per line out of stdout. The process is spawned once, before the terminal is taken over (so a command that cannot even start reports on the normal terminal), and lives for the whole session — reloads included — because an incremental search would otherwise pay the dictionary load on every keystroke. Killed on drop, so nothing is left blocked on a query that will never come.
* The answer parsing also understands a command run **without** `-q`, whose startup notices and newline-less `QUERY: PATTERN: ` prompt arrive on the answer's line — the flag takes the command as given rather than dictating its options.
* `search::Translator` is the new seam between "what was typed" and "the regex to compile": `Plain` (as today) or `Migemo`. It is shared (`Rc`) from the `SessionConfig` through the app, so a reload or an options change rebuilds the view around the same process.
* Search errors are no longer only `regex::Error`: `SearchError` also carries a migemo failure, and the search bar names which (`[migemo exited]`, `[no migemo pattern]`, …) instead of always claiming an invalid regex.

## Testing

* `cargo test`, `cargo clippy --all-targets` clean.
* The protocol is unit-tested over in-memory streams (banner, prompt, `\r\n`, a dead process, an empty answer, and that a newline in the input can never desynchronize the pipe).
* `real_migemo_expands_a_romaji_query` runs the round trip against an actual tool when `OKANE_TEST_MIGEMO` names one; it skips otherwise, since CI has neither the tool nor a dictionary.
* Driven by hand against a Japanese ledger with real cmigemo, quiet and non-quiet: typing `/ginkou` selects `資産:銀行:普通預金` (1 match) with the flag and finds nothing without it, and no cmigemo process survives the exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W26nzY1AtivgustLVx7u2Q